### PR TITLE
Added Cancel Reason for Data Movement

### DIFF
--- a/api/v1alpha1/nnf_datamovement_types.go
+++ b/api/v1alpha1/nnf_datamovement_types.go
@@ -131,9 +131,10 @@ const (
 // Reasons describing the various data movement status conditions. Must be
 // in CamelCase format (see metav1.Condition)
 const (
-	DataMovementConditionReasonSuccess = "Success"
-	DataMovementConditionReasonFailed  = "Failed"
-	DataMovementConditionReasonInvalid = "Invalid"
+	DataMovementConditionReasonSuccess   = "Success"
+	DataMovementConditionReasonFailed    = "Failed"
+	DataMovementConditionReasonInvalid   = "Invalid"
+	DataMovementConditionReasonCancelled = "Cancelled"
 )
 
 //+kubebuilder:object:root=true


### PR DESCRIPTION
This is to support Cancel for the Copy Offload API in nnf-dm.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>