### PR TITLE
Allow a colocation constraint to be specified for an MDT.

### DIFF
--- a/api/v1alpha1/nnfstorageprofile_types.go
+++ b/api/v1alpha1/nnfstorageprofile_types.go
@@ -65,6 +65,10 @@ type NnfStorageProfileLustreData struct {
 	// +kubebuilder:default:="5GiB"
 	CapacityMDT string `json:"capacityMdt,omitempty"`
 
+	// ExclusiveMDT indicates that the MDT should not be colocated with any other target on the chosen server.
+	// +kubebuilder:default:=false
+	ExclusiveMDT bool `json:"exclusiveMdt,omitempty"`
+
 	// MgtCmdLines contains commands to create an MGT target.
 	MgtCmdLines NnfStorageProfileLustreCmdLines `json:"mgtCommandlines,omitempty"`
 

--- a/api/v1alpha1/nnfstorageprofile_webhook.go
+++ b/api/v1alpha1/nnfstorageprofile_webhook.go
@@ -101,9 +101,6 @@ func (r *NnfStorageProfile) validateContentLustre() error {
 	if r.Data.LustreStorage.CombinedMGTMDT && len(r.Data.LustreStorage.ExternalMGS) > 0 {
 		return fmt.Errorf("cannot set both combinedMgtMdt and externalMgs")
 	}
-	if r.Data.LustreStorage.CombinedMGTMDT && r.Data.LustreStorage.ExclusiveMDT {
-		return fmt.Errorf("cannot set both combinedMgtMdt and exclusiveMdt; the target will already be constrained because it is an MGT")
-	}
 
 	return nil
 }

--- a/api/v1alpha1/nnfstorageprofile_webhook.go
+++ b/api/v1alpha1/nnfstorageprofile_webhook.go
@@ -64,7 +64,7 @@ func (r *NnfStorageProfile) ValidateUpdate(old runtime.Object) error {
 		// ownerReferences, and labels, but do not allow Data to be
 		// updated.
 		if !reflect.DeepEqual(r.Data, obj.Data) {
-			msg := "Update on pinned resource not allowed"
+			msg := "update on pinned resource not allowed"
 			err := fmt.Errorf(msg)
 			nnfstorageprofilelog.Error(err, "invalid")
 			return err
@@ -89,7 +89,7 @@ func (r *NnfStorageProfile) ValidateDelete() error {
 func (r *NnfStorageProfile) validateContent() error {
 
 	if r.Data.Default && r.Data.Pinned {
-		return fmt.Errorf("The NnfStorageProfile cannot be both default and pinned.")
+		return fmt.Errorf("the NnfStorageProfile cannot be both default and pinned")
 	}
 	if err := r.validateContentLustre(); err != nil {
 		return err
@@ -99,7 +99,10 @@ func (r *NnfStorageProfile) validateContent() error {
 
 func (r *NnfStorageProfile) validateContentLustre() error {
 	if r.Data.LustreStorage.CombinedMGTMDT && len(r.Data.LustreStorage.ExternalMGS) > 0 {
-		return fmt.Errorf("Cannot set both combinedMgtMdt and externalMgs")
+		return fmt.Errorf("cannot set both combinedMgtMdt and externalMgs")
+	}
+	if r.Data.LustreStorage.CombinedMGTMDT && r.Data.LustreStorage.ExclusiveMDT {
+		return fmt.Errorf("cannot set both combinedMgtMdt and exclusiveMdt; the target will already be constrained because it is an MGT")
 	}
 
 	return nil

--- a/api/v1alpha1/nnfstorageprofile_webhook_test.go
+++ b/api/v1alpha1/nnfstorageprofile_webhook_test.go
@@ -88,9 +88,23 @@ var _ = Describe("NnfStorageProfile Webhook", func() {
 		Expect(newProfile.Data.Default).ToNot(BeTrue())
 	})
 
+	It("should accept exclusiveMdt", func() {
+		nnfProfile.Data.LustreStorage.ExclusiveMDT = true
+		Expect(k8sClient.Create(context.TODO(), nnfProfile)).To(Succeed())
+		Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(nnfProfile), newProfile)).To(Succeed())
+		Expect(newProfile.Data.Default).ToNot(BeTrue())
+	})
+
 	It("should not accept combinedMgtMdt with externalMgs", func() {
 		nnfProfile.Data.LustreStorage.CombinedMGTMDT = true
 		nnfProfile.Data.LustreStorage.ExternalMGS = "10.0.0.1@tcp"
+		Expect(k8sClient.Create(context.TODO(), nnfProfile)).ToNot(Succeed())
+		nnfProfile = nil
+	})
+
+	It("should not accept combinedMgtMdt with exclusiveMdt", func() {
+		nnfProfile.Data.LustreStorage.CombinedMGTMDT = true
+		nnfProfile.Data.LustreStorage.ExclusiveMDT = true
 		Expect(k8sClient.Create(context.TODO(), nnfProfile)).ToNot(Succeed())
 		nnfProfile = nil
 	})

--- a/api/v1alpha1/nnfstorageprofile_webhook_test.go
+++ b/api/v1alpha1/nnfstorageprofile_webhook_test.go
@@ -95,16 +95,17 @@ var _ = Describe("NnfStorageProfile Webhook", func() {
 		Expect(newProfile.Data.Default).ToNot(BeTrue())
 	})
 
+	It("should accept combinedMgtMdt with exclusiveMdt", func() {
+		nnfProfile.Data.LustreStorage.CombinedMGTMDT = true
+		nnfProfile.Data.LustreStorage.ExclusiveMDT = true
+		Expect(k8sClient.Create(context.TODO(), nnfProfile)).To(Succeed())
+		Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(nnfProfile), newProfile)).To(Succeed())
+		Expect(newProfile.Data.Default).ToNot(BeTrue())
+	})
+
 	It("should not accept combinedMgtMdt with externalMgs", func() {
 		nnfProfile.Data.LustreStorage.CombinedMGTMDT = true
 		nnfProfile.Data.LustreStorage.ExternalMGS = "10.0.0.1@tcp"
-		Expect(k8sClient.Create(context.TODO(), nnfProfile)).ToNot(Succeed())
-		nnfProfile = nil
-	})
-
-	It("should not accept combinedMgtMdt with exclusiveMdt", func() {
-		nnfProfile.Data.LustreStorage.CombinedMGTMDT = true
-		nnfProfile.Data.LustreStorage.ExclusiveMDT = true
 		Expect(k8sClient.Create(context.TODO(), nnfProfile)).ToNot(Succeed())
 		nnfProfile = nil
 	})

--- a/config/crd/bases/nnf.cray.hpe.com_nnfstorageprofiles.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfstorageprofiles.yaml
@@ -103,6 +103,11 @@ spec:
                     description: CombinedMGTMDT indicates whether the MGT and MDT
                       should be created on the same target device
                     type: boolean
+                  exclusiveMdt:
+                    default: false
+                    description: ExclusiveMDT indicates that the MDT should not be
+                      colocated with any other target on the chosen server.
+                    type: boolean
                   externalMgs:
                     description: ExternalMGS contains the NIDs of a pre-existing MGS
                       that should be used

--- a/config/samples/nnf_v1alpha1_nnfstorageprofile.yaml
+++ b/config/samples/nnf_v1alpha1_nnfstorageprofile.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: nnf-system
 data:
   lustreStorage:
-    externalMgs: "10.0.0.1@tcp"
+    exclusiveMdt: true
     mgtCommandlines:
       zpoolCreate: -O canmount=off -o cachefile=none $POOL_NAME $DEVICE_LIST
       mkfs: --mgs $VOL_NAME

--- a/controllers/directivebreakdown_controller.go
+++ b/controllers/directivebreakdown_controller.go
@@ -421,12 +421,17 @@ func (r *DirectiveBreakdownReconciler) populateStorageBreakdown(ctx context.Cont
 		var lustreComponents []lustreComponentType
 		lustreComponents = append(lustreComponents, lustreComponentType{"AllocateAcrossServers", breakdownCapacity, "ost", ""})
 
+		mdtColocationKey := ""
+		if nnfStorageProfile.Data.LustreStorage.ExclusiveMDT {
+			mdtColocationKey = "lustre-mdt"
+		}
+
 		if lustreData.CombinedMGTMDT {
 			lustreComponents = append(lustreComponents, lustreComponentType{"AllocateSingleServer", mdtCapacity, "mgtmdt", "lustre-mgt"})
 		} else if len(lustreData.ExternalMGS) > 0 {
-			lustreComponents = append(lustreComponents, lustreComponentType{"AllocateSingleServer", mdtCapacity, "mdt", ""})
+			lustreComponents = append(lustreComponents, lustreComponentType{"AllocateSingleServer", mdtCapacity, "mdt", mdtColocationKey})
 		} else {
-			lustreComponents = append(lustreComponents, lustreComponentType{"AllocateSingleServer", mdtCapacity, "mdt", ""})
+			lustreComponents = append(lustreComponents, lustreComponentType{"AllocateSingleServer", mdtCapacity, "mdt", mdtColocationKey})
 			lustreComponents = append(lustreComponents, lustreComponentType{"AllocateSingleServer", mgtCapacity, "mgt", "lustre-mgt"})
 		}
 

--- a/controllers/directivebreakdown_controller.go
+++ b/controllers/directivebreakdown_controller.go
@@ -428,7 +428,12 @@ func (r *DirectiveBreakdownReconciler) populateStorageBreakdown(ctx context.Cont
 		}
 
 		if lustreData.CombinedMGTMDT {
-			lustreComponents = append(lustreComponents, lustreComponentType{"AllocateSingleServer", mdtCapacity, "mgtmdt", mgtKey})
+			useKey := mgtKey
+			// If both combinedMGTMDT and exclusiveMDT are specified, then exclusiveMDT wins.
+			if mdtKey != nil {
+				useKey = mdtKey
+			}
+			lustreComponents = append(lustreComponents, lustreComponentType{"AllocateSingleServer", mdtCapacity, "mgtmdt", useKey})
 		} else if len(lustreData.ExternalMGS) > 0 {
 			lustreComponents = append(lustreComponents, lustreComponentType{"AllocateSingleServer", mdtCapacity, "mdt", mdtKey})
 		} else {


### PR DESCRIPTION
Add a field named "exclusiveMdt" to the storage profile to indicate that the MDT must be marked in the directive breakdown as being the only lustre target on its server.

This is similar to the way an MGT is marked in the directive breakdown.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>