### PR TITLE
RABSW-968: Verify NnfNodeStorage count when aggregating status

### DIFF
--- a/controllers/nnf_storage_controller.go
+++ b/controllers/nnf_storage_controller.go
@@ -281,6 +281,11 @@ func (r *NnfStorageReconciler) aggregateNodeStorageStatus(ctx context.Context, s
 		return &ctrl.Result{Requeue: true}, nil
 	}
 
+	// Ensure that we found all the NnfNodeStorage resources we were expecting
+	if len(nnfNodeStorageList.Items) != len(storage.Spec.AllocationSets[allocationSetIndex].Nodes) {
+		status = nnfv1alpha1.ResourceStarting
+	}
+
 	for _, nnfNodeStorage := range nnfNodeStorageList.Items {
 		if nnfNodeStorage.Spec.LustreStorage.TargetType == "MGT" || nnfNodeStorage.Spec.LustreStorage.TargetType == "MGTMDT" {
 			statusUpdater.update(func(s *nnfv1alpha1.NnfStorageStatus) {


### PR DESCRIPTION
The NnfNodeStorage status aggregator uses a List() operation to find all the
NnfNodeStorage resources that are part of an allocation set. Depending on the
state of the client cache, we may miss some of the resources. This commit adds
a check to make sure we've found the expected number of resources.