### PR TITLE
Fixes #65 - lvm settings must disable only udev_sync

### DIFF
--- a/rabbit-os-mods/nnf-ec.sh
+++ b/rabbit-os-mods/nnf-ec.sh
@@ -21,9 +21,8 @@
 # nnf-ec makes lvm calls within the nnf-manager container. Udev operations in this case are problematic.
 # Refer to: https://serverfault.com/questions/802766/calling-lvcreate-from-inside-the-container-hangs
 #
-# Disable lvm udev options:
+# Disable lvm udev option:
 #   `udev_sync`
-#   `udev_rules`
 # to allow nnf-ec running within a pod to execute `lvm` commands without udev interfering
 disable_lvm_udev_processing ()
 {
@@ -32,7 +31,7 @@ disable_lvm_udev_processing ()
 
     for RABBIT in $RABBIT_NODES; do
         echo "$RABBIT"
-        ssh -t "$RABBIT" "sed -e 's|udev_sync = 1|udev_sync = 0|g' -e 's|udev_rules = 1|udev_rules = 0|g' /etc/lvm/lvm.conf > /etc/lvm/lvm.confnew; mv -f /etc/lvm/lvm.confnew /etc/lvm/lvm.conf"
+        ssh -t "$RABBIT" "sed -e 's|udev_sync = 1|udev_sync = 0|g' /etc/lvm/lvm.conf > /etc/lvm/lvm.confnew; mv -f /etc/lvm/lvm.confnew /etc/lvm/lvm.conf"
         ssh -t "$RABBIT" grep udev_[r:s] /etc/lvm/lvm.conf
         ssh -
     done


### PR DESCRIPTION
Signed-off-by: Anthony Floeder <anthony.floeder@hpe.com>