### PR TITLE
RABSW-1004 Add metrics support to the operators

### DIFF
--- a/controllers/directivebreakdown_controller.go
+++ b/controllers/directivebreakdown_controller.go
@@ -42,6 +42,7 @@ import (
 	dwsv1alpha1 "github.com/HewlettPackard/dws/api/v1alpha1"
 	"github.com/HewlettPackard/dws/utils/dwdparse"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
+	"github.com/NearNodeFlash/nnf-sos/controllers/metrics"
 )
 
 // Define condition values
@@ -94,6 +95,8 @@ type lustreComponentType struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.2/pkg/reconcile
 func (r *DirectiveBreakdownReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
 	log := r.Log.WithValues("DirectiveBreakdown", req.NamespacedName)
+
+	metrics.NnfDirectiveBreakdownReconcilesTotal.Inc()
 
 	dbd := &dwsv1alpha1.DirectiveBreakdown{}
 	err = r.Get(ctx, req.NamespacedName, dbd)

--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -1,0 +1,99 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	NnfWorkflowReconcilesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "nnf_workflow_reconciles_total",
+			Help: "Number of total reconciles in nnf_workflow controller",
+		},
+	)
+
+	NnfDirectiveBreakdownReconcilesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "nnf_directive_breakdown_reconciles_total",
+			Help: "Number of total reconciles in directive_breakdown controller",
+		},
+	)
+
+	NnfAccessReconcilesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "nnf_access_reconciles_total",
+			Help: "Number of total reconciles in nnf_access controller",
+		},
+	)
+
+	NnfClientMountReconcilesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "nnf_clientmount_reconciles_total",
+			Help: "Number of total reconciles in nnf_clientmount controller",
+		},
+	)
+
+	NnfNodeReconcilesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "nnf_node_reconciles_total",
+			Help: "Number of total reconciles in nnf_node controller",
+		},
+	)
+
+	NnfNodeECDataReconcilesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "nnf_node_ec_data_reconciles_total",
+			Help: "Number of total reconciles in nnf_node_ec_data controller",
+		},
+	)
+
+	NnfNodeStorageReconcilesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "nnf_node_storage_reconciles_total",
+			Help: "Number of total reconciles in nnf_node_storage controller",
+		},
+	)
+
+	NnfPersistentStorageReconcilesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "nnf_persistent_storage_reconciles_total",
+			Help: "Number of total reconciles in nnf_persistentstorage controller",
+		},
+	)
+
+	NnfServersReconcilesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "nnf_servers_reconciles_total",
+			Help: "Number of total reconciles in nnf_servers controller",
+		},
+	)
+
+	NnfStorageReconcilesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "nnf_storage_reconciles_total",
+			Help: "Number of total reconciles in nnf_storage controller",
+		},
+	)
+
+	NnfSystemConfigurationReconcilesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "nnf_system_configuration_reconciles_total",
+			Help: "Number of total reconciles in nnf_systemconfiguration controller",
+		},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(NnfWorkflowReconcilesTotal)
+	metrics.Registry.MustRegister(NnfDirectiveBreakdownReconcilesTotal)
+	metrics.Registry.MustRegister(NnfAccessReconcilesTotal)
+	metrics.Registry.MustRegister(NnfClientMountReconcilesTotal)
+	metrics.Registry.MustRegister(NnfNodeReconcilesTotal)
+	metrics.Registry.MustRegister(NnfNodeECDataReconcilesTotal)
+	metrics.Registry.MustRegister(NnfNodeStorageReconcilesTotal)
+	metrics.Registry.MustRegister(NnfPersistentStorageReconcilesTotal)
+	metrics.Registry.MustRegister(NnfServersReconcilesTotal)
+	metrics.Registry.MustRegister(NnfStorageReconcilesTotal)
+	metrics.Registry.MustRegister(NnfSystemConfigurationReconcilesTotal)
+}

--- a/controllers/nnf_access_controller.go
+++ b/controllers/nnf_access_controller.go
@@ -44,6 +44,7 @@ import (
 
 	dwsv1alpha1 "github.com/HewlettPackard/dws/api/v1alpha1"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
+	"github.com/NearNodeFlash/nnf-sos/controllers/metrics"
 )
 
 // NnfAccessReconciler reconciles a NnfAccess object
@@ -75,6 +76,8 @@ const (
 // move the current state of the cluster closer to the desired state.
 func (r *NnfAccessReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
 	log := r.Log.WithValues("NnfAccess", req.NamespacedName)
+
+	metrics.NnfAccessReconcilesTotal.Inc()
 
 	access := &nnfv1alpha1.NnfAccess{}
 	if err := r.Get(ctx, req.NamespacedName, access); err != nil {

--- a/controllers/nnf_clientmount_controller.go
+++ b/controllers/nnf_clientmount_controller.go
@@ -42,6 +42,7 @@ import (
 	dwsv1alpha1 "github.com/HewlettPackard/dws/api/v1alpha1"
 	sf "github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/models"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
+	"github.com/NearNodeFlash/nnf-sos/controllers/metrics"
 )
 
 const (
@@ -66,6 +67,9 @@ type NnfClientMountReconciler struct {
 // move the current state of the cluster closer to the desired state.
 func (r *NnfClientMountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
 	log := r.Log.WithValues("ClientMount", req.NamespacedName)
+
+	metrics.NnfClientMountReconcilesTotal.Inc()
+
 	clientMount := &dwsv1alpha1.ClientMount{}
 	if err := r.Get(ctx, req.NamespacedName, clientMount); err != nil {
 		// ignore not-found errors, since they can't be fixed by an immediate

--- a/controllers/nnf_node_controller.go
+++ b/controllers/nnf_node_controller.go
@@ -49,6 +49,7 @@ import (
 
 	dwsv1alpha1 "github.com/HewlettPackard/dws/api/v1alpha1"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
+	"github.com/NearNodeFlash/nnf-sos/controllers/metrics"
 )
 
 const (
@@ -78,6 +79,8 @@ type NnfNodeReconciler struct {
 // NNF Node CRD that is representiative of this particular NNF Node.
 func (r *NnfNodeReconciler) Start(ctx context.Context) error {
 	log := r.Log.WithValues("NnfNode", r.NamespacedName, "State", "Start")
+
+	metrics.NnfNodeReconcilesTotal.Inc()
 
 	// During testing, the NNF Node Reconciler is started before the kubeapi-server runs, so any Get() will
 	// fail with 'connection refused'. The test code will instead bootstrap some nodes using the k8s test client.

--- a/controllers/nnf_node_ec_data_controller.go
+++ b/controllers/nnf_node_ec_data_controller.go
@@ -34,6 +34,7 @@ import (
 	ec "github.com/NearNodeFlash/nnf-ec/pkg/ec"
 	"github.com/NearNodeFlash/nnf-ec/pkg/persistent"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
+	"github.com/NearNodeFlash/nnf-sos/controllers/metrics"
 )
 
 const (
@@ -110,6 +111,8 @@ func (r *NnfNodeECDataReconciler) Start(ctx context.Context) error {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.10.0/pkg/reconcile
 func (r *NnfNodeECDataReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
+
+	metrics.NnfNodeECDataReconcilesTotal.Inc()
 
 	// your logic here
 

--- a/controllers/nnf_node_storage_controller.go
+++ b/controllers/nnf_node_storage_controller.go
@@ -50,6 +50,7 @@ import (
 
 	dwsv1alpha1 "github.com/HewlettPackard/dws/api/v1alpha1"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
+	"github.com/NearNodeFlash/nnf-sos/controllers/metrics"
 )
 
 const (
@@ -80,6 +81,9 @@ type NnfNodeStorageReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.7.2/pkg/reconcile
 func (r *NnfNodeStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
+
+	metrics.NnfNodeStorageReconcilesTotal.Inc()
+
 	nodeStorage := &nnfv1alpha1.NnfNodeStorage{}
 	if err := r.Get(ctx, req.NamespacedName, nodeStorage); err != nil {
 		// ignore not-found errors, since they can't be fixed by an immediate

--- a/controllers/nnf_persistentstorageinstance_controller.go
+++ b/controllers/nnf_persistentstorageinstance_controller.go
@@ -38,6 +38,7 @@ import (
 	dwsv1alpha1 "github.com/HewlettPackard/dws/api/v1alpha1"
 	"github.com/HewlettPackard/dws/utils/dwdparse"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
+	"github.com/NearNodeFlash/nnf-sos/controllers/metrics"
 )
 
 const (
@@ -65,6 +66,8 @@ type PersistentStorageReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.2/pkg/reconcile
 func (r *PersistentStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
 	log := r.Log.WithValues("PersistentStorage", req.NamespacedName)
+
+	metrics.NnfPersistentStorageReconcilesTotal.Inc()
 
 	persistentStorage := &dwsv1alpha1.PersistentStorageInstance{}
 	if err := r.Get(ctx, req.NamespacedName, persistentStorage); err != nil {

--- a/controllers/nnf_servers_controller.go
+++ b/controllers/nnf_servers_controller.go
@@ -44,6 +44,7 @@ import (
 
 	dwsv1alpha1 "github.com/HewlettPackard/dws/api/v1alpha1"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
+	"github.com/NearNodeFlash/nnf-sos/controllers/metrics"
 )
 
 // DWSServersReconciler reconciles a DWS Servers object
@@ -83,6 +84,8 @@ const (
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.2/pkg/reconcile
 func (r *DWSServersReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
+
+	metrics.NnfServersReconcilesTotal.Inc()
 
 	servers := &dwsv1alpha1.Servers{}
 	if err := r.Get(ctx, req.NamespacedName, servers); err != nil {

--- a/controllers/nnf_storage_controller.go
+++ b/controllers/nnf_storage_controller.go
@@ -40,6 +40,7 @@ import (
 
 	dwsv1alpha1 "github.com/HewlettPackard/dws/api/v1alpha1"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
+	"github.com/NearNodeFlash/nnf-sos/controllers/metrics"
 )
 
 // NnfStorageReconciler reconciles a Storage object
@@ -84,6 +85,9 @@ const (
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *NnfStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
+
+	metrics.NnfStorageReconcilesTotal.Inc()
+
 	storage := &nnfv1alpha1.NnfStorage{}
 	if err := r.Get(ctx, req.NamespacedName, storage); err != nil {
 		// ignore not-found errors, since they can't be fixed by an immediate

--- a/controllers/nnf_systemconfiguration_controller.go
+++ b/controllers/nnf_systemconfiguration_controller.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	dwsv1alpha1 "github.com/HewlettPackard/dws/api/v1alpha1"
+	"github.com/NearNodeFlash/nnf-sos/controllers/metrics"
 )
 
 const (
@@ -60,6 +61,9 @@ type NnfSystemConfigurationReconciler struct {
 // move the current state of the cluster closer to the desired state.
 func (r *NnfSystemConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("SystemConfiguration", req.NamespacedName)
+
+	metrics.NnfSystemConfigurationReconcilesTotal.Inc()
+
 	systemConfiguration := &dwsv1alpha1.SystemConfiguration{}
 	if err := r.Get(ctx, req.NamespacedName, systemConfiguration); err != nil {
 		// ignore not-found errors, since they can't be fixed by an immediate

--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -47,6 +47,7 @@ import (
 	"github.com/HewlettPackard/dws/utils/dwdparse"
 	lusv1alpha1 "github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
+	"github.com/NearNodeFlash/nnf-sos/controllers/metrics"
 )
 
 const (
@@ -108,6 +109,8 @@ type NnfWorkflowReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.2/pkg/reconcile
 func (r *NnfWorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
 	log := r.Log.WithValues("Workflow", req.NamespacedName)
+
+	metrics.NnfWorkflowReconcilesTotal.Inc()
 
 	// Fetch the Workflow instance
 	workflow := &dwsv1alpha1.Workflow{}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0
+	github.com/prometheus/client_golang v1.11.0
 	go.uber.org/zap v1.21.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	k8s.io/api v0.23.6

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -176,6 +176,7 @@ github.com/pkg/errors
 github.com/pkg/term
 github.com/pkg/term/termios
 # github.com/prometheus/client_golang v1.11.0
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/collectors
 github.com/prometheus/client_golang/prometheus/internal


### PR DESCRIPTION
Add some basic seed metrics to the operators,  to act as a pattern for others
to follow.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>