### PR TITLE
Change fsname for Lustre (#68)

### DIFF
--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -719,11 +719,7 @@ func (r *NnfWorkflowReconciler) createNnfStorage(ctx context.Context, workflow *
 				if dwArgs["type"] == "lustre" {
 					nnfAllocSet.NnfStorageLustreSpec.TargetType = strings.ToUpper(s.Spec.AllocationSets[i].Label)
 					nnfAllocSet.NnfStorageLustreSpec.BackFs = "zfs"
-					charsWanted := 8
-					if len(dwArgs["name"]) < charsWanted {
-						charsWanted = len(dwArgs["name"])
-					}
-					nnfAllocSet.NnfStorageLustreSpec.FileSystemName = dwArgs["name"][:charsWanted]
+					nnfAllocSet.NnfStorageLustreSpec.FileSystemName = string(s.GetUID())[:8]
 					lustreData := mergeLustreStorageDirectiveAndProfile(dwArgs, nnfStorageProfile)
 					if len(lustreData.ExternalMGS) > 0 {
 						nnfAllocSet.NnfStorageLustreSpec.ExternalMgsNid = lustreData.ExternalMGS


### PR DESCRIPTION
This commit changes the string that is used for the lustre fsname. Instead of using the "name" field in the #DW line, this commit uses the first 8 characters of the UID of the servers resource.

Signed-off-by: Matt Richerson <matthew.richerson@Matts-MacBook-Pro.local>