### PR TITLE
RABSW-981  recognize the use of externalMgs

### DIFF
--- a/controllers/integration_test.go
+++ b/controllers/integration_test.go
@@ -426,6 +426,8 @@ var _ = Describe("Integration Test", func() {
 			{"#DW jobdw name=jobdw-xfs    type=xfs    capacity=1GiB", 1, true, true, 1},
 			{"#DW jobdw name=jobdw-gfs2   type=gfs2   capacity=1GiB", 1, true, true, 1},
 			{"#DW jobdw name=jobdw-lustre type=lustre capacity=1GiB", 1, true, true, 3},
+			{"#DW jobdw name=jobdw-lustre type=lustre combined_mgtmdt capacity=1GiB", 1, true, true, 2},
+			{"#DW jobdw name=jobdw-lustre type=lustre external_mgs=localhost@tcp capacity=1GiB", 1, true, true, 2},
 
 			{"#DW create_persistent name=createpersistent-xfs    type=xfs    capacity=1GiB", 1, false, true, 1},
 			{"#DW create_persistent name=createpersistent-gfs2   type=gfs2   capacity=1GiB", 1, false, true, 1},


### PR DESCRIPTION
Nnf_access_controller needs the MGS NID of an orchestrated lustre filesystem
when creating the ClientMount resource. Sometimes that filesystem is using an
external MGS.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>