### PR TITLE
RABSW-1015: Ensure fsname starts with a letter and fix error propagation

### DIFF
--- a/controllers/nnf_storage_controller.go
+++ b/controllers/nnf_storage_controller.go
@@ -156,6 +156,8 @@ func (r *NnfStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
+	storage.Status.Error = nil
+
 	// For each allocation, create the NnfNodeStorage resources to fan out to the Rabbit nodes
 	for i := range storage.Spec.AllocationSets {
 		res, err := r.createNodeStorage(ctx, storage, i)
@@ -269,6 +271,7 @@ func (r *NnfStorageReconciler) aggregateNodeStorageStatus(ctx context.Context, s
 	var status nnfv1alpha1.NnfResourceStatusType = nnfv1alpha1.ResourceReady
 
 	allocationSet.AllocationCount = 0
+	allocationSet.Error = ""
 
 	nnfNodeStorageList := &nnfv1alpha1.NnfNodeStorageList{}
 	matchLabels := dwsv1alpha1.MatchingOwner(storage)

--- a/controllers/nnf_workflow_controller_helpers.go
+++ b/controllers/nnf_workflow_controller_helpers.go
@@ -325,7 +325,7 @@ func (r *NnfWorkflowReconciler) createNnfStorage(ctx context.Context, workflow *
 				if dwArgs["type"] == "lustre" {
 					nnfAllocSet.NnfStorageLustreSpec.TargetType = strings.ToUpper(s.Spec.AllocationSets[i].Label)
 					nnfAllocSet.NnfStorageLustreSpec.BackFs = "zfs"
-					nnfAllocSet.NnfStorageLustreSpec.FileSystemName = string(s.GetUID())[:8]
+					nnfAllocSet.NnfStorageLustreSpec.FileSystemName = "z" + string(s.GetUID())[:7]
 					lustreData := mergeLustreStorageDirectiveAndProfile(dwArgs, nnfStorageProfile)
 					if len(lustreData.ExternalMGS) > 0 {
 						nnfAllocSet.NnfStorageLustreSpec.ExternalMgsNid = lustreData.ExternalMGS


### PR DESCRIPTION
This commit fixes two bugs:
 - The file system name in the nnfStorage is used as the Lustre fsname. This needs to start with a letter to satisfy Lustre's requirements.
 - Errors in the nnfNodeStorage that eventually recover still show up as an error in the nnfStorage. The error is properly cleared out now.