### PR TITLE
RABSW-934: Add owner labels to NnfDataMovement

### DIFF
--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -1028,6 +1028,7 @@ func (r *NnfWorkflowReconciler) createDataMovementResource(ctx context.Context, 
 	}
 
 	dwsv1alpha1.AddWorkflowLabels(dm, workflow)
+	dwsv1alpha1.AddOwnerLabels(dm, workflow)
 
 	dm.Spec = nnfv1alpha1.NnfDataMovementSpec{
 		Source: &nnfv1alpha1.NnfDataMovementSpecSourceDestination{


### PR DESCRIPTION
The NnfDataMovement resources created during data_in and data_out did not have
the owner labels applied. Add the workflow as the owner.

Signed-off-by: Matt Richerson <mattr@cray.com>