### PR TITLE
RABSW-971: Fix multiple match labels

### DIFF
--- a/controllers/nnf_access_controller.go
+++ b/controllers/nnf_access_controller.go
@@ -467,9 +467,11 @@ func (r *NnfAccessReconciler) mapClientLocalStorage(ctx context.Context, access 
 	// Read each NnfNodeStorage resource and find the NVMe information for each
 	// allocation.
 	for nodeName, storageCount := range storageCountMap {
+		matchLabels := dwsv1alpha1.MatchingOwner(nnfStorage)
+		matchLabels[nnfv1alpha1.AllocationSetLabel] = allocationSetSpec.Name
+
 		listOptions := []client.ListOption{
-			client.MatchingLabels{nnfv1alpha1.AllocationSetLabel: allocationSetSpec.Name},
-			dwsv1alpha1.MatchingOwner(nnfStorage),
+			matchLabels,
 			client.InNamespace(nodeName),
 		}
 

--- a/controllers/nnf_servers_controller.go
+++ b/controllers/nnf_servers_controller.go
@@ -215,9 +215,11 @@ func (r *DWSServersReconciler) updateCapacityUsed(ctx context.Context, servers *
 		}
 
 		// Loop through the nnfNodeStorages corresponding to each of the Rabbit nodes and find
+		matchLabels := dwsv1alpha1.MatchingOwner(nnfStorage)
+		matchLabels[nnfv1alpha1.AllocationSetLabel] = label
+
 		listOptions := []client.ListOption{
-			dwsv1alpha1.MatchingOwner(nnfStorage),
-			client.MatchingLabels{nnfv1alpha1.AllocationSetLabel: label},
+			matchLabels,
 		}
 
 		nnfNodeStorageList := &nnfv1alpha1.NnfNodeStorageList{}

--- a/controllers/nnf_storage_controller.go
+++ b/controllers/nnf_storage_controller.go
@@ -270,9 +270,11 @@ func (r *NnfStorageReconciler) aggregateNodeStorageStatus(ctx context.Context, s
 	allocationSet.AllocationCount = 0
 
 	nnfNodeStorageList := &nnfv1alpha1.NnfNodeStorageList{}
+	matchLabels := dwsv1alpha1.MatchingOwner(storage)
+	matchLabels[nnfv1alpha1.AllocationSetLabel] = storage.Spec.AllocationSets[allocationSetIndex].Name
+
 	listOptions := []client.ListOption{
-		dwsv1alpha1.MatchingOwner(storage),
-		client.MatchingLabels{nnfv1alpha1.AllocationSetLabel: storage.Spec.AllocationSets[allocationSetIndex].Name},
+		matchLabels,
 	}
 
 	if err := r.List(ctx, nnfNodeStorageList, listOptions...); err != nil {


### PR DESCRIPTION
ListOptions doesn't honor multiple MatchingLabels. Create a single MatchingLabels
map with all the labels we want to match on.

Signed-off-by: Matt Richerson <mattr@cray.com>