### PR TITLE
RABSW-999: Collect error string from NnfNodeStorage

### DIFF
--- a/api/v1alpha1/nnf_storage_types.go
+++ b/api/v1alpha1/nnf_storage_types.go
@@ -98,8 +98,8 @@ type NnfStorageAllocationSetStatus struct {
 	// Health reflects the health of this NNF Storage
 	Health NnfResourceHealthType `json:"health,omitempty"`
 
-	// Reason is the human readable reason for the status
-	Reason string `json:"reason,omitempty"`
+	// Error is the human readable error string
+	Error string `json:"error,omitempty"`
 
 	// AllocationCount is the total number of allocations that currently
 	// exist

--- a/config/crd/bases/nnf.cray.hpe.com_nnfstorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfstorages.yaml
@@ -136,11 +136,11 @@ spec:
                       description: AllocationCount is the total number of allocations
                         that currently exist
                       type: integer
+                    error:
+                      description: Error is the human readable error string
+                      type: string
                     health:
                       description: Health reflects the health of this NNF Storage
-                      type: string
-                    reason:
-                      description: Reason is the human readable reason for the status
                       type: string
                     status:
                       description: Status reflects the status of this NNF Storage

--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -635,9 +635,9 @@ func (r *NnfWorkflowReconciler) finishSetupState(ctx context.Context, workflow *
 		if set.Status != "Ready" {
 			complete = false
 
-			if set.Reason != "" {
-				err := fmt.Errorf("NnfStorage %v allocation set %d error: %s", client.ObjectKeyFromObject(nnfStorage), i, set.Reason)
-				return nil, nnfv1alpha1.NewWorkflowError("Could not create allocation").WithError(err)
+			if set.Error != "" {
+				err := fmt.Errorf("NnfStorage %v allocation set %d error: %s", client.ObjectKeyFromObject(nnfStorage), i, set.Error)
+				return nil, nnfv1alpha1.NewWorkflowError("Could not create allocation").WithFatal().WithError(err)
 			}
 		}
 	}

--- a/controllers/nnf_workflow_controller_test.go
+++ b/controllers/nnf_workflow_controller_test.go
@@ -457,7 +457,7 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 						AllocationSets: []nnfv1alpha1.NnfStorageAllocationSetStatus{{
 							Status:          "Ready",
 							Health:          "OK",
-							Reason:          "",
+							Error:           "",
 							AllocationCount: 0,
 						}},
 					},


### PR DESCRIPTION
This commit finds the error string in the NnfNodeStorageConditions array
and passes it through the NnfStorage to end up in the workflow.

Signed-off-by: Matt Richerson <mattr@cray.com>