### PR TITLE
RABSW-984: Fix directive index to name/namespace mapping

### DIFF
--- a/controllers/nnf_workflow_controller_helpers.go
+++ b/controllers/nnf_workflow_controller_helpers.go
@@ -564,8 +564,8 @@ func getStorageReferenceNameFromWorkflowActual(workflow *dwsv1alpha1.Workflow, d
 		name = p["name"]
 		namespace = workflow.Namespace
 	default:
-		name = workflow.Status.DirectiveBreakdowns[dwdIndex].Name
-		namespace = workflow.Status.DirectiveBreakdowns[dwdIndex].Namespace
+		name = indexedResourceName(workflow, dwdIndex)
+		namespace = workflow.Namespace
 	}
 
 	return name, namespace


### PR DESCRIPTION
One of the helper functions was assuming that the index of the directiveBreakdown was the same as the index of the directive in the #DW list. That doesn't have to be the case and leads to a panic.

Signed-off-by: Matt Richerson <matthew.richerson@Matts-MacBook-Pro.local>