### PR TITLE
RABSW-991: Fix XFS/GFS2 unmount bug

### DIFF
--- a/config/crd/bases/nnf.cray.hpe.com_nnfdatamovements.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfdatamovements.yaml
@@ -302,43 +302,11 @@ spec:
                   - type
                   type: object
                 type: array
-              job:
-                description: Job references the underlying job that performs data
-                  movement
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
+              endTime:
+                description: EndTime reflects the time at which the Data Movement
+                  operation ended.
+                format: date-time
+                type: string
               nodeStatus:
                 description: Node Status reflects the status of individual NNF Node
                   Data Movement operations
@@ -381,6 +349,11 @@ spec:
                   - running
                   type: object
                 type: array
+              startTime:
+                description: StartTime reflects the time at which the Data Movement
+                  operation started.
+                format: date-time
+                type: string
             type: object
         type: object
     served: true

--- a/controllers/nnf_access_controller.go
+++ b/controllers/nnf_access_controller.go
@@ -114,11 +114,6 @@ func (r *NnfAccessReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, nil
 		}
 
-		err = r.removeNodeStorageEndpoints(ctx, access, storageMapping)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-
 		deleteStatus, err := dwsv1alpha1.DeleteChildren(ctx, r.Client, r.ChildObjects, access)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -126,6 +121,11 @@ func (r *NnfAccessReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		if deleteStatus == dwsv1alpha1.DeleteRetry {
 			return ctrl.Result{}, nil
+		}
+
+		err = r.removeNodeStorageEndpoints(ctx, access, storageMapping)
+		if err != nil {
+			return ctrl.Result{}, err
 		}
 
 		// Unlock the NnfStorage so it can be used by another NnfAccess

--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -1398,8 +1398,8 @@ func (r *NnfWorkflowReconciler) finishPostRunState(ctx context.Context, workflow
 	}
 
 	if err := r.Get(ctx, client.ObjectKeyFromObject(access), access); err == nil {
-		if access.Status.State != "unmounted" {
-			return &ctrl.Result{Requeue: true}, nil
+		if access.Status.State != "unmounted" || access.Status.Ready != true {
+			return &ctrl.Result{}, nil
 		}
 	}
 


### PR DESCRIPTION
This commit fixes two issues related to unmounting XFS and GFS2 filesystems
from the client:
- The workflow controller wasn't waiting for the NnfAccess to have a state of
"Unmounted" and "Ready" before deleting the NnfAccess.
- The NnfAccess controller was removing the compute node PCIe mappings before
deleting the ClientMount resources. If the ClientMounts were still mounted,
then clientmountd would give an error.

Signed-off-by: Matt Richerson <mattr@cray.com>