### PR TITLE
RABSW-987: Delete DirectiveBreakdown children explicitly

### DIFF
--- a/controllers/directivebreakdown_controller.go
+++ b/controllers/directivebreakdown_controller.go
@@ -69,8 +69,9 @@ const ( // They should complete the sentence "populateDirectiveBreakdown ____ th
 // DirectiveBreakdownReconciler reconciles a DirectiveBreakdown object
 type DirectiveBreakdownReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *kruntime.Scheme
+	Log          logr.Logger
+	Scheme       *kruntime.Scheme
+	ChildObjects []dwsv1alpha1.ObjectList
 }
 
 type lustreComponentType struct {
@@ -115,17 +116,30 @@ func (r *DirectiveBreakdownReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, nil
 		}
 
-		// TODO: Teardown directiveBreakdown
-		/*
-			if err := r.teardownDirectiveBreakdown(ctx, dbd); err != nil {
-				return ctrl.Result{}, err
-			}
+		// Delete all  children that are owned by this DirectiveBreakdown.
+		deleteStatus, err := dwsv1alpha1.DeleteChildren(ctx, r.Client, r.ChildObjects, dbd)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 
-			controllerutil.RemoveFinalizer(dbd, finalizerDirectiveBreakdown)
-			if err := r.Update(ctx, dbd); err != nil {
-				return ctrl.Result{}, err
-			}
-		*/
+		if deleteStatus == dwsv1alpha1.DeleteRetry {
+			return ctrl.Result{}, nil
+		}
+
+		controllerutil.RemoveFinalizer(dbd, finalizerDirectiveBreakdown)
+		if err := r.Update(ctx, dbd); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	// Add the finalizer if it doesn't exist
+	if !controllerutil.ContainsFinalizer(dbd, finalizerDirectiveBreakdown) {
+		controllerutil.AddFinalizer(dbd, finalizerDirectiveBreakdown)
+		if err := r.Update(ctx, dbd); err != nil {
+			return ctrl.Result{Requeue: true}, nil
+		}
 
 		return ctrl.Result{}, nil
 	}
@@ -488,6 +502,12 @@ func (d *directiveBreakdownStatusUpdater) close(ctx context.Context, r *Directiv
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *DirectiveBreakdownReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.ChildObjects = []dwsv1alpha1.ObjectList{
+		&dwsv1alpha1.ServersList{},
+		&nnfv1alpha1.NnfStorageProfileList{},
+		&dwsv1alpha1.PersistentStorageInstanceList{},
+	}
+
 	maxReconciles := runtime.GOMAXPROCS(0)
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxReconciles}).

