### PR TITLE
Fix delete collection / update nnf-ec

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -80,6 +80,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/controllers/nnf_access_controller.go
+++ b/controllers/nnf_access_controller.go
@@ -68,7 +68,7 @@ const (
 //+kubebuilder:rbac:groups=nnf.cray.hpe.com,resources=nnfaccesses/finalizers,verbs=update
 //+kubebuilder:rbac:groups=nnf.cray.hpe.com,resources=nnfstorages,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=nnf.cray.hpe.com,resources=nnfstorages/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=dws.cray.hpe.com,resources=clientmounts,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=dws.cray.hpe.com,resources=clientmounts,verbs=get;list;watch;create;update;patch;delete;deletecollection
 //+kubebuilder:rbac:groups=dws.cray.hpe.com,resources=clientmounts/status,verbs=get;update;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/HewlettPackard/dws v0.0.0-20220602132813-57f1c320098c
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220517205036-02c092067a4c
-	github.com/NearNodeFlash/nnf-ec v0.0.0-20220601220718-94874456fa8e
+	github.com/NearNodeFlash/nnf-ec v0.0.0-20220606155209-2e43ead5e2f4
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -100,10 +100,8 @@ github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb0
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220517205036-02c092067a4c h1:+m9OtyIa9vlkLE1jI0lTkAhlVQSOlIM4V4GgkJ0HZpA=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220517205036-02c092067a4c/go.mod h1:VeS+yILAhE2pDE9iIHwsco3UdAVsMLlQdg6L1aTLPOg=
-github.com/NearNodeFlash/nnf-ec v0.0.0-20220518125038-17176c02ce3f h1:z4yEuREovwyu7ijqu6MpkhIwOEyWkxnwl+bXwiCPZPQ=
-github.com/NearNodeFlash/nnf-ec v0.0.0-20220518125038-17176c02ce3f/go.mod h1:WGhuERMbd1gdgfdf3LcX9ZHEIlNBWdXRMpFikRgfJ+g=
-github.com/NearNodeFlash/nnf-ec v0.0.0-20220601220718-94874456fa8e h1:z2ga1FHmlfK0hn7YMXK6crqBFIEIOfuRXMz4C3qi5Xo=
-github.com/NearNodeFlash/nnf-ec v0.0.0-20220601220718-94874456fa8e/go.mod h1:WGhuERMbd1gdgfdf3LcX9ZHEIlNBWdXRMpFikRgfJ+g=
+github.com/NearNodeFlash/nnf-ec v0.0.0-20220606155209-2e43ead5e2f4 h1:VlkBWhVnduwfKnmnQJPjG1eCUtnprbwLyilk6cBw+rU=
+github.com/NearNodeFlash/nnf-ec v0.0.0-20220606155209-2e43ead5e2f4/go.mod h1:WGhuERMbd1gdgfdf3LcX9ZHEIlNBWdXRMpFikRgfJ+g=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nnf/persistent.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nnf/persistent.go
@@ -90,9 +90,12 @@ func (*DefaultPersistentController) DeletePersistentObject(obj PersistentObjectA
 	if err != nil {
 		return err
 	}
-	defer ledger.Close()
 
-	return executePersistentObjectTransaction(ledger, obj, deleteFunc, startingState, endingState)
+	if err := executePersistentObjectTransaction(ledger, obj, deleteFunc, startingState, endingState); err != nil {
+		return err
+	}
+
+	return ledger.Close()
 }
 
 func executePersistentObjectTransaction(ledger *kvstore.Ledger, obj PersistentObjectApi, updateFunc func() error, startingState, endingState uint32) error {

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nnf/storage_group.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nnf/storage_group.go
@@ -131,7 +131,23 @@ func (sg *StorageGroup) Rollback(state uint32) error {
 				return err
 			}
 		}
+
+	case storageGroupDeleteStartLogEntryType:
+		// Rollback to a state where all controllers are attached to the storage pool
+
+		sp := sg.storageService.findStoragePool(sg.storagePoolId)
+		if sp == nil {
+			return fmt.Errorf("Storage Pool %s not found", sg.storagePoolId)
+		}
+
+		for _, pv := range sp.providingVolumes {
+			if err := pv.storage.FindVolume(pv.volumeId).AttachController(sg.endpoint.controllerId); err != nil {
+				return err
+			}
+		}
 	}
+
+
 
 	return nil
 }

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nvme/manager.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nvme/manager.go
@@ -572,9 +572,22 @@ func (v *Volume) DetachController(controllerId uint16) error {
 
 	for _, ctrlId := range controllerIds {
 		if ctrlId == controllerId {
-			if err := v.detach([]uint16{controllerId}); err != nil {
-				return err
-			}
+			return v.detach([]uint16{controllerId})
+		}
+	}
+
+	return nil
+}
+
+func (v *Volume) AttachController(controllerId uint16) error {
+	controllerIds, err := v.storage.device.ListAttachedControllers(v.namespaceId)
+	if err != nil {
+		return err
+	}
+
+	for _, ctrlId := range controllerIds {
+		if ctrlId == controllerId {
+			return v.attach([]uint16{controllerId})
 		}
 	}
 

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-server/file_system_lvm.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-server/file_system_lvm.go
@@ -116,6 +116,15 @@ func (f *FileSystemLvm) Create(devices []string, opts FileSystemOptions) error {
 		return err
 	}
 
+	shared = ""
+	if f.shared {
+		if _, err := f.run(fmt.Sprintf("vgchange --lockstart %s", f.vgName)); err != nil {
+			return err
+		}
+
+		shared = "s"
+	}
+
 	// Create the logical volume
 	// -Zn - don't zero the volume, it will fail.
 	// We are depending on the drive behavior for newly allocated blocks to track
@@ -142,11 +151,6 @@ func (f *FileSystemLvm) Create(devices []string, opts FileSystemOptions) error {
 	}
 
 	// Activate the volume group.
-	shared = ""
-	if f.shared {
-		shared = "s"
-	}
-
 	if _, err := f.run(fmt.Sprintf("vgchange --activate %sy %s", shared, f.vgName)); err != nil {
 		return err
 	}
@@ -155,7 +159,12 @@ func (f *FileSystemLvm) Create(devices []string, opts FileSystemOptions) error {
 }
 
 func (f *FileSystemLvm) Delete() error {
+
 	if _, err := f.run(fmt.Sprintf("lvremove --yes %s", f.devPath())); err != nil {
+		return err
+	}
+
+	if _, err := f.run(fmt.Sprintf("vgchange --activate n %s", f.vgName)); err != nil {
 		return err
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -27,7 +27,7 @@ github.com/HewlettPackard/structex
 ## explicit
 github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1
 github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
-# github.com/NearNodeFlash/nnf-ec v0.0.0-20220601220718-94874456fa8e
+# github.com/NearNodeFlash/nnf-ec v0.0.0-20220606155209-2e43ead5e2f4
 ## explicit
 github.com/NearNodeFlash/nnf-ec/internal/kvstore
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme


### PR DESCRIPTION
- NNF Access is failing the DeleteAllOf call for Client Mounts because it's missing the `deletecollection` permission
- update nnf-ec to the latest and greatest