### PR TITLE
RABSW-933 nnf-ec: use all devices when creating zpools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/NearNodeFlash/nnf-sos
 
 go 1.16
 
+replace github.com/NearNodeFlash/nnf-ec => ../nnf-ec-2.git
+
 require (
 	github.com/HewlettPackard/dws v0.0.0-20220602132813-57f1c320098c
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220517205036-02c092067a4c

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,10 @@ module github.com/NearNodeFlash/nnf-sos
 
 go 1.16
 
-replace github.com/NearNodeFlash/nnf-ec => ../nnf-ec-2.git
-
 require (
 	github.com/HewlettPackard/dws v0.0.0-20220602132813-57f1c320098c
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220517205036-02c092067a4c
-	github.com/NearNodeFlash/nnf-ec v0.0.0-20220606155209-2e43ead5e2f4
+	github.com/NearNodeFlash/nnf-ec v0.0.0-20220607211319-444868fe289a
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb0
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220517205036-02c092067a4c h1:+m9OtyIa9vlkLE1jI0lTkAhlVQSOlIM4V4GgkJ0HZpA=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220517205036-02c092067a4c/go.mod h1:VeS+yILAhE2pDE9iIHwsco3UdAVsMLlQdg6L1aTLPOg=
-github.com/NearNodeFlash/nnf-ec v0.0.0-20220606155209-2e43ead5e2f4 h1:VlkBWhVnduwfKnmnQJPjG1eCUtnprbwLyilk6cBw+rU=
-github.com/NearNodeFlash/nnf-ec v0.0.0-20220606155209-2e43ead5e2f4/go.mod h1:WGhuERMbd1gdgfdf3LcX9ZHEIlNBWdXRMpFikRgfJ+g=
+github.com/NearNodeFlash/nnf-ec v0.0.0-20220607211319-444868fe289a h1:r9F2q2Yd7bpVpoU50xi0FfpQ32MFphzf6rnOogVrIIE=
+github.com/NearNodeFlash/nnf-ec v0.0.0-20220607211319-444868fe289a/go.mod h1:WGhuERMbd1gdgfdf3LcX9ZHEIlNBWdXRMpFikRgfJ+g=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-server/file_system_lustre.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-server/file_system_lustre.go
@@ -100,15 +100,20 @@ func (f *FileSystemLustre) Create(devices []string, options FileSystemOptions) e
 	if f.backFs == BackFsZfs {
 		backFs = fmt.Sprintf("--backfstype=%s %s", f.backFs, f.zfsVolName())
 	}
+	devsStr := strings.Join(devices, " ")
+	if _, ok := os.LookupEnv("NNF_SUPPLIED_DEVICES"); ok {
+		// On non-NVMe.
+		devsStr = devices[0]
+	}
 	switch f.targetType {
 	case TargetMGT:
-		err = runCmd(f, fmt.Sprintf("mkfs.lustre --mgs %s %s", backFs, f.devices[0]))
+		err = runCmd(f, fmt.Sprintf("mkfs.lustre --mgs %s %s", backFs, devsStr))
 	case TargetMDT:
-		err = runCmd(f, fmt.Sprintf("mkfs.lustre --mdt --fsname=%s --mgsnode=%s --index=%d %s %s", f.name, f.mgsNode, f.index, backFs, f.devices[0]))
+		err = runCmd(f, fmt.Sprintf("mkfs.lustre --mdt --fsname=%s --mgsnode=%s --index=%d %s %s", f.name, f.mgsNode, f.index, backFs, devsStr))
 	case TargetMGTMDT:
-		err = runCmd(f, fmt.Sprintf("mkfs.lustre --mgs --mdt --fsname=%s --index=%d %s %s", f.name, f.index, backFs, f.devices[0]))
+		err = runCmd(f, fmt.Sprintf("mkfs.lustre --mgs --mdt --fsname=%s --index=%d %s %s", f.name, f.index, backFs, devsStr))
 	case TargetOST:
-		err = runCmd(f, fmt.Sprintf("mkfs.lustre --ost --fsname=%s --mgsnode=%s --index=%d %s %s", f.name, f.mgsNode, f.index, backFs, f.devices[0]))
+		err = runCmd(f, fmt.Sprintf("mkfs.lustre --ost --fsname=%s --mgsnode=%s --index=%d %s %s", f.name, f.mgsNode, f.index, backFs, devsStr))
 	}
 
 	return err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -27,7 +27,7 @@ github.com/HewlettPackard/structex
 ## explicit
 github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1
 github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
-# github.com/NearNodeFlash/nnf-ec v0.0.0-20220606155209-2e43ead5e2f4
+# github.com/NearNodeFlash/nnf-ec v0.0.0-20220606155209-2e43ead5e2f4 => ../nnf-ec-2.git
 ## explicit
 github.com/NearNodeFlash/nnf-ec/internal/kvstore
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme
@@ -696,3 +696,4 @@ sigs.k8s.io/structured-merge-diff/v4/typed
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 sigs.k8s.io/yaml
+# github.com/NearNodeFlash/nnf-ec => ../nnf-ec-2.git

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -27,7 +27,7 @@ github.com/HewlettPackard/structex
 ## explicit
 github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1
 github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
-# github.com/NearNodeFlash/nnf-ec v0.0.0-20220606155209-2e43ead5e2f4 => ../nnf-ec-2.git
+# github.com/NearNodeFlash/nnf-ec v0.0.0-20220607211319-444868fe289a
 ## explicit
 github.com/NearNodeFlash/nnf-ec/internal/kvstore
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme
@@ -696,4 +696,3 @@ sigs.k8s.io/structured-merge-diff/v4/typed
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 sigs.k8s.io/yaml
-# github.com/NearNodeFlash/nnf-ec => ../nnf-ec-2.git


### PR DESCRIPTION
Use all of the provided devices when creating zpools for lustre targets.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>