--- a/controllers/directivebreakdown_controller.go
+++ b/controllers/directivebreakdown_controller.go
@@ -128,7 +128,11 @@ func (r *DirectiveBreakdownReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 		controllerutil.RemoveFinalizer(dbd, finalizerDirectiveBreakdown)
 		if err := r.Update(ctx, dbd); err != nil {
-			return ctrl.Result{}, err
+			if !apierrors.IsConflict(err) {
+				return ctrl.Result{}, err
+			}
+
+			return ctrl.Result{Requeue: true}, nil
 		}
 
 		return ctrl.Result{}, nil
@@ -138,6 +142,10 @@ func (r *DirectiveBreakdownReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if !controllerutil.ContainsFinalizer(dbd, finalizerDirectiveBreakdown) {
 		controllerutil.AddFinalizer(dbd, finalizerDirectiveBreakdown)
 		if err := r.Update(ctx, dbd); err != nil {
+			if !apierrors.IsConflict(err) {
+				return ctrl.Result{}, err
+			}
+
 			return ctrl.Result{Requeue: true}, nil
 		}
 

--- a/controllers/directivebreakdown_controller_test.go
+++ b/controllers/directivebreakdown_controller_test.go
@@ -1,0 +1,141 @@
+package controllers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	dwsv1alpha1 "github.com/HewlettPackard/dws/api/v1alpha1"
+	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
+)
+
+var _ = Describe("DirectiveBreakdown test", func() {
+	var (
+		storageProfile *nnfv1alpha1.NnfStorageProfile
+	)
+
+	BeforeEach(func() {
+		// Create a default NnfStorageProfile for the unit tests.
+		storageProfile = createBasicDefaultNnfStorageProfile()
+	})
+
+	AfterEach(func() {
+		Expect(k8sClient.Delete(context.TODO(), storageProfile)).To(Succeed())
+		profExpected := &nnfv1alpha1.NnfStorageProfile{}
+		Eventually(func() error { // Delete can still return the cached object. Wait until the object is no longer present
+			return k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(storageProfile), profExpected)
+		}).ShouldNot(Succeed())
+	})
+
+	It("Creates a DirectiveBreakdown with a jobdw", func() {
+		By("Creating a DirectiveBreakdown")
+		directiveBreakdown := &dwsv1alpha1.DirectiveBreakdown{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "jobdw-test",
+				Namespace: corev1.NamespaceDefault,
+			},
+			Spec: dwsv1alpha1.DirectiveBreakdownSpec{
+				Directive: "#DW jobdw name=jobdw-xfs type=xfs capacity=1GiB",
+			},
+		}
+
+		Expect(k8sClient.Create(context.TODO(), directiveBreakdown)).To(Succeed())
+
+		Eventually(func(g Gomega) bool {
+			g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(directiveBreakdown), directiveBreakdown)).To(Succeed())
+			return directiveBreakdown.Status.Ready
+		}).Should(BeTrue())
+
+		servers := &dwsv1alpha1.Servers{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      directiveBreakdown.GetName(),
+				Namespace: directiveBreakdown.GetNamespace(),
+			},
+		}
+		Eventually(func() error {
+			return k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(servers), servers)
+		}).Should(Succeed(), "Create the DWS Servers Resource")
+
+		pinnedStorageProfile := &nnfv1alpha1.NnfStorageProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      directiveBreakdown.GetName(),
+				Namespace: directiveBreakdown.GetNamespace(),
+			},
+		}
+		Eventually(func() error {
+			return k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(pinnedStorageProfile), pinnedStorageProfile)
+		}).Should(Succeed(), "Create the pinned StorageProfile Resource")
+
+		By("Deleting the DirectiveBreakdown")
+		Expect(k8sClient.Delete(context.TODO(), directiveBreakdown)).To(Succeed())
+		Eventually(func() error {
+			return k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(pinnedStorageProfile), pinnedStorageProfile)
+		}).ShouldNot(Succeed())
+
+		Eventually(func() error {
+			return k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(servers), servers)
+		}).ShouldNot(Succeed())
+	})
+
+	It("Verifies DirectiveBreakdowns with persistent storage", func() {
+		By("Creating a DirectiveBreakdown with create_persistent")
+		directiveBreakdownOne := &dwsv1alpha1.DirectiveBreakdown{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "create-persistent-test",
+				Namespace: corev1.NamespaceDefault,
+			},
+			Spec: dwsv1alpha1.DirectiveBreakdownSpec{
+				Directive: "#DW create_persistent name=persistent-storage type=xfs capacity=1GiB",
+			},
+		}
+
+		Expect(k8sClient.Create(context.TODO(), directiveBreakdownOne)).To(Succeed())
+
+		Eventually(func(g Gomega) bool {
+			g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(directiveBreakdownOne), directiveBreakdownOne)).To(Succeed())
+			return directiveBreakdownOne.Status.Ready
+		}).Should(BeTrue())
+
+		persistentStorage := &dwsv1alpha1.PersistentStorageInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "persistent-storage",
+				Namespace: directiveBreakdownOne.GetNamespace(),
+			},
+		}
+		Eventually(func() error {
+			return k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(persistentStorage), persistentStorage)
+		}).Should(Succeed(), "Create the PersistentStorageInstance resource")
+
+		By("Creating a DirectiveBreakdown with persistentdw")
+		directiveBreakdownTwo := &dwsv1alpha1.DirectiveBreakdown{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "use-persistent-test",
+				Namespace: corev1.NamespaceDefault,
+			},
+			Spec: dwsv1alpha1.DirectiveBreakdownSpec{
+				Directive: "#DW persistentdw name=persistent-storage",
+			},
+		}
+
+		Expect(k8sClient.Create(context.TODO(), directiveBreakdownTwo)).To(Succeed())
+
+		Eventually(func(g Gomega) bool {
+			g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(directiveBreakdownTwo), directiveBreakdownTwo)).To(Succeed())
+			return directiveBreakdownTwo.Status.Ready
+		}).Should(BeTrue())
+
+		By("Deleting the DirectiveBreakdown with persistentdw")
+		Expect(k8sClient.Delete(context.TODO(), directiveBreakdownTwo)).To(Succeed())
+
+		By("Deleting the DirectiveBreakdown with create_persistent")
+		Expect(k8sClient.Delete(context.TODO(), directiveBreakdownOne)).To(Succeed())
+		Eventually(func() error {
+			return k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(persistentStorage), persistentStorage)
+		}).ShouldNot(Succeed())
+	})
+})

--- a/controllers/nnf_access_controller.go
+++ b/controllers/nnf_access_controller.go
@@ -135,7 +135,11 @@ func (r *NnfAccessReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		controllerutil.RemoveFinalizer(access, finalizerNnfAccess)
 		if err := r.Update(ctx, access); err != nil {
-			return ctrl.Result{}, err
+			if !apierrors.IsConflict(err) {
+				return ctrl.Result{}, err
+			}
+
+			return ctrl.Result{Requeue: true}, nil
 		}
 
 		return ctrl.Result{}, nil
@@ -145,6 +149,10 @@ func (r *NnfAccessReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if !controllerutil.ContainsFinalizer(access, finalizerNnfAccess) {
 		controllerutil.AddFinalizer(access, finalizerNnfAccess)
 		if err := r.Update(ctx, access); err != nil {
+			if !apierrors.IsConflict(err) {
+				return ctrl.Result{}, err
+			}
+
 			return ctrl.Result{Requeue: true}, nil
 		}
 

--- a/controllers/nnf_clientmount_controller.go
+++ b/controllers/nnf_clientmount_controller.go
@@ -97,7 +97,11 @@ func (r *NnfClientMountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 		controllerutil.RemoveFinalizer(clientMount, finalizerNnfClientMount)
 		if err := r.Update(ctx, clientMount); err != nil {
-			return ctrl.Result{}, err
+			if !apierrors.IsConflict(err) {
+				return ctrl.Result{}, err
+			}
+
+			return ctrl.Result{Requeue: true}, nil
 		}
 
 		return ctrl.Result{}, nil
@@ -123,6 +127,10 @@ func (r *NnfClientMountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if !controllerutil.ContainsFinalizer(clientMount, finalizerNnfClientMount) {
 		controllerutil.AddFinalizer(clientMount, finalizerNnfClientMount)
 		if err := r.Update(ctx, clientMount); err != nil {
+			if !apierrors.IsConflict(err) {
+				return ctrl.Result{}, err
+			}
+
 			return ctrl.Result{Requeue: true}, nil
 		}
 

--- a/controllers/nnf_node_slc.go
+++ b/controllers/nnf_node_slc.go
@@ -90,7 +90,11 @@ func (r *NnfNodeSLCReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 		controllerutil.RemoveFinalizer(nnfNode, finalizerNnfNodeSLC)
 		if err := r.Update(ctx, nnfNode); err != nil {
-			return ctrl.Result{}, err
+			if !apierrors.IsConflict(err) {
+				return ctrl.Result{}, err
+			}
+
+			return ctrl.Result{Requeue: true}, nil
 		}
 
 		return ctrl.Result{}, nil
@@ -101,6 +105,10 @@ func (r *NnfNodeSLCReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 		controllerutil.AddFinalizer(nnfNode, finalizerNnfNodeSLC)
 		if err := r.Update(ctx, nnfNode); err != nil {
+			if !apierrors.IsConflict(err) {
+				return ctrl.Result{}, err
+			}
+
 			return ctrl.Result{Requeue: true}, nil
 		}
 

--- a/controllers/nnf_node_storage_controller.go
+++ b/controllers/nnf_node_storage_controller.go
@@ -127,7 +127,11 @@ func (r *NnfNodeStorageReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 		controllerutil.RemoveFinalizer(nodeStorage, finalizerNnfNodeStorage)
 		if err := r.Update(ctx, nodeStorage); err != nil {
-			return ctrl.Result{}, err
+			if !apierrors.IsConflict(err) {
+				return ctrl.Result{}, err
+			}
+
+			return ctrl.Result{Requeue: true}, nil
 		}
 
 		return ctrl.Result{}, nil
@@ -139,6 +143,10 @@ func (r *NnfNodeStorageReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if !controllerutil.ContainsFinalizer(nodeStorage, finalizerNnfNodeStorage) {
 		controllerutil.AddFinalizer(nodeStorage, finalizerNnfNodeStorage)
 		if err := r.Update(ctx, nodeStorage); err != nil {
+			if !apierrors.IsConflict(err) {
+				return ctrl.Result{}, err
+			}
+
 			return ctrl.Result{Requeue: true}, nil
 		}
 

--- a/controllers/nnf_persistentstorageinstance_controller.go
+++ b/controllers/nnf_persistentstorageinstance_controller.go
@@ -215,6 +215,7 @@ func (r *PersistentStorageReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.ChildObjects = []dwsv1alpha1.ObjectList{
 		&nnfv1alpha1.NnfStorageList{},
 		&dwsv1alpha1.ServersList{},
+		&nnfv1alpha1.NnfStorageProfileList{},
 	}
 
 	maxReconciles := runtime.GOMAXPROCS(0)

--- a/controllers/nnf_persistentstorageinstance_controller.go
+++ b/controllers/nnf_persistentstorageinstance_controller.go
@@ -99,7 +99,11 @@ func (r *PersistentStorageReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 		controllerutil.RemoveFinalizer(persistentStorage, finalizerPersistentStorage)
 		if err := r.Update(ctx, persistentStorage); err != nil {
-			return ctrl.Result{}, err
+			if !apierrors.IsConflict(err) {
+				return ctrl.Result{}, err
+			}
+
+			return ctrl.Result{Requeue: true}, nil
 		}
 
 		return ctrl.Result{}, nil
@@ -109,6 +113,10 @@ func (r *PersistentStorageReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	if !controllerutil.ContainsFinalizer(persistentStorage, finalizerPersistentStorage) {
 		controllerutil.AddFinalizer(persistentStorage, finalizerPersistentStorage)
 		if err := r.Update(ctx, persistentStorage); err != nil {
+			if !apierrors.IsConflict(err) {
+				return ctrl.Result{}, err
+			}
+
 			return ctrl.Result{Requeue: true}, nil
 		}
 

--- a/controllers/nnf_storage_controller.go
+++ b/controllers/nnf_storage_controller.go
@@ -126,7 +126,11 @@ func (r *NnfStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 		controllerutil.RemoveFinalizer(storage, finalizerNnfStorage)
 		if err := r.Update(ctx, storage); err != nil {
-			return ctrl.Result{}, err
+			if !apierrors.IsConflict(err) {
+				return ctrl.Result{}, err
+			}
+
+			return ctrl.Result{Requeue: true}, nil
 		}
 
 		return ctrl.Result{}, nil
@@ -137,6 +141,10 @@ func (r *NnfStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 		controllerutil.AddFinalizer(storage, finalizerNnfStorage)
 		if err := r.Update(ctx, storage); err != nil {
+			if !apierrors.IsConflict(err) {
+				return ctrl.Result{}, err
+			}
+
 			return ctrl.Result{Requeue: true}, nil
 		}
 

--- a/controllers/nnf_systemconfiguration_controller.go
+++ b/controllers/nnf_systemconfiguration_controller.go
@@ -81,7 +81,11 @@ func (r *NnfSystemConfigurationReconciler) Reconcile(ctx context.Context, req ct
 
 		controllerutil.RemoveFinalizer(systemConfiguration, finalizerNnfSystemConfiguration)
 		if err := r.Update(ctx, systemConfiguration); err != nil {
-			return ctrl.Result{}, err
+			if !apierrors.IsConflict(err) {
+				return ctrl.Result{}, err
+			}
+
+			return ctrl.Result{Requeue: true}, nil
 		}
 
 		return ctrl.Result{}, nil
@@ -91,6 +95,10 @@ func (r *NnfSystemConfigurationReconciler) Reconcile(ctx context.Context, req ct
 	if !controllerutil.ContainsFinalizer(systemConfiguration, finalizerNnfSystemConfiguration) {
 		controllerutil.AddFinalizer(systemConfiguration, finalizerNnfSystemConfiguration)
 		if err := r.Update(ctx, systemConfiguration); err != nil {
+			if !apierrors.IsConflict(err) {
+				return ctrl.Result{}, err
+			}
+
 			return ctrl.Result{Requeue: true}, nil
 		}
 

--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -154,7 +154,11 @@ func (r *NnfWorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 		controllerutil.RemoveFinalizer(workflow, finalizerNnfWorkflow)
 		if err := r.Update(ctx, workflow); err != nil {
-			return ctrl.Result{}, err
+			if !apierrors.IsConflict(err) {
+				return ctrl.Result{}, err
+			}
+
+			return ctrl.Result{Requeue: true}, nil
 		}
 
 		return ctrl.Result{}, nil
@@ -164,6 +168,10 @@ func (r *NnfWorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if !controllerutil.ContainsFinalizer(workflow, finalizerNnfWorkflow) {
 		controllerutil.AddFinalizer(workflow, finalizerNnfWorkflow)
 		if err := r.Update(ctx, workflow); err != nil {
+			if !apierrors.IsConflict(err) {
+				return ctrl.Result{}, err
+			}
+
 			return ctrl.Result{Requeue: true}, nil
 		}
 

--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -1576,7 +1576,6 @@ func (r *NnfWorkflowReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		&nnfv1alpha1.NnfStorageList{},
 		&dwsv1alpha1.PersistentStorageInstanceList{},
 		&dwsv1alpha1.DirectiveBreakdownList{},
-		&nnfv1alpha1.NnfStorageProfileList{},
 	}
 
 	maxReconciles := runtime.GOMAXPROCS(0)


### PR DESCRIPTION
The DirectiveBreakdown controller was relying on garbage collecting to delete
children. Use the DeleteChildren() call to delete them explicitly.

Signed-off-by: Matt Richerson <mattr@cray.com>