### PR TITLE
RABSW-999: Use constants for driver status

### DIFF
--- a/api/v1alpha1/workflow_error.go
+++ b/api/v1alpha1/workflow_error.go
@@ -64,9 +64,9 @@ func (e *WorkflowError) Unwrap() error {
 func (e *WorkflowError) Inject(driverStatus *dwsv1alpha1.WorkflowDriverStatus) {
 	driverStatus.Message = e.GetMessage()
 	if e.GetRecoverable() {
-		driverStatus.Reason = "running"
+		driverStatus.Status = dwsv1alpha1.StatusRunning
 	} else {
-		driverStatus.Reason = "error"
+		driverStatus.Status = dwsv1alpha1.StatusError
 	}
 
 	if e.Unwrap() != nil {

--- a/controllers/integration_test.go
+++ b/controllers/integration_test.go
@@ -1188,7 +1188,7 @@ var _ = Describe("Integration Test", func() {
 					driverID := os.Getenv("DWS_DRIVER_ID")
 					for _, driver := range workflow.Status.Drivers {
 						if driver.DriverID == driverID {
-							if driver.Reason == "error" {
+							if driver.Status == dwsv1alpha1.StatusError {
 								return &driver
 							}
 						}
@@ -1473,7 +1473,7 @@ var _ = Describe("Integration Test", func() {
 				driverID := os.Getenv("DWS_DRIVER_ID")
 				for _, driver := range workflow.Status.Drivers {
 					if driver.DriverID == driverID {
-						if driver.Reason == "error" {
+						if driver.Status == dwsv1alpha1.StatusError {
 							return &driver
 						}
 					}

--- a/controllers/nnf_node_controller.go
+++ b/controllers/nnf_node_controller.go
@@ -147,10 +147,10 @@ func (r *NnfNodeReconciler) EventHandler(e event.Event) error {
 	if linkEstablished || linkDropped {
 		r.Reconcile(context.TODO(), ctrl.Request{NamespacedName: r.NamespacedName})
 	}
-	
+
 	// Downstream link events
-	linkEstablished = e.Is(msgreg.DownstreamLinkEstablishedFabric("","")) || e.Is(msgreg.DegradedDownstreamLinkEstablishedFabric("",""))
-	linkDropped = e.Is(msgreg.DownstreamLinkDroppedFabric("",""))
+	linkEstablished = e.Is(msgreg.DownstreamLinkEstablishedFabric("", "")) || e.Is(msgreg.DegradedDownstreamLinkEstablishedFabric("", ""))
+	linkDropped = e.Is(msgreg.DownstreamLinkDroppedFabric("", ""))
 
 	if linkEstablished || linkDropped {
 		r.Reconcile(context.TODO(), ctrl.Request{NamespacedName: r.NamespacedName})

--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -224,7 +224,7 @@ func (r *NnfWorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{}, err
 		}
 
-		driverStatus.Reason = "running"
+		driverStatus.Status = dwsv1alpha1.StatusRunning
 		driverStatus.Message = ""
 		driverStatus.Error = ""
 
@@ -260,7 +260,7 @@ func (r *NnfWorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{}, err
 		}
 
-		driverStatus.Reason = "running"
+		driverStatus.Status = dwsv1alpha1.StatusRunning
 		driverStatus.Message = ""
 		driverStatus.Error = ""
 
@@ -272,7 +272,7 @@ func (r *NnfWorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		log.Info("Finish done", "State", workflow.Status.State, "index", driverStatus.DWDIndex)
 
 		ts := metav1.NowMicro()
-		driverStatus.Reason = "completed"
+		driverStatus.Status = dwsv1alpha1.StatusCompleted
 		driverStatus.Message = ""
 		driverStatus.Error = ""
 		driverStatus.CompleteTime = &ts

--- a/controllers/nnf_workflow_controller_helpers.go
+++ b/controllers/nnf_workflow_controller_helpers.go
@@ -16,7 +16,7 @@ func handleWorkflowError(err error, driverStatus *dwsv1alpha1.WorkflowDriverStat
 	if ok {
 		e.Inject(driverStatus)
 	} else {
-		driverStatus.Reason = "error"
+		driverStatus.Status = dwsv1alpha1.StatusError
 		driverStatus.Message = "Internal error: " + err.Error()
 		driverStatus.Error = err.Error()
 	}

--- a/controllers/nnf_workflow_controller_test.go
+++ b/controllers/nnf_workflow_controller_test.go
@@ -96,7 +96,7 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 		driverID := os.Getenv("DWS_DRIVER_ID")
 		for _, driver := range workflow.Status.Drivers {
 			if driver.DriverID == driverID {
-				if driver.Reason == "error" {
+				if driver.Status == dwsv1alpha1.StatusError {
 					return &driver
 				}
 			}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/NearNodeFlash/nnf-sos
 go 1.16
 
 require (
-	github.com/HewlettPackard/dws v0.0.0-20220808201220-9c78c6733e77
+	github.com/HewlettPackard/dws v0.0.0-20220811145532-a7d1177caa91
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220727174249-9b7004c2cb38
 	github.com/NearNodeFlash/nnf-ec v0.0.0-20220726184901-f1d60304f049
 	github.com/ghodss/yaml v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/NearNodeFlash/nnf-sos
 go 1.16
 
 require (
-	github.com/HewlettPackard/dws v0.0.0-20220811145532-a7d1177caa91
+	github.com/HewlettPackard/dws v0.0.0-20220811184026-49708e243332
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220727174249-9b7004c2cb38
 	github.com/NearNodeFlash/nnf-ec v0.0.0-20220726184901-f1d60304f049
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/HewlettPackard/dws v0.0.0-20220811145532-a7d1177caa91 h1:tQ+3NbEuS1nS4f24cS9t3uNpnQ6JdF24GlHP2mtvi34=
-github.com/HewlettPackard/dws v0.0.0-20220811145532-a7d1177caa91/go.mod h1:ENSzxviBNafkA5X+c1XUNIV9J1d2lVt4+r9AbidihNI=
+github.com/HewlettPackard/dws v0.0.0-20220811184026-49708e243332 h1:O+Ow+HiWNnJnfUDW1oLm3eZgydaycE5W0Rz3q2SN0Nk=
+github.com/HewlettPackard/dws v0.0.0-20220811184026-49708e243332/go.mod h1:ENSzxviBNafkA5X+c1XUNIV9J1d2lVt4+r9AbidihNI=
 github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220623192103-4ce53adacc95/go.mod h1:Wwr96QYACIixBjBXpST9yMS81WxMu/tF/zc/5OW21Dk=
 github.com/HewlettPackard/structex v1.0.2 h1:p2EH/p6zvUd5fSa0onudAUvLWdKsvQSRP0jGKeblA5E=
 github.com/HewlettPackard/structex v1.0.2/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/HewlettPackard/dws v0.0.0-20220808201220-9c78c6733e77 h1:pLUfhLhFrdjlFDGaOir1biGm49dBRTDSPmJ8cr0/F60=
-github.com/HewlettPackard/dws v0.0.0-20220808201220-9c78c6733e77/go.mod h1:ENSzxviBNafkA5X+c1XUNIV9J1d2lVt4+r9AbidihNI=
+github.com/HewlettPackard/dws v0.0.0-20220811145532-a7d1177caa91 h1:tQ+3NbEuS1nS4f24cS9t3uNpnQ6JdF24GlHP2mtvi34=
+github.com/HewlettPackard/dws v0.0.0-20220811145532-a7d1177caa91/go.mod h1:ENSzxviBNafkA5X+c1XUNIV9J1d2lVt4+r9AbidihNI=
 github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220623192103-4ce53adacc95/go.mod h1:Wwr96QYACIixBjBXpST9yMS81WxMu/tF/zc/5OW21Dk=
 github.com/HewlettPackard/structex v1.0.2 h1:p2EH/p6zvUd5fSa0onudAUvLWdKsvQSRP0jGKeblA5E=
 github.com/HewlettPackard/structex v1.0.2/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=

--- a/vendor/github.com/HewlettPackard/dws/api/v1alpha1/workflow_types.go
+++ b/vendor/github.com/HewlettPackard/dws/api/v1alpha1/workflow_types.go
@@ -58,6 +58,15 @@ var workflowStrings = [...]string{
 	"teardown",
 }
 
+const (
+	StatusPending    = "Pending"
+	StatusQueued     = "Queued"
+	StatusRunning    = "Running"
+	StatusCompleted  = "Completed"
+	StatusError      = "Error"
+	StatusDriverWait = "DriverWait"
+)
+
 func (s WorkflowState) String() string {
 	return workflowStrings[s]
 }
@@ -109,7 +118,9 @@ type WorkflowDriverStatus struct {
 	// User readable reason.
 	// For the CDS driver, this could be the state of the underlying
 	// data movement request:  Pending, Queued, Running, Completed or Error
-	Reason  string `json:"reason,omitempty"`
+	// +kubebuilder:validation:Enum=Pending;Queued;Running;Completed;Error
+	Status string `json:"status,omitempty"`
+
 	Message string `json:"message,omitempty"`
 
 	// Driver error string. This is not rolled up into the workflow's

--- a/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_workflows.yaml
+++ b/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_workflows.yaml
@@ -251,10 +251,16 @@ spec:
                       type: integer
                     message:
                       type: string
-                    reason:
+                    status:
                       description: 'User readable reason. For the CDS driver, this
                         could be the state of the underlying data movement request:  Pending,
                         Queued, Running, Completed or Error'
+                      enum:
+                      - Pending
+                      - Queued
+                      - Running
+                      - Completed
+                      - Error
                       type: string
                     taskID:
                       type: string

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/Azure/go-autorest/autorest/date
 github.com/Azure/go-autorest/logger
 # github.com/Azure/go-autorest/tracing v0.6.0
 github.com/Azure/go-autorest/tracing
-# github.com/HewlettPackard/dws v0.0.0-20220811145532-a7d1177caa91
+# github.com/HewlettPackard/dws v0.0.0-20220811184026-49708e243332
 ## explicit
 github.com/HewlettPackard/dws/api/v1alpha1
 github.com/HewlettPackard/dws/config/crd/bases

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/Azure/go-autorest/autorest/date
 github.com/Azure/go-autorest/logger
 # github.com/Azure/go-autorest/tracing v0.6.0
 github.com/Azure/go-autorest/tracing
-# github.com/HewlettPackard/dws v0.0.0-20220808201220-9c78c6733e77
+# github.com/HewlettPackard/dws v0.0.0-20220811145532-a7d1177caa91
 ## explicit
 github.com/HewlettPackard/dws/api/v1alpha1
 github.com/HewlettPackard/dws/config/crd/bases


### PR DESCRIPTION
This commit uses the new string constants for the workflow driver
array status field.

Signed-off-by: Matt Richerson <mattr@cray.com>