### PR TITLE
RABSW-1086: Remove combined_mgtmdt and external_mgs directive arguments

### DIFF
--- a/config/dws/nnf-ruleset.yaml
+++ b/config/dws/nnf-ruleset.yaml
@@ -29,15 +29,6 @@ spec:
         pattern: "^[A-Za-z][A-Za-z0-9-]+$"
         isRequired: false
         isValueRequired: true
-      - key: "combined_mgtmdt"
-        type: "bool"
-        isRequired: false
-        isValueRequired: false
-      - key: "external_mgs"
-        type: "string"
-        pattern: "^[A-Za-z0-9\\-_\\.@,:]+$"
-        isRequired: false
-        isValueRequired: true
   - command: "create_persistent"
     watchStates: Proposal,Setup,Teardown
     ruleDefs:
@@ -60,15 +51,6 @@ spec:
       - key: "profile"
         type: "string"
         pattern: "^[A-Za-z][A-Za-z0-9-]+$"
-        isRequired: false
-        isValueRequired: true
-      - key: "combined_mgtmdt"
-        type: "bool"
-        isRequired: false
-        isValueRequired: false
-      - key: "external_mgs"
-        type: "string"
-        pattern: "^[A-Za-z0-9\\-_\\.@,:]+$"
         isRequired: false
         isValueRequired: true
   - command: "destroy_persistent"

--- a/controllers/directivebreakdown_controller.go
+++ b/controllers/directivebreakdown_controller.go
@@ -415,8 +415,6 @@ func (r *DirectiveBreakdownReconciler) populateStorageBreakdown(ctx context.Cont
 		mdtCapacity, _ := getCapacityInBytes(nnfStorageProfile.Data.LustreStorage.CapacityMDT)
 		mgtCapacity, _ := getCapacityInBytes(nnfStorageProfile.Data.LustreStorage.CapacityMGT)
 
-		lustreData := mergeLustreStorageDirectiveAndProfile(argsMap, nnfStorageProfile)
-
 		// We need 3 distinct components for Lustre, ost, mdt, and mgt
 		var lustreComponents []lustreComponentType
 		lustreComponents = append(lustreComponents, lustreComponentType{dwsv1alpha1.AllocateAcrossServers, breakdownCapacity, "ost", nil})
@@ -427,14 +425,14 @@ func (r *DirectiveBreakdownReconciler) populateStorageBreakdown(ctx context.Cont
 			mdtKey = &dwsv1alpha1.AllocationSetColocationConstraint{Type: "exclusive"}
 		}
 
-		if lustreData.CombinedMGTMDT {
+		if nnfStorageProfile.Data.LustreStorage.CombinedMGTMDT {
 			useKey := mgtKey
 			// If both combinedMGTMDT and exclusiveMDT are specified, then exclusiveMDT wins.
 			if mdtKey != nil {
 				useKey = mdtKey
 			}
 			lustreComponents = append(lustreComponents, lustreComponentType{dwsv1alpha1.AllocateSingleServer, mdtCapacity, "mgtmdt", useKey})
-		} else if len(lustreData.ExternalMGS) > 0 {
+		} else if len(nnfStorageProfile.Data.LustreStorage.ExternalMGS) > 0 {
 			lustreComponents = append(lustreComponents, lustreComponentType{dwsv1alpha1.AllocateSingleServer, mdtCapacity, "mdt", mdtKey})
 		} else {
 			lustreComponents = append(lustreComponents, lustreComponentType{dwsv1alpha1.AllocateSingleServer, mdtCapacity, "mdt", mdtKey})

--- a/controllers/integration_test.go
+++ b/controllers/integration_test.go
@@ -432,8 +432,6 @@ var _ = Describe("Integration Test", func() {
 			{"#DW jobdw name=jobdw-xfs    type=xfs    capacity=1GiB", 1, true, true, 1},
 			{"#DW jobdw name=jobdw-gfs2   type=gfs2   capacity=1GiB", 1, true, true, 1},
 			{"#DW jobdw name=jobdw-lustre type=lustre capacity=1GiB", 1, true, true, 3},
-			{"#DW jobdw name=jobdw-lustre type=lustre combined_mgtmdt capacity=1GiB", 1, true, true, 2},
-			{"#DW jobdw name=jobdw-lustre type=lustre external_mgs=localhost@tcp capacity=1GiB", 1, true, true, 2},
 
 			{"#DW create_persistent name=createpersistent-xfs    type=xfs    capacity=1GiB", 1, false, true, 1},
 			{"#DW create_persistent name=createpersistent-gfs2   type=gfs2   capacity=1GiB", 1, false, true, 1},
@@ -1234,8 +1232,7 @@ var _ = Describe("Integration Test", func() {
 			profileExternalMGS    *nnfv1alpha1.NnfStorageProfile
 			profileCombinedMGTMDT *nnfv1alpha1.NnfStorageProfile
 
-			directiveMgsNid string
-			profileMgsNid   string
+			profileMgsNid string
 
 			dbd       *dwsv1alpha1.DirectiveBreakdown
 			dbdServer *dwsv1alpha1.Servers
@@ -1245,7 +1242,6 @@ var _ = Describe("Integration Test", func() {
 		)
 
 		BeforeEach(func() {
-			directiveMgsNid = "directive-mgs@tcp"
 			profileMgsNid = "profile-mgs@tcp"
 
 			dbd = &dwsv1alpha1.DirectiveBreakdown{}
@@ -1382,16 +1378,6 @@ var _ = Describe("Integration Test", func() {
 			}
 		}
 
-		When("using external_mgs in directive", func() {
-			BeforeEach(func() {
-				intendedDirective = fmt.Sprintf("#DW jobdw type=lustre external_mgs=%s capacity=5GB name=directive-mgs", directiveMgsNid)
-			})
-
-			It("Uses external_mgs via the directive", func() {
-				verifyExternalMgsNid("via directive", directiveMgsNid)
-			})
-		})
-
 		When("using external_mgs in profile", func() {
 			BeforeEach(func() {
 				intendedDirective = fmt.Sprintf("#DW jobdw type=lustre profile=%s capacity=5GB name=profile-mgs", externalMgsProfileName)
@@ -1402,26 +1388,6 @@ var _ = Describe("Integration Test", func() {
 			})
 		})
 
-		When("using external_mgs in directive and profile", func() {
-			BeforeEach(func() {
-				intendedDirective = fmt.Sprintf("#DW jobdw type=lustre profile=%s external_mgs=%s capacity=5GB name=both-mgs", externalMgsProfileName, directiveMgsNid)
-			})
-
-			It("Uses external_mgs via the directive", func() {
-				verifyExternalMgsNid("via directive", directiveMgsNid)
-			})
-		})
-
-		When("using combined_mgtmdt in directive", func() {
-			BeforeEach(func() {
-				intendedDirective = fmt.Sprintf("#DW jobdw type=lustre combined_mgtmdt capacity=5GB name=directive-mgtmdt")
-			})
-
-			It("Uses combined_mgtmdt via the directive", func() {
-				verifyCombinedMgtMdt()
-			})
-		})
-
 		When("using combined_mgtmdt in profile", func() {
 			BeforeEach(func() {
 				intendedDirective = fmt.Sprintf("#DW jobdw type=lustre profile=%s capacity=5GB name=profile-mgtmdt", combinedMgtMdtProfileName)
@@ -1429,26 +1395,6 @@ var _ = Describe("Integration Test", func() {
 
 			It("Uses combined_mgtmdt via the profile", func() {
 				verifyCombinedMgtMdt()
-			})
-		})
-
-		When("using combined_mgtmdt from directive when external_mgs is in profile", func() {
-			BeforeEach(func() {
-				intendedDirective = fmt.Sprintf("#DW jobdw type=lustre profile=%s combined_mgtmdt capacity=5GB name=profile-mgtmdt", externalMgsProfileName)
-			})
-
-			It("Uses combined_mgtmdt via the directive", func() {
-				verifyCombinedMgtMdt()
-			})
-		})
-
-		When("using external_mgs from directive when combined_mgtmdt is in profile", func() {
-			BeforeEach(func() {
-				intendedDirective = fmt.Sprintf("#DW jobdw type=lustre profile=%s external_mgs=%s capacity=5GB name=profile-mgtmdt", combinedMgtMdtProfileName, directiveMgsNid)
-			})
-
-			It("Uses external_mgs via the directive", func() {
-				verifyExternalMgsNid("via directive", directiveMgsNid)
 			})
 		})
 	})

--- a/controllers/nnf_workflow_controller_helpers.go
+++ b/controllers/nnf_workflow_controller_helpers.go
@@ -393,9 +393,8 @@ func (r *NnfWorkflowReconciler) createNnfStorage(ctx context.Context, workflow *
 					nnfAllocSet.NnfStorageLustreSpec.TargetType = strings.ToUpper(s.Spec.AllocationSets[i].Label)
 					nnfAllocSet.NnfStorageLustreSpec.BackFs = "zfs"
 					nnfAllocSet.NnfStorageLustreSpec.FileSystemName = "z" + string(s.GetUID())[:7]
-					lustreData := mergeLustreStorageDirectiveAndProfile(dwArgs, nnfStorageProfile)
-					if len(lustreData.ExternalMGS) > 0 {
-						nnfAllocSet.NnfStorageLustreSpec.ExternalMgsNid = lustreData.ExternalMGS
+					if len(nnfStorageProfile.Data.LustreStorage.ExternalMGS) > 0 {
+						nnfAllocSet.NnfStorageLustreSpec.ExternalMgsNid = nnfStorageProfile.Data.LustreStorage.ExternalMGS
 					}
 				}
 

--- a/controllers/nnfstorageprofile_helpers.go
+++ b/controllers/nnfstorageprofile_helpers.go
@@ -164,29 +164,3 @@ func getPinnedStorageProfileFromLabel(ctx context.Context, clnt client.Client, o
 
 	return findPinnedProfile(ctx, clnt, pinnedNamespace, pinnedName)
 }
-
-// mergeLustreStorageDirectiveAndProfile returns an object that merges Lustre options from the DW directive with lustre options from the NnfStorageProfile, with the proper precedence.
-func mergeLustreStorageDirectiveAndProfile(dwArgs map[string]string, nnfStorageProfile *nnfv1alpha1.NnfStorageProfile) *nnfv1alpha1.NnfStorageProfileLustreData {
-	lustreData := &nnfv1alpha1.NnfStorageProfileLustreData{}
-
-	// The combined_mgtmdt and external_mgs args in the directive
-	// take precedence over the storage profile.
-	//
-	// The directive may have only one of these specified; this is
-	// enforced by a webhook.  Likewise, the profile may have only
-	// one specified; this is also enforced by a webhook.
-
-	if _, present := dwArgs["combined_mgtmdt"]; present {
-		lustreData.CombinedMGTMDT = true
-	} else if externalMgs, present := dwArgs["external_mgs"]; present {
-		lustreData.ExternalMGS = externalMgs
-	} else if nnfStorageProfile != nil {
-		if nnfStorageProfile.Data.LustreStorage.CombinedMGTMDT {
-			lustreData.CombinedMGTMDT = true
-		} else if len(nnfStorageProfile.Data.LustreStorage.ExternalMGS) > 0 {
-			lustreData.ExternalMGS = nnfStorageProfile.Data.LustreStorage.ExternalMGS
-		}
-	}
-
-	return lustreData
-}


### PR DESCRIPTION
Combined_mgtmdt and external_mgs can be specified in the storage profile. Removing these options from the directive allows the admins to have greater control of what end users can and cannot do.

Signed-off-by: Matt Richerson <matthew.richerson@dhcp-10-113-10-52.its.hpecorp.net>