### PR TITLE
Added SerialNumber, FirmwareVersion, and Slot to NnfDriveStatus

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -51,5 +51,17 @@
             },
             "showLog": true
         },
+        {
+            "name": "Debug k8s operator remotely",
+            "type": "go",
+            "request": "attach",
+            "mode": "remote",
+            "remotePath": "",
+            "port": 40000,
+            "host": "127.0.0.1",
+            "showLog": true,
+            "trace": "log",
+            "logOutput": "rpc"
+        }
     ]
 }

--- a/api/v1alpha1/nnf_node_types.go
+++ b/api/v1alpha1/nnf_node_types.go
@@ -72,6 +72,15 @@ type NnfDriveStatus struct {
 	// Model is the manufacturer information about the device
 	Model string `json:"model,omitempty"`
 
+	// The serial number for this storage controller.
+	SerialNumber string `json:"serialNumber,omitempty"`
+
+	// The firmware version of this storage controller.
+	FirmwareVersion string `json:"firmwareVersion,omitempty"`
+
+	// Physical slot location of the storage controller.
+	Slot string `json:"slot,omitempty"`
+
 	// Capacity in bytes of the device. The full capacity may not
 	// be usable depending on what the storage driver can provide.
 	Capacity int64 `json:"capacity,omitempty"`

--- a/config/crd/bases/nnf.cray.hpe.com_nnfnodes.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfnodes.yaml
@@ -86,6 +86,9 @@ spec:
                         provide.
                       format: int64
                       type: integer
+                    firmwareVersion:
+                      description: The firmware version of this storage controller.
+                      type: string
                     health:
                       description: NnfResourceHealthType defines the health of an
                         NNF resource.
@@ -101,6 +104,12 @@ spec:
                     name:
                       description: Name reflects the common name of this NNF Server
                         resource.
+                      type: string
+                    serialNumber:
+                      description: The serial number for this storage controller.
+                      type: string
+                    slot:
+                      description: Physical slot location of the storage controller.
                       type: string
                     status:
                       description: NnfResourceStatusType is the string that indicates

--- a/controllers/nnf_node_controller.go
+++ b/controllers/nnf_node_controller.go
@@ -377,6 +377,9 @@ func updateDrives(node *nnfv1alpha1.NnfNode, log logr.Logger) error {
 
 				drive.Model = storageController.Model
 				drive.WearLevel = int64(storageController.NVMeControllerProperties.NVMeSMARTPercentageUsage)
+				drive.SerialNumber = storageController.SerialNumber
+				drive.FirmwareVersion = storageController.FirmwareVersion
+				drive.Slot = fmt.Sprintf("%s%d", storageController.Location.PartLocation.ServiceLabel, storageController.Location.PartLocation.LocationOrdinalValue)
 			}
 
 			// The Swordfish architecture places capacity information in a Storage device's Storage Pools. For our implementation,

--- a/controllers/nnf_node_slc.go
+++ b/controllers/nnf_node_slc.go
@@ -199,10 +199,13 @@ func (r *NnfNodeSLCReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 				wearLevel := d.WearLevel
 				device := dwsv1alpha1.StorageDevice{
-					Model:     d.Model,
-					Capacity:  d.Capacity,
-					Status:    string(d.Status),
-					WearLevel: &wearLevel,
+					Model:           d.Model,
+					SerialNumber:    d.SerialNumber,
+					FirmwareVersion: d.FirmwareVersion,
+					Capacity:        d.Capacity,
+					Status:          string(d.Status),
+					WearLevel:       &wearLevel,
+					Slot:            d.Slot,
 				}
 				devices = append(devices, device)
 			}

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/NearNodeFlash/nnf-sos
 go 1.19
 
 require (
-	github.com/HewlettPackard/dws v0.0.0-20220912185638-8515b1a0003d
+	github.com/HewlettPackard/dws v0.0.0-20220915195527-2515faa59c7f
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220727174249-9b7004c2cb38
-	github.com/NearNodeFlash/nnf-ec v0.0.0-20220909132713-e531bba9f6bb
+	github.com/NearNodeFlash/nnf-ec v0.0.0-20220915194816-49769d6bcf19
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/uuid v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/NearNodeFlash/nnf-sos
 go 1.19
 
 require (
-	github.com/HewlettPackard/dws v0.0.0-20220915195527-2515faa59c7f
+	github.com/HewlettPackard/dws v0.0.0-20220915211447-2536c3f45adb
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220727174249-9b7004c2cb38
-	github.com/NearNodeFlash/nnf-ec v0.0.0-20220915194816-49769d6bcf19
+	github.com/NearNodeFlash/nnf-ec v0.0.0-20220916150000-517a1ab34a59
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -85,10 +85,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/HewlettPackard/dws v0.0.0-20220912170832-cfd60d860c7e h1:8iL6LKGIyms92N9wQadLDfCgDg8jHc5ElG+vpzqoftM=
-github.com/HewlettPackard/dws v0.0.0-20220912170832-cfd60d860c7e/go.mod h1:ls20UsxQwpC+PBp0olV9xCVsp0pH6dHEmJIVpZVqtUg=
-github.com/HewlettPackard/dws v0.0.0-20220912185638-8515b1a0003d h1:iQNfFqOrMwaj9bPvZZqIEoJ48vcWDvdF74Rqng1gJdo=
-github.com/HewlettPackard/dws v0.0.0-20220912185638-8515b1a0003d/go.mod h1:ls20UsxQwpC+PBp0olV9xCVsp0pH6dHEmJIVpZVqtUg=
+github.com/HewlettPackard/dws v0.0.0-20220915195527-2515faa59c7f h1:n7tXCeT0y1TWYP4da3xKwI/HMSKhnbGnhR5Uj28g6dM=
+github.com/HewlettPackard/dws v0.0.0-20220915195527-2515faa59c7f/go.mod h1:ls20UsxQwpC+PBp0olV9xCVsp0pH6dHEmJIVpZVqtUg=
 github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220623192103-4ce53adacc95/go.mod h1:Wwr96QYACIixBjBXpST9yMS81WxMu/tF/zc/5OW21Dk=
 github.com/HewlettPackard/structex v1.0.2 h1:p2EH/p6zvUd5fSa0onudAUvLWdKsvQSRP0jGKeblA5E=
 github.com/HewlettPackard/structex v1.0.2/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
@@ -98,8 +96,8 @@ github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb0
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220727174249-9b7004c2cb38 h1:eUS+ynG1Xni4CEMhmQ3dduA3TfUWEyUXRUFKwEJEF30=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220727174249-9b7004c2cb38/go.mod h1:Ae1E/j2hmUaHW7pQAOesc57pyYmBlgBgI2C6xtwPutg=
-github.com/NearNodeFlash/nnf-ec v0.0.0-20220909132713-e531bba9f6bb h1:Oxfv2iJpAhraqku05+Ym8quQMeCP9CRNuUDJjU5cWO8=
-github.com/NearNodeFlash/nnf-ec v0.0.0-20220909132713-e531bba9f6bb/go.mod h1:s6Gp5d88rhMFcqrkF/Ds8D+n6GMAv9iw004YhAL3Neo=
+github.com/NearNodeFlash/nnf-ec v0.0.0-20220915194816-49769d6bcf19 h1:ORS/gdyQK1xFXX4OemfnIgSI42N/Y4nuFSagvvFgi94=
+github.com/NearNodeFlash/nnf-ec v0.0.0-20220915194816-49769d6bcf19/go.mod h1:s6Gp5d88rhMFcqrkF/Ds8D+n6GMAv9iw004YhAL3Neo=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/HewlettPackard/dws v0.0.0-20220915195527-2515faa59c7f h1:n7tXCeT0y1TWYP4da3xKwI/HMSKhnbGnhR5Uj28g6dM=
-github.com/HewlettPackard/dws v0.0.0-20220915195527-2515faa59c7f/go.mod h1:ls20UsxQwpC+PBp0olV9xCVsp0pH6dHEmJIVpZVqtUg=
+github.com/HewlettPackard/dws v0.0.0-20220915211447-2536c3f45adb h1:zxVGrO6CzK2rLKmu7b6e0ku2yKYHFNqW5LQhQ3H1u20=
+github.com/HewlettPackard/dws v0.0.0-20220915211447-2536c3f45adb/go.mod h1:ls20UsxQwpC+PBp0olV9xCVsp0pH6dHEmJIVpZVqtUg=
 github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220623192103-4ce53adacc95/go.mod h1:Wwr96QYACIixBjBXpST9yMS81WxMu/tF/zc/5OW21Dk=
 github.com/HewlettPackard/structex v1.0.2 h1:p2EH/p6zvUd5fSa0onudAUvLWdKsvQSRP0jGKeblA5E=
 github.com/HewlettPackard/structex v1.0.2/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
@@ -96,8 +96,8 @@ github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb0
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220727174249-9b7004c2cb38 h1:eUS+ynG1Xni4CEMhmQ3dduA3TfUWEyUXRUFKwEJEF30=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220727174249-9b7004c2cb38/go.mod h1:Ae1E/j2hmUaHW7pQAOesc57pyYmBlgBgI2C6xtwPutg=
-github.com/NearNodeFlash/nnf-ec v0.0.0-20220915194816-49769d6bcf19 h1:ORS/gdyQK1xFXX4OemfnIgSI42N/Y4nuFSagvvFgi94=
-github.com/NearNodeFlash/nnf-ec v0.0.0-20220915194816-49769d6bcf19/go.mod h1:s6Gp5d88rhMFcqrkF/Ds8D+n6GMAv9iw004YhAL3Neo=
+github.com/NearNodeFlash/nnf-ec v0.0.0-20220916150000-517a1ab34a59 h1:QFkPIdADUOMcq3abBzoOifgtQUpVnCI7AHJGjJZMd6w=
+github.com/NearNodeFlash/nnf-ec v0.0.0-20220916150000-517a1ab34a59/go.mod h1:s6Gp5d88rhMFcqrkF/Ds8D+n6GMAv9iw004YhAL3Neo=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=

--- a/vendor/github.com/HewlettPackard/dws/api/v1alpha1/storage_types.go
+++ b/vendor/github.com/HewlettPackard/dws/api/v1alpha1/storage_types.go
@@ -39,6 +39,15 @@ type StorageDevice struct {
 	// Model is the manufacturer information about the device
 	Model string `json:"model,omitempty"`
 
+	// The serial number for this storage controller.
+	SerialNumber string `json:"serialNumber,omitempty"`
+
+	// The firmware version of this storage controller.
+	FirmwareVersion string `json:"firmwareVersion,omitempty"`
+
+	// Physical slot location of the storage controller.
+	Slot string `json:"slot,omitempty"`
+
 	// Capacity in bytes of the device. The full capacity may not
 	// be usable depending on what the storage driver can provide.
 	Capacity int64 `json:"capacity,omitempty"`

--- a/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_storages.yaml
+++ b/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_storages.yaml
@@ -101,9 +101,18 @@ spec:
                         provide.
                       format: int64
                       type: integer
+                    firmwareVersion:
+                      description: The firmware version of this storage controller.
+                      type: string
                     model:
                       description: Model is the manufacturer information about the
                         device
+                      type: string
+                    serialNumber:
+                      description: The serial number for this storage controller.
+                      type: string
+                    slot:
+                      description: Physical slot location of the storage controller.
                       type: string
                     status:
                       description: Status of the individual device

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/api/fabric.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/api/fabric.go
@@ -19,15 +19,20 @@
 
 package api
 
+import openapi "github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/common"
+
 // FabricApi - Presents an API into the fabric outside of the fabric manager
 // TODO: This should be obsolete - the NVMe Namespace Manager can
-//       include the Fabric Manager (but NOT the other way around!!! Go doesn't
-//       support circular bindings.
+//
+//	include the Fabric Manager (but NOT the other way around!!! Go doesn't
+//	support circular bindings.
 type FabricControllerApi interface {
 	// Locates the index of the Downstream Port DSP within the Fabric Controller's list of all Downstream Endpoints, regardless of current endpoint status.
 	GetDownstreamPortRelativePortIndex(switchId, portId string) (int, error)
 
 	FindDownstreamEndpoint(portId, functionId string) (string, error)
+
+	GetPortPartLocation(switchId, portId string) (*openapi.PartLocation, error)
 }
 
 // FabricDeviceControllerApi defines the interface for controlling a device on the fabric.

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-fabric/config.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-fabric/config.go
@@ -62,8 +62,9 @@ type SwitchConfig struct {
 	Metadata struct {
 		Name string
 	}
-	PciGen int32 `yaml:"pciGen"`
-	Ports  []PortConfig
+	PciGen     int32  `yaml:"pciGen"`
+	SlotPrefix string `yaml:"slotPrefix"`
+	Ports      []PortConfig
 
 	ManagementPortCount int
 	UpstreamPortCount   int
@@ -75,6 +76,7 @@ type PortConfig struct {
 	Name  string
 	Type  string
 	Port  int
+	Slot  int
 	Width int
 }
 

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-fabric/config_default.yaml
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-fabric/config_default.yaml
@@ -7,6 +7,7 @@ switches:
     metadata:
       name: PAX 0
     pciGen: 4
+    slotPrefix: J
     ports:
       - name: Interswitch Fabric
         type: InterswitchPort
@@ -51,43 +52,53 @@ switches:
       - name: SSD 0
         type: DownstreamPort
         port: 8
+        slot: 13
         width: 4
       - name: SSD 1
         type: DownstreamPort
         port: 10
+        slot: 14
         width: 4
       - name: SSD 2
         type: DownstreamPort
         port: 12
+        slot: 18
         width: 4
       - name: SSD 3
         type: DownstreamPort
         port: 14
+        slot: 17
         width: 4
       - name: SSD 4
         type: DownstreamPort
         port: 16
+        slot: 16
         width: 4
       - name: SSD 5
         type: DownstreamPort
         port: 18
+        slot: 15
         width: 4
       - name: SSD 6
         type: DownstreamPort
         port: 20
+        slot: 7
         width: 4
       - name: SSD 7
         type: DownstreamPort
         port: 22
+        slot: 8
         width: 4
       - name: SSD 8
         type: DownstreamPort
         port: 48
+        slot: 12
         width: 4
   - id: 1
     metadata:
       name: PAX 1
     pciGen: 4
+    slotPrefix: J
     ports:
       - name: Interswitch Fabric
         type: InterswitchPort
@@ -132,36 +143,45 @@ switches:
       - name: SSD 9
         type: DownstreamPort
         port: 8
+        slot: 11
         width: 4
       - name: SSD 10
         type: DownstreamPort
         port: 10
+        slot: 10
         width: 4
       - name: SSD 11
         type: DownstreamPort
         port: 12
+        slot: 9
         width: 4
       - name: SSD 12
         type: DownstreamPort
         port: 14
+        slot: 1
         width: 4
       - name: SSD 13
         type: DownstreamPort
         port: 16
+        slot: 2
         width: 4
       - name: SSD 14
         type: DownstreamPort
         port: 18
+        slot: 6
         width: 4
       - name: SSD 15
         type: DownstreamPort
         port: 20
+        slot: 5
         width: 4
       - name: SSD 16
         type: DownstreamPort
         port: 22
+        slot: 4
         width: 4
       - name: SSD 17
         type: DownstreamPort
         port: 48
+        slot: 3
         width: 4

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-fabric/config_default.yaml
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-fabric/config_default.yaml
@@ -52,42 +52,42 @@ switches:
       - name: SSD 0
         type: DownstreamPort
         port: 8
-        slot: 13
+        slot: 8
         width: 4
       - name: SSD 1
         type: DownstreamPort
         port: 10
-        slot: 14
+        slot: 7
         width: 4
       - name: SSD 2
         type: DownstreamPort
         port: 12
-        slot: 18
+        slot: 15
         width: 4
       - name: SSD 3
         type: DownstreamPort
         port: 14
-        slot: 17
+        slot: 16
         width: 4
       - name: SSD 4
         type: DownstreamPort
         port: 16
-        slot: 16
+        slot: 17
         width: 4
       - name: SSD 5
         type: DownstreamPort
         port: 18
-        slot: 15
+        slot: 18
         width: 4
       - name: SSD 6
         type: DownstreamPort
         port: 20
-        slot: 7
+        slot: 14
         width: 4
       - name: SSD 7
         type: DownstreamPort
         port: 22
-        slot: 8
+        slot: 13
         width: 4
       - name: SSD 8
         type: DownstreamPort
@@ -143,42 +143,42 @@ switches:
       - name: SSD 9
         type: DownstreamPort
         port: 8
-        slot: 11
+        slot: 4
         width: 4
       - name: SSD 10
         type: DownstreamPort
         port: 10
-        slot: 10
+        slot: 5
         width: 4
       - name: SSD 11
         type: DownstreamPort
         port: 12
-        slot: 9
+        slot: 6
         width: 4
       - name: SSD 12
         type: DownstreamPort
         port: 14
-        slot: 1
+        slot: 2
         width: 4
       - name: SSD 13
         type: DownstreamPort
         port: 16
-        slot: 2
+        slot: 1
         width: 4
       - name: SSD 14
         type: DownstreamPort
         port: 18
-        slot: 6
+        slot: 9
         width: 4
       - name: SSD 15
         type: DownstreamPort
         port: 20
-        slot: 5
+        slot: 10
         width: 4
       - name: SSD 16
         type: DownstreamPort
         port: 22
-        slot: 4
+        slot: 11
         width: 4
       - name: SSD 17
         type: DownstreamPort

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-fabric/manager.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-fabric/manager.go
@@ -1532,3 +1532,29 @@ func (f *Fabric) FindDownstreamEndpoint(portId, functionId string) (string, erro
 
 	return fmt.Sprintf("/redfish/v1/Fabrics/%s/Endpoints/%s", f.id, ep.id), nil
 }
+
+func (f *Fabric) GetSwitchPort(switchId, portId string) (*Port, error) {
+	s := f.findSwitch(switchId)
+	if s == nil {
+		return nil, fmt.Errorf("failed to find switch: switchId: %s", switchId)
+	}
+	p := s.findPort(portId)
+	if p == nil {
+		return nil, fmt.Errorf("failed to find port: switchId: %s, portId: %s", switchId, portId)
+	}
+
+	return p, nil
+}
+
+func (f *Fabric) GetPortPartLocation(switchId, portId string) (*openapi.PartLocation, error) {
+	p, err := f.GetSwitchPort(switchId, portId)
+	if err != nil {
+		return nil, err
+	}
+
+	return &openapi.PartLocation{
+		ServiceLabel:         p.swtch.config.SlotPrefix,
+		LocationOrdinalValue: int64(p.config.Slot),
+		LocationType:         sf.SLOT_RV1100LT,
+	}, nil
+}

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nvme/manager.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nvme/manager.go
@@ -988,6 +988,15 @@ func (mgr *Manager) StorageIdControllersControllerIdGet(storageId, controllerId 
 	model.FirmwareVersion = s.firmwareRevision
 	model.Model = s.modelNumber
 
+	// Retrieve the slot label and value for this storage controller
+	location, err := FabricController.GetPortPartLocation(s.switchId, s.portId)
+	if err != nil {
+		return ec.NewErrNotFound().WithError(err).WithCause(fmt.Sprintf("Storage Controller failed to retrieve part location: Storage: %s", storageId))
+	}
+	model.Location.PartLocation.ServiceLabel = location.ServiceLabel
+	model.Location.PartLocation.LocationOrdinalValue = location.LocationOrdinalValue
+	model.Location.PartLocation.LocationType = location.LocationType
+
 	model.Links.EndpointsodataCount = 1
 	model.Links.Endpoints = make([]sf.OdataV4IdRef, model.Links.EndpointsodataCount)
 	model.Links.Endpoints[0].OdataId = endpointId

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nvme/manager.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nvme/manager.go
@@ -577,9 +577,10 @@ func (v *Volume) attach(controllerId uint16) error {
 	}
 
 	err := v.storage.device.AttachNamespace(v.namespaceId, []uint16{controllerId})
-	log.Infof("Device %s Attach Namespace: %d Controller: %d Error: %s", v.storage.id, v.namespaceId, controllerId, err)
-
+	
 	if err != nil {
+		log.Infof("Device %s Attach Namespace: %d Controller: %d Error: %s", v.storage.id, v.namespaceId, controllerId, err)
+		
 		var cmdErr *nvme.CommandError
 		if errors.As(err, &cmdErr) {
 			if cmdErr.StatusCode != nvme.NamespaceAlreadyAttached {
@@ -607,9 +608,10 @@ func (v *Volume) detach(controllerId uint16) error {
 	}
 
 	err := v.storage.device.DetachNamespace(v.namespaceId, []uint16{controllerId})
-	log.Infof("Device %s Detach Namespace: %d Controller: %d Error: %s", v.storage.id, v.namespaceId, controllerId, err)
 
 	if err != nil {
+		log.Infof("Device %s Detach Namespace: %d Controller: %d Error: %s", v.storage.id, v.namespaceId, controllerId, err)
+
 		var cmdErr *nvme.CommandError
 		if errors.As(err, &cmdErr) {
 			if cmdErr.StatusCode != nvme.NamespaceNotAttached {

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/common/alias.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/common/alias.go
@@ -7,7 +7,7 @@
 
  * Author: Nate Roiger
  *
- * Copyright 2020 Hewlett Packard Enterprise Development LP
+ * Copyright 2020, 2022 Hewlett Packard Enterprise Development LP
  */
 
 package openapi
@@ -59,6 +59,9 @@ type ManagerActions = models.ManagerV1100Actions
 // OdataIdRef - A reference to a resource.
 type OdataIdRef = models.OdataV4IdRef
 
+// PartLocation - The part location within the placement.
+type PartLocation = models.ResourceV1100PartLocation
+
 // RedfishError - The error payload from a Redfish Service.
 type RedfishError = models.RedfishError
 
@@ -70,6 +73,9 @@ type ResourceBlock = models.ResourceBlockV133ResourceBlock
 
 // ResourceIdentifier - Any additional identifiers for a resource.
 type ResourceIdentifier = models.ResourceIdentifier
+
+// ResourceLocation - The location of a resource.
+type ResourceLocation = models.ResourceLocation
 
 // ResourcePowerState - Power state of a resource
 type ResourcePowerState = models.ResourcePowerState

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -20,7 +20,7 @@ github.com/Azure/go-autorest/logger
 # github.com/Azure/go-autorest/tracing v0.6.0
 ## explicit; go 1.12
 github.com/Azure/go-autorest/tracing
-# github.com/HewlettPackard/dws v0.0.0-20220912185638-8515b1a0003d
+# github.com/HewlettPackard/dws v0.0.0-20220915195527-2515faa59c7f
 ## explicit; go 1.19
 github.com/HewlettPackard/dws/api/v1alpha1
 github.com/HewlettPackard/dws/config/crd/bases
@@ -36,7 +36,7 @@ github.com/HewlettPackard/structex
 ## explicit; go 1.16
 github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1
 github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
-# github.com/NearNodeFlash/nnf-ec v0.0.0-20220909132713-e531bba9f6bb
+# github.com/NearNodeFlash/nnf-ec v0.0.0-20220915194816-49769d6bcf19
 ## explicit; go 1.16
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/switchtec

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -20,7 +20,7 @@ github.com/Azure/go-autorest/logger
 # github.com/Azure/go-autorest/tracing v0.6.0
 ## explicit; go 1.12
 github.com/Azure/go-autorest/tracing
-# github.com/HewlettPackard/dws v0.0.0-20220915195527-2515faa59c7f
+# github.com/HewlettPackard/dws v0.0.0-20220915211447-2536c3f45adb
 ## explicit; go 1.19
 github.com/HewlettPackard/dws/api/v1alpha1
 github.com/HewlettPackard/dws/config/crd/bases
@@ -36,7 +36,7 @@ github.com/HewlettPackard/structex
 ## explicit; go 1.16
 github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1
 github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
-# github.com/NearNodeFlash/nnf-ec v0.0.0-20220915194816-49769d6bcf19
+# github.com/NearNodeFlash/nnf-ec v0.0.0-20220916150000-517a1ab34a59
 ## explicit; go 1.16
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/switchtec


### PR DESCRIPTION
Each new field is sourced from the `StorageController`'s corresponding field.

In the case of `slot`, it is a concatenation of the `StorageController`'s `Location` field. The `SeviceLabel` and `LocationOrdinalValue` are put together. These two fields are sourced from the StorageController's config file - see nnf-ec for more details.

For example, with a label of `J` and ordinal value of `12`, the resulting `slot` is `J12`.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>