### PR TITLE
RABSW-1083: Change group and owner of storage

### DIFF
--- a/api/v1alpha1/nnf_node_storage_types.go
+++ b/api/v1alpha1/nnf_node_storage_types.go
@@ -37,6 +37,15 @@ type NnfNodeStorageSpec struct {
 	// +kubebuilder:validation:Minimum:=0
 	Count int `json:"count"`
 
+	// User ID for file system
+	UserID uint32 `json:"userID"`
+
+	// Group ID for file system
+	GroupID uint32 `json:"groupID"`
+
+	// +kubebuilder:default:=false
+	SetOwnerGroup bool `json:"setOwnerGroup"`
+
 	// Capacity defines the capacity, in bytes, of this storage specification. The NNF Node itself
 	// may split the storage among the available drives operating in the NNF Node.
 	Capacity int64 `json:"capacity,omitempty"`
@@ -100,6 +109,10 @@ type NnfNodeStorageStatus struct {
 
 	// LustreStorageStatus describes the Lustre targets created here.
 	LustreStorage LustreStorageStatus `json:"lustreStorage,omitempty"`
+
+	// OwnerGroupStatus is the status of the operation for setting the owner and group
+	// of a file system
+	OwnerGroupStatus NnfResourceStatusType `json:"ownerGroupStatus,omitempty"`
 }
 
 // NnfNodeStorageNVMeStatus provides a way to uniquely identify an NVMe namespace

--- a/api/v1alpha1/nnf_storage_types.go
+++ b/api/v1alpha1/nnf_storage_types.go
@@ -85,6 +85,12 @@ type NnfStorageSpec struct {
 	// +kubebuilder:default:=raw
 	FileSystemType string `json:"fileSystemType"`
 
+	// User ID for file system
+	UserID uint32 `json:"userID"`
+
+	// Group ID for file system
+	GroupID uint32 `json:"groupID"`
+
 	// AllocationSets is a list of different types of storage allocations to make. Each
 	// AllocationSet describes an entire allocation spanning multiple Rabbits. For example,
 	// an AllocationSet could be all of the OSTs in a Lustre filesystem, or all of the raw
@@ -94,10 +100,10 @@ type NnfStorageSpec struct {
 
 // NnfStorageAllocationSetStatus contains the status information for an allocation set
 type NnfStorageAllocationSetStatus struct {
-	// Status reflects the status of this NNF Storage
+	// Status reflects the status of this allocation set
 	Status NnfResourceStatusType `json:"status,omitempty"`
 
-	// Health reflects the health of this NNF Storage
+	// Health reflects the health of this allocation set
 	Health NnfResourceHealthType `json:"health,omitempty"`
 
 	// Error is the human readable error string
@@ -120,6 +126,9 @@ type NnfStorageStatus struct {
 	AllocationSets []NnfStorageAllocationSetStatus `json:"allocationSets,omitempty"`
 
 	dwsv1alpha1.ResourceError `json:",inline"`
+
+	// Status reflects the status of this NNF Storage
+	Status NnfResourceStatusType `json:"status,omitempty"`
 
 	// TODO: Conditions
 }

--- a/config/crd/bases/nnf.cray.hpe.com_nnfnodestorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfnodestorages.yaml
@@ -80,6 +80,10 @@ spec:
                 - gfs2
                 - lustre
                 type: string
+              groupID:
+                description: Group ID for file system
+                format: int32
+                type: integer
               lustreStorage:
                 description: LustreStorageSpec describes the Lustre target created
                   here, if FileSystemType specifies a Lustre target.
@@ -116,10 +120,20 @@ spec:
                     - OST
                     type: string
                 type: object
+              setOwnerGroup:
+                default: false
+                type: boolean
+              userID:
+                description: User ID for file system
+                format: int32
+                type: integer
             required:
             - clientEndpoints
             - count
             - fileSystemType
+            - groupID
+            - setOwnerGroup
+            - userID
             type: object
           status:
             description: NnfNodeStorageStatus defines the status for NnfNodeStorage
@@ -369,6 +383,10 @@ spec:
                       is populated on MGS nodes only.
                     type: string
                 type: object
+              ownerGroupStatus:
+                description: OwnerGroupStatus is the status of the operation for setting
+                  the owner and group of a file system
+                type: string
             type: object
         type: object
     served: true

--- a/config/crd/bases/nnf.cray.hpe.com_nnfstorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfstorages.yaml
@@ -117,9 +117,19 @@ spec:
                 - gfs2
                 - lustre
                 type: string
+              groupID:
+                description: Group ID for file system
+                format: int32
+                type: integer
+              userID:
+                description: User ID for file system
+                format: int32
+                type: integer
             required:
             - allocationSets
             - fileSystemType
+            - groupID
+            - userID
             type: object
           status:
             description: NnfStorageStatus defines the observed status of NNF Storage.
@@ -139,10 +149,10 @@ spec:
                       description: Error is the human readable error string
                       type: string
                     health:
-                      description: Health reflects the health of this NNF Storage
+                      description: Health reflects the health of this allocation set
                       type: string
                     status:
-                      description: Status reflects the status of this NNF Storage
+                      description: Status reflects the status of this allocation set
                       type: string
                   required:
                   - allocationCount
@@ -168,6 +178,9 @@ spec:
                 type: object
               mgsNode:
                 description: MgsNode is the NID of the MGS.
+                type: string
+              status:
+                description: Status reflects the status of this NNF Storage
                 type: string
             type: object
         type: object

--- a/controllers/nnf_node_storage_controller.go
+++ b/controllers/nnf_node_storage_controller.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/mount-utils"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -211,6 +212,20 @@ func (r *NnfNodeStorageReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		if result != nil {
 			return *result, nil
 		}
+	}
+
+	if nodeStorage.Spec.SetOwnerGroup && nodeStorage.Status.OwnerGroupStatus != nnfv1alpha1.ResourceReady {
+		if nodeStorage.Status.OwnerGroupStatus == "" {
+			nodeStorage.Status.OwnerGroupStatus = nnfv1alpha1.ResourceStarting
+
+			return ctrl.Result{}, nil
+		}
+
+		if err := r.setLustreOwnerGroup(nodeStorage); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		nodeStorage.Status.OwnerGroupStatus = nnfv1alpha1.ResourceReady
 	}
 
 	return ctrl.Result{}, nil
@@ -544,6 +559,8 @@ func (r *NnfNodeStorageReconciler) formatFileSystem(ctx context.Context, nodeSto
 	} else {
 		shareOptions["volumeGroupName"] = volumeGroupName(fileShareID)
 		shareOptions["logicalVolumeName"] = logicalVolumeName(fileShareID)
+		shareOptions["userID"] = int(nodeStorage.Spec.UserID)
+		shareOptions["groupID"] = int(nodeStorage.Spec.GroupID)
 	}
 
 	sh, err = r.createFileShare(ss, fileShareID, allocationStatus.FileSystem.ID, os.Getenv("RABBIT_NODE"), mountPath, shareOptions)
@@ -582,6 +599,44 @@ func (r *NnfNodeStorageReconciler) formatFileSystem(ctx context.Context, nodeSto
 	nodeStorage.Status.LustreStorage.Nid = nid
 
 	return nil, nil
+}
+
+func (r *NnfNodeStorageReconciler) setLustreOwnerGroup(nodeStorage *nnfv1alpha1.NnfNodeStorage) error {
+	log := r.Log.WithValues("NnfNodeStorage", types.NamespacedName{Name: nodeStorage.Name, Namespace: nodeStorage.Namespace})
+
+	if nodeStorage.Spec.FileSystemType != "lustre" {
+		return fmt.Errorf("Invalid file system type '%s' for setting owner/group", nodeStorage.Spec.FileSystemType)
+	}
+
+	target := "/mnt/nnf/client/" + nodeStorage.Name
+	if err := os.MkdirAll(target, 0755); err != nil {
+		log.Error(err, "Mkdir failed")
+		return err
+	}
+	defer os.RemoveAll(target)
+
+	mounter := mount.New("")
+	mounted, err := mounter.IsMountPoint(target)
+	if err != nil {
+		return err
+	}
+
+	source := nodeStorage.Spec.LustreStorage.MgsNode + ":/" + nodeStorage.Spec.LustreStorage.FileSystemName
+
+	if !mounted {
+		if err := mounter.Mount(source, target, "lustre", nil); err != nil {
+			log.Error(err, "Mount failed")
+			return err
+		}
+	}
+	defer func() { err = mounter.Unmount(target) }()
+
+	if err := os.Chown(target, int(nodeStorage.Spec.UserID), int(nodeStorage.Spec.GroupID)); err != nil {
+		log.Error(err, "Chown failed")
+		return err
+	}
+
+	return nil
 }
 
 func (r *NnfNodeStorageReconciler) deleteStorage(nodeStorage *nnfv1alpha1.NnfNodeStorage, index int) (*ctrl.Result, error) {

--- a/controllers/nnf_storage_controller.go
+++ b/controllers/nnf_storage_controller.go
@@ -152,6 +152,7 @@ func (r *NnfStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		for i := range storage.Status.AllocationSets {
 			storage.Status.AllocationSets[i].Status = nnfv1alpha1.ResourceStarting
 		}
+		storage.Status.Status = nnfv1alpha1.ResourceStarting
 
 		return ctrl.Result{}, nil
 	}
@@ -183,6 +184,33 @@ func (r *NnfStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}
 
+	// Wait for all the allocation sets to be ready
+	for _, allocationSet := range storage.Status.AllocationSets {
+		if allocationSet.Status != nnfv1alpha1.ResourceReady {
+			return ctrl.Result{}, nil
+		}
+	}
+
+	// For Lustre, the owner and group have to be set once all the Lustre targets
+	// have completed. This is done on the Rabbit node that hosts OST 0.
+	for i, allocationSet := range storage.Spec.AllocationSets {
+		if allocationSet.TargetType != "OST" {
+			continue
+		}
+
+		res, err := r.setLustreOwnerGroup(ctx, storage, i)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		if res != nil {
+			return *res, nil
+		}
+	}
+
+	// All allocation sets are ready and the owner/group is set
+	storage.Status.Status = nnfv1alpha1.ResourceReady
+
 	return ctrl.Result{}, nil
 }
 
@@ -212,6 +240,8 @@ func (r *NnfStorageReconciler) createNodeStorage(ctx context.Context, storage *n
 				labels[nnfv1alpha1.AllocationSetLabel] = allocationSet.Name
 				nnfNodeStorage.SetLabels(labels)
 
+				nnfNodeStorage.Spec.UserID = storage.Spec.UserID
+				nnfNodeStorage.Spec.GroupID = storage.Spec.GroupID
 				nnfNodeStorage.Spec.Capacity = allocationSet.Capacity
 				nnfNodeStorage.Spec.Count = node.Count
 				nnfNodeStorage.Spec.FileSystemType = storage.Spec.FileSystemType
@@ -336,6 +366,42 @@ func (r *NnfStorageReconciler) aggregateNodeStorageStatus(ctx context.Context, s
 
 	allocationSet.Health = health
 	allocationSet.Status = status
+
+	return nil, nil
+}
+
+// setLustreOwnerGroup sets the "SetOwnerGroup" field in the NnfNodeStorage for OST 0 in a Lustre
+// file system. This tells the node controller on the Rabbit to mount the Lustre file system and set
+// the owner and group.
+func (r *NnfStorageReconciler) setLustreOwnerGroup(ctx context.Context, storage *nnfv1alpha1.NnfStorage, allocationSetIndex int) (*ctrl.Result, error) {
+	allocationSet := storage.Spec.AllocationSets[allocationSetIndex]
+
+	if len(allocationSet.Nodes) == 0 {
+		return nil, nil
+	}
+
+	nnfNodeStorage := &nnfv1alpha1.NnfNodeStorage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nnfNodeStorageName(storage, allocationSetIndex, 0),
+			Namespace: allocationSet.Nodes[0].Name,
+		},
+	}
+
+	if err := r.Get(ctx, client.ObjectKeyFromObject(nnfNodeStorage), nnfNodeStorage); err != nil {
+		return nil, err
+	}
+
+	if !nnfNodeStorage.Spec.SetOwnerGroup {
+		nnfNodeStorage.Spec.SetOwnerGroup = true
+
+		if err := r.Update(ctx, nnfNodeStorage); err != nil {
+			return nil, err
+		}
+	}
+
+	if nnfNodeStorage.Status.OwnerGroupStatus != nnfv1alpha1.ResourceReady {
+		return &ctrl.Result{}, nil
+	}
 
 	return nil, nil
 }

--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -429,19 +429,11 @@ func (r *NnfWorkflowReconciler) finishSetupState(ctx context.Context, workflow *
 		return Requeue("allocation").after(2 * time.Second).withObject(nnfStorage), nil
 	}
 
-	var complete bool = true
-	// Status section should be usable now, check for Ready
-	for _, set := range nnfStorage.Status.AllocationSets {
-		if set.Status != "Ready" {
-			complete = false
-		}
-	}
-
 	if nnfStorage.Status.Error != nil {
 		return nil, nnfv1alpha1.NewWorkflowError("Could not create allocation").WithError(nnfStorage.Status.Error)
 	}
 
-	if !complete {
+	if nnfStorage.Status.Status != nnfv1alpha1.ResourceReady {
 		// RequeueAfter is necessary for persistent storage that isn't owned by this workflow
 		return Requeue("allocation set not ready").after(2 * time.Second).withObject(nnfStorage), nil
 	}

--- a/controllers/nnf_workflow_controller_helpers.go
+++ b/controllers/nnf_workflow_controller_helpers.go
@@ -379,6 +379,8 @@ func (r *NnfWorkflowReconciler) createNnfStorage(ctx context.Context, workflow *
 			addPinnedStorageProfileLabel(nnfStorage, nnfStorageProfile)
 
 			nnfStorage.Spec.FileSystemType = dwArgs["type"]
+			nnfStorage.Spec.UserID = workflow.Spec.UserID
+			nnfStorage.Spec.GroupID = workflow.Spec.GroupID
 
 			// Need to remove all of the AllocationSets in the NnfStorage object before we begin
 			nnfStorage.Spec.AllocationSets = []nnfv1alpha1.NnfStorageAllocationSetSpec{}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/HewlettPackard/dws v0.0.0-20221110142740-abf44bba3b47
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220929204230-5dcfe552c9e0
-	github.com/NearNodeFlash/nnf-ec v0.0.0-20221115142605-90bfe8d47356
+	github.com/NearNodeFlash/nnf-ec v0.0.0-20221201213632-f02777cce37d
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/Masterminds/squirrel v1.5.0/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA4
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220929204230-5dcfe552c9e0 h1:upOQcpaEDmgLxoK7SZeqzGOQs8raxd9/paJYmBS/3/M=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220929204230-5dcfe552c9e0/go.mod h1:1SLPG4mFeuISXS/GoPtHV541AqR6e9n1Fd9KEnuTDIU=
-github.com/NearNodeFlash/nnf-ec v0.0.0-20221115142605-90bfe8d47356 h1:FqFGyLOV25NQJCh3d0xwr+L6o7UOUvO+MEIKI1XCPkI=
-github.com/NearNodeFlash/nnf-ec v0.0.0-20221115142605-90bfe8d47356/go.mod h1:s6Gp5d88rhMFcqrkF/Ds8D+n6GMAv9iw004YhAL3Neo=
+github.com/NearNodeFlash/nnf-ec v0.0.0-20221201213632-f02777cce37d h1:kvHyW5MTRi/qRcObWGTpteiEiILy//2ATBrrA9owdHo=
+github.com/NearNodeFlash/nnf-ec v0.0.0-20221201213632-f02777cce37d/go.mod h1:s6Gp5d88rhMFcqrkF/Ds8D+n6GMAv9iw004YhAL3Neo=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/VividCortex/mysqlerr v1.0.0/go.mod h1:xERx8E4tBhLvpjzdUyQiSfUxeMcATEQrflDAfXsqcAE=

--- a/vendor/github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme/device_list.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme/device_list.go
@@ -27,7 +27,7 @@ import (
 	"regexp"
 )
 
-// Return the devices that match the provided regexp in Model Number, Serial Number,
+// DeviceList returns the devices that match the provided regexp in Model Number, Serial Number,
 // or Node Qualifying Name (NQN). Returned paths are of the form /dev/nvme[0-9]+.
 func DeviceList(r string) ([]string, error) {
 

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nvme/nvme_api.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nvme/nvme_api.go
@@ -56,6 +56,9 @@ type NvmeDeviceApi interface {
 	CreateNamespace(capacityBytes uint64, sectorSizeBytes uint64, sectorSizeIndex uint8) (nvme.NamespaceIdentifier, nvme.NamespaceGloballyUniqueIdentifier, error)
 	DeleteNamespace(namespaceId nvme.NamespaceIdentifier) error
 
+	FormatNamespace(namespaceID nvme.NamespaceIdentifier) error
+	WaitFormatComplete(namespaceID nvme.NamespaceIdentifier) error
+
 	AttachNamespace(namespaceId nvme.NamespaceIdentifier, controllers []uint16) error
 	DetachNamespace(namespaceId nvme.NamespaceIdentifier, controllers []uint16) error
 

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nvme/nvme_device.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nvme/nvme_device.go
@@ -88,11 +88,11 @@ func (d *nvmeDevice) IdentifyNamespace(namespaceId nvme.NamespaceIdentifier) (*n
 	// 2) Allocated Namespace Management, returns Identify Namespace data structure for the specified
 	//    allocated NSID, regardless of its attach state to a controller.
 	//
-	// We prefer to manage namespaces regardless of there attach state to a particular controller, so
+	// We prefer to manage namespaces regardless of their attach state to a particular controller, so
 	// option 2 is preferred except in cases of the common namespace identifier (-1), in which case
 	// we need to use option 1.
 
-	present := true // Force reading of namespace even if not attached to the particular controller
+	present := true // Force identify namespace even if not attached to the particular controller
 	if namespaceId == CommonNamespaceIdentifier {
 		present = false
 	}
@@ -191,6 +191,16 @@ func (d *nvmeDevice) CreateNamespace(capacityBytes uint64, sectorSizeBytes uint6
 // DeleteNamespace -
 func (d *nvmeDevice) DeleteNamespace(namespaceId nvme.NamespaceIdentifier) error {
 	return d.dev.DeleteNamespace(uint32(namespaceId))
+}
+
+// FormatNamespace -
+func (d *nvmeDevice) FormatNamespace(namespaceID nvme.NamespaceIdentifier) error {
+	return d.dev.FormatNamespace(uint32(namespaceID))
+}
+
+// WaitFormatComplete -
+func (d *nvmeDevice) WaitFormatComplete(namespaceID nvme.NamespaceIdentifier) error {
+	return d.dev.WaitFormatComplete(uint32(namespaceID))
 }
 
 // AttachNamespace -

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nvme/nvme_direct_device.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nvme/nvme_direct_device.go
@@ -122,6 +122,10 @@ func (d *nvmeDirectDevice) DeleteNamespace(namespaceId nvme.NamespaceIdentifier)
 	return d.cliDevice.DeleteNamespace(namespaceId)
 }
 
+func (d *nvmeDirectDevice) FormatNamespace(namespaceId nvme.NamespaceIdentifier) error {
+	return d.cliDevice.FormatNamespace(namespaceId)
+}
+
 func (d *nvmeDirectDevice) AttachNamespace(namespaceId nvme.NamespaceIdentifier, controllers []uint16) error {
 	return d.cliDevice.AttachNamespace(namespaceId, controllers)
 }

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nvme/nvme_mock.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nvme/nvme_mock.go
@@ -367,6 +367,16 @@ func (d *mockDevice) DeleteNamespace(namespaceId nvme.NamespaceIdentifier) error
 	return nil
 }
 
+// FormatNamespace -
+func (d *mockDevice) FormatNamespace(namespaceID nvme.NamespaceIdentifier) error {
+	return nil
+}
+
+// FormatNamespace -
+func (d *mockDevice) WaitFormatComplete(namespaceID nvme.NamespaceIdentifier) error {
+	return nil
+}
+
 // AttachNamespace -
 func (d *mockDevice) AttachNamespace(namespaceId nvme.NamespaceIdentifier, controllers []uint16) error {
 	ns := d.findNamespace(namespaceId)

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nvme/nvme_mock_persistence.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nvme/nvme_mock_persistence.go
@@ -158,7 +158,7 @@ func (mgr *MockNvmePersistenceManager) recordDeleteNamespace(dev *mockDevice, ns
 		panic(err)
 	}
 
-	ledger.Close(true)
+	ledger.Close(false)
 }
 
 func (mgr *MockNvmePersistenceManager) recordAttachController(dev *mockDevice, ns *mockNamespace, ctrlId uint16) {

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-server/file_system_xfs.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-server/file_system_xfs.go
@@ -21,8 +21,14 @@ package server
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/NearNodeFlash/nnf-ec/pkg/var_handler"
+)
+
+const (
+	UserID = "userID"
+	GroupID = "groupID"
 )
 
 // FileSystemXfs establishes an XFS file system on an underlying LVM logical volume.
@@ -52,7 +58,7 @@ func (*FileSystemXfs) IsMockable() bool              { return false }
 func (*FileSystemXfs) Type() string   { return "xfs" }
 func (f *FileSystemXfs) Name() string { return f.name }
 
-func (f *FileSystemXfs) Create(devices []string, opts FileSystemOptions) error {
+func (f *FileSystemXfs) Create(devices []string, opts FileSystemOptions) (err error) {
 	if err := f.FileSystemLvm.Create(devices, opts); err != nil {
 		return err
 	}
@@ -63,6 +69,27 @@ func (f *FileSystemXfs) Create(devices []string, opts FileSystemOptions) error {
 	mkfsArgs := varHandler.ReplaceAll(f.MkfsMount.Mkfs)
 
 	if _, err := f.run(fmt.Sprintf("mkfs.xfs %s", mkfsArgs)); err != nil {
+		return err
+	}
+
+	userID := 0
+	if _, exists := opts[UserID]; exists {
+		userID = opts[UserID].(int)
+	}
+
+	groupID := 0
+	if _, exists := opts[GroupID]; exists {
+		groupID = opts[GroupID].(int)
+	}
+
+	mountpath := "/mnt/nnf/client/" + f.name
+	if err := f.Mount(mountpath); err != nil {
+		return err
+	}
+
+	defer func() { err = f.Unmount(mountpath) }()
+
+	if err := os.Chown(mountpath, userID, groupID); err != nil {
 		return err
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -36,7 +36,7 @@ github.com/HewlettPackard/structex
 ## explicit; go 1.19
 github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1
 github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
-# github.com/NearNodeFlash/nnf-ec v0.0.0-20221115142605-90bfe8d47356
+# github.com/NearNodeFlash/nnf-ec v0.0.0-20221201213632-f02777cce37d
 ## explicit; go 1.16
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/switchtec


### PR DESCRIPTION
This commit passes the group ID and owner ID fields down to the NnfNodeStorage so it can be used to set the owner/group of a file system. For XFS and gfs2, this is done through nnf-ec. For Lustre file systems, all Lustre targets have to complete before the owner/group can be set. The Lustre client mounts the file system on the Rabbit node hosting OST 0, and the owner/group are set from there. This is coordinated through a "SetOwnerGroup" flag in the NnfNodeStorage that is set once all the Lustre targets are ready.

Signed-off-by: Matt Richerson <matthew.richerson@Matts-MacBook-Pro.local>