### PR TITLE
RABSW-1007: Use uniqueWithin for NNF ruleset

### DIFF
--- a/config/dws/nnf-ruleset.yaml
+++ b/config/dws/nnf-ruleset.yaml
@@ -23,6 +23,7 @@ spec:
         pattern: "^[A-Za-z][A-Za-z0-9-]+$"
         isRequired: true
         isValueRequired: true
+        uniqueWithin: "jobdw_name"
       - key: "profile"
         type: "string"
         pattern: "^[A-Za-z][A-Za-z0-9-]+$"
@@ -55,6 +56,7 @@ spec:
         pattern: "^[A-Za-z][A-Za-z0-9-]+$"
         isRequired: true
         isValueRequired: true
+        uniqueWithin: "create_persistent_name"
       - key: "profile"
         type: "string"
         pattern: "^[A-Za-z][A-Za-z0-9-]+$"
@@ -77,6 +79,7 @@ spec:
         pattern: "^[A-Za-z][A-Za-z0-9-]+$"
         isRequired: true
         isValueRequired: true
+        uniqueWithin: "destroy_persistent_name"
   - command: "persistentdw"
     watchStates: proposal,setup,pre_run,post_run,teardown
     ruleDefs:


### PR DESCRIPTION
Use the DWS uniqueWithin option for the name field in jobdw,
create_persistent, and destroy_persistent.

Signed-off-by: Matt Richerson <mattr@cray.com>