### PR TITLE
RABSW-1006: Add verification to Servers resource inputs

### DIFF
--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -595,6 +595,27 @@ func (r *NnfWorkflowReconciler) startSetupState(ctx context.Context, workflow *d
 			err := fmt.Errorf("Servers resource does not meet storage requirements for directive '%s'", dbd.Spec.Directive)
 			return nil, nnfv1alpha1.NewWorkflowError("Allocation request does not meet directive requirements").WithFatal().WithError(err)
 		}
+
+		for _, breakdownAllocationSet := range dbd.Status.Storage.AllocationSets {
+			found := false
+			for _, serverAllocationsSet := range s.Spec.AllocationSets {
+				if breakdownAllocationSet.Label != serverAllocationsSet.Label {
+					continue
+				}
+
+				found = true
+
+				if serverAllocationsSet.AllocationSize < breakdownAllocationSet.MinimumCapacity {
+					err := fmt.Errorf("Allocation set %s specified insufficient capacity", breakdownAllocationSet.Label)
+					return nil, nnfv1alpha1.NewWorkflowError("Allocation request does not meet directive requirements").WithFatal().WithError(err)
+				}
+			}
+
+			if found == false {
+				err := fmt.Errorf("Allocation set %s not found in Servers resource", breakdownAllocationSet.Label)
+				return nil, nnfv1alpha1.NewWorkflowError("Allocation request does not meet directive requirements").WithFatal().WithError(err)
+			}
+		}
 	}
 
 	_, err = r.createNnfStorage(ctx, workflow, s, index, log)


### PR DESCRIPTION
Verify that the allocations specified in the Servers resource by the WLM satisfy
the requirements of the DirectiveBreakdown.

Signed-off-by: Matt Richerson <mattr@cray.com>