### PR TITLE
Fixes found during data movement testing

### DIFF
--- a/controllers/nnf_workflow_controller_test.go
+++ b/controllers/nnf_workflow_controller_test.go
@@ -403,12 +403,6 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 						"Name":      Equal(fmt.Sprintf("%s-%d", workflow.Name, 0)),
 						"Namespace": Equal(workflow.Namespace),
 					}))
-
-				By("expect NnfAccess to be ready")
-				access := &nnfv1alpha1.NnfAccess{}
-				Expect(dm.Spec.Destination.Access).ToNot(BeNil())
-				Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Name: dm.Spec.Destination.Access.Name, Namespace: dm.Spec.Destination.Access.Namespace}, access)).To(Succeed())
-				Expect(access.Status.Ready).To(BeTrue())
 			})
 		})
 
@@ -541,12 +535,6 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 						"Name":      Equal(persistentStorageName),
 						"Namespace": Equal(workflow.Namespace),
 					}))
-
-				By("expect NnfAccess to be ready")
-				access := &nnfv1alpha1.NnfAccess{}
-				Expect(dm.Spec.Destination.Access).ToNot(BeNil())
-				Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Name: dm.Spec.Destination.Access.Name, Namespace: dm.Spec.Destination.Access.Namespace}, access)).To(Succeed())
-				Expect(access.Status.Ready).To(BeTrue())
 			})
 		})
 	}) // When("Using copy_in directives", func()

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/HewlettPackard/dws v0.0.0-20220602132813-57f1c320098c
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220517205036-02c092067a4c
-	github.com/NearNodeFlash/nnf-ec v0.0.0-20220518125038-17176c02ce3f
+	github.com/NearNodeFlash/nnf-ec v0.0.0-20220601220718-94874456fa8e
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220517205036-02c092067a4c h
 github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220517205036-02c092067a4c/go.mod h1:VeS+yILAhE2pDE9iIHwsco3UdAVsMLlQdg6L1aTLPOg=
 github.com/NearNodeFlash/nnf-ec v0.0.0-20220518125038-17176c02ce3f h1:z4yEuREovwyu7ijqu6MpkhIwOEyWkxnwl+bXwiCPZPQ=
 github.com/NearNodeFlash/nnf-ec v0.0.0-20220518125038-17176c02ce3f/go.mod h1:WGhuERMbd1gdgfdf3LcX9ZHEIlNBWdXRMpFikRgfJ+g=
+github.com/NearNodeFlash/nnf-ec v0.0.0-20220601220718-94874456fa8e h1:z2ga1FHmlfK0hn7YMXK6crqBFIEIOfuRXMz4C3qi5Xo=
+github.com/NearNodeFlash/nnf-ec v0.0.0-20220601220718-94874456fa8e/go.mod h1:WGhuERMbd1gdgfdf3LcX9ZHEIlNBWdXRMpFikRgfJ+g=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nnf/manager.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nnf/manager.go
@@ -1218,9 +1218,16 @@ func (*StorageService) StorageServiceIdFileSystemIdDelete(storageServiceId, file
 		return ec.NewErrNotFound().WithEvent(msgreg.ResourceNotFoundBase(FileSystemOdataType, fileSystemId))
 	}
 
-	for _, sh := range fs.shares {
-		if err := s.StorageServiceIdFileSystemIdExportedShareIdDelete(s.id, fs.id, sh.id); err != nil {
-			return ec.NewErrInternalServerError().WithResourceType(FileSystemOdataType).WithError(err).WithCause(fmt.Sprintf("Exported share '%s' failed delete", sh.id))
+	// Create a copy of file share IDs; The deletion of a share will modify the fs.shares[] so we cannot
+	// iterate on that array directly as it is editted in place.
+	shareIds := make([]string, len(fs.shares))
+	for idx, sh := range fs.shares {
+		shareIds[idx] = sh.id
+	}
+
+	for _, shid := range shareIds {
+		if err := s.StorageServiceIdFileSystemIdExportedShareIdDelete(s.id, fs.id, shid); err != nil {
+			return ec.NewErrInternalServerError().WithResourceType(FileSystemOdataType).WithError(err).WithCause(fmt.Sprintf("Exported share '%s' failed delete", shid))
 		}
 	}
 

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-server/server_local.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-server/server_local.go
@@ -45,7 +45,7 @@ func (DefaultServerControllerProvider) NewServerController(opts ServerController
 }
 
 type LocalServerController struct {
-	storage []Storage
+	storage []*Storage
 }
 
 func (c *LocalServerController) Connected() bool { return true }
@@ -68,13 +68,16 @@ func (c *LocalServerController) GetServerInfo() ServerInfo {
 }
 
 func (c *LocalServerController) NewStorage(pid uuid.UUID, expectedNamespaces []StorageNamespace) *Storage {
-	c.storage = append(c.storage, Storage{
+
+	storage := &Storage{
 		Id:                   pid,
 		expectedNamespaces:   expectedNamespaces,
 		discoveredNamespaces: make([]StorageNamespace, 0),
 		ctrl:                 c,
-	})
-	return &c.storage[len(c.storage)-1]
+	}
+
+	c.storage = append(c.storage, storage)
+	return storage
 }
 
 func (c *LocalServerController) Delete(s *Storage) error {
@@ -220,9 +223,9 @@ func (c *LocalServerController) discoverViaNamespaces(s *Storage) error {
 }
 
 func (c *LocalServerController) findStorage(pid uuid.UUID) *Storage {
-	for idx, p := range c.storage {
-		if p.Id == pid {
-			return &c.storage[idx]
+	for idx, s := range c.storage {
+		if s.Id == pid {
+			return c.storage[idx]
 		}
 	}
 

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-server/server_mock.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-server/server_mock.go
@@ -32,7 +32,7 @@ func NewMockServerController() ServerControllerApi {
 }
 
 type MockServerController struct {
-	storage []Storage
+	storage []*Storage
 }
 
 func (c *MockServerController) Connected() bool { return true }
@@ -44,12 +44,13 @@ func (m *MockServerController) GetServerInfo() ServerInfo {
 }
 
 func (c *MockServerController) NewStorage(pid uuid.UUID, expectedNamespaces []StorageNamespace) *Storage {
-	c.storage = append(c.storage, Storage{
+	storage := &Storage{
 		Id:                 pid,
 		expectedNamespaces: expectedNamespaces,
 		ctrl:               c,
-	})
-	return &c.storage[len(c.storage)-1]
+	}
+	c.storage = append(c.storage, storage)
+	return storage
 }
 
 func (c *MockServerController) Delete(s *Storage) error {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -27,7 +27,7 @@ github.com/HewlettPackard/structex
 ## explicit
 github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1
 github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
-# github.com/NearNodeFlash/nnf-ec v0.0.0-20220518125038-17176c02ce3f
+# github.com/NearNodeFlash/nnf-ec v0.0.0-20220601220718-94874456fa8e
 ## explicit
 github.com/NearNodeFlash/nnf-ec/internal/kvstore
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme


### PR DESCRIPTION
- Do not create nnfaccess for lustre fs
- Delete nnfaccess on cleanup of data-movement instead of just unmount

Signed-off-by: Nate Roiger <nate.roiger@hpe.com>