### PR TITLE
RABSW-994 Export directiveIndexLabel from nnf-sos for nnf-dm

### DIFF
--- a/api/v1alpha1/workflow_helpers.go
+++ b/api/v1alpha1/workflow_helpers.go
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1alpha1
+
+const (
+	// DirectiveIndexLabel is a label applied to child objects of the workflow
+	// to show which directive they were created for. This is useful during deletion
+	// to filter the child objects by the directive index and only delete the
+	// resources for the directive being processed
+	DirectiveIndexLabel = "nnf.cray.hpe.com/directive_index"
+)

--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -56,12 +56,6 @@ const (
 	// reconciler has finished in using the resource.
 	finalizerNnfWorkflow = "nnf.cray.hpe.com/nnf_workflow"
 
-	// directiveIndexLabel is a label applied to child objects of the workflow
-	// to show which directive they were created for. This is useful during deletion
-	// to filter the child objects by the directive index and only delete the
-	// resources for the directive being processed
-	directiveIndexLabel = "nnf.cray.hpe.com/directive_index"
-
 	// teardownStateLabel is a label applied to NnfAccess resources to determine when
 	// they should be deleted. The delete code filters by the current workflow state
 	// to only delete the correct NnfAccess resources
@@ -1459,7 +1453,7 @@ func (r *NnfWorkflowReconciler) startTeardownState(ctx context.Context, workflow
 		&nnfv1alpha1.NnfAccessList{},
 	}
 
-	deleteStatus, err := dwsv1alpha1.DeleteChildrenWithLabels(ctx, r.Client, childObjects, workflow, client.MatchingLabels{directiveIndexLabel: strconv.Itoa(index)})
+	deleteStatus, err := dwsv1alpha1.DeleteChildrenWithLabels(ctx, r.Client, childObjects, workflow, client.MatchingLabels{nnfv1alpha1.DirectiveIndexLabel: strconv.Itoa(index)})
 	if err != nil {
 		return nil, err
 	}
@@ -1495,7 +1489,7 @@ func (r *NnfWorkflowReconciler) finishTeardownState(ctx context.Context, workflo
 		persistentStorage.SetOwnerReferences([]metav1.OwnerReference{})
 		dwsv1alpha1.RemoveOwnerLabels(persistentStorage)
 		labels := persistentStorage.GetLabels()
-		delete(labels, directiveIndexLabel)
+		delete(labels, nnfv1alpha1.DirectiveIndexLabel)
 		persistentStorage.SetLabels(labels)
 
 		err = r.Update(ctx, persistentStorage)
@@ -1530,7 +1524,7 @@ func (r *NnfWorkflowReconciler) finishTeardownState(ctx context.Context, workflo
 		&dwsv1alpha1.PersistentStorageInstanceList{},
 	}
 
-	deleteStatus, err := dwsv1alpha1.DeleteChildrenWithLabels(ctx, r.Client, childObjects, workflow, client.MatchingLabels{directiveIndexLabel: strconv.Itoa(index)})
+	deleteStatus, err := dwsv1alpha1.DeleteChildrenWithLabels(ctx, r.Client, childObjects, workflow, client.MatchingLabels{nnfv1alpha1.DirectiveIndexLabel: strconv.Itoa(index)})
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/nnf_workflow_controller_helpers.go
+++ b/controllers/nnf_workflow_controller_helpers.go
@@ -7,6 +7,7 @@ import (
 
 	dwsv1alpha1 "github.com/HewlettPackard/dws/api/v1alpha1"
 	"github.com/HewlettPackard/dws/utils/dwdparse"
+	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -103,7 +104,7 @@ func addDirectiveIndexLabel(object metav1.Object, index int) {
 		labels = make(map[string]string)
 	}
 
-	labels[directiveIndexLabel] = strconv.Itoa(index)
+	labels[nnfv1alpha1.DirectiveIndexLabel] = strconv.Itoa(index)
 	object.SetLabels(labels)
 }
 


### PR DESCRIPTION
Move directiveIndexLabel from controllers/ to api/ and make it exported.  Then
the nnf-dm daemon will be able to use it.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>