### PR TITLE
Fix: XFS doesn't unmount after data-in finishes

### DIFF
--- a/controllers/nnf_workflow_controller_helpers.go
+++ b/controllers/nnf_workflow_controller_helpers.go
@@ -650,18 +650,6 @@ func (r *NnfWorkflowReconciler) unmountNnfAccessIfNecessary(ctx context.Context,
 		panic(fmt.Sprint("unhandled NnfAccess suffix", accessSuffix))
 	}
 
-	if accessSuffix == "servers" {
-		// Check if we should also wait on the NnfAccess for the servers
-		fsType, err := r.getDirectiveFileSystemType(ctx, workflow, index)
-		if err != nil {
-			return nil, nnfv1alpha1.NewWorkflowError("Unable to determine directive file system type").WithError(err)
-		}
-
-		if !(fsType == "gfs2" || fsType == "lustre") {
-			return nil, nil
-		}
-	}
-
 	access := &nnfv1alpha1.NnfAccess{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      indexedResourceName(workflow, index) + "-" + accessSuffix,


### PR DESCRIPTION
The offending code block is both wrong and not needed as the _unmount-when-necessary_ logic always uses the `nnfv1alpha1.DataMovementTeardownStateLabel`

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>