### PR TITLE
Fix for the NNF Node Status reporting 'Ready' when not ready

### DIFF
--- a/api/v1alpha1/nnf_node_types.go
+++ b/api/v1alpha1/nnf_node_types.go
@@ -96,6 +96,7 @@ type NnfDriveStatus struct {
 //+kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".spec.state",description="Current desired state"
 //+kubebuilder:printcolumn:name="HEALTH",type="string",JSONPath=".status.health",description="Health of node"
 //+kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.status",description="Current status of node"
+//+kubebuilder:printcolumn:name="POD",type="string",JSONPath=".spec.pod",description="Parent pod name"
 //+kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 
 // NnfNode is the Schema for the NnfNode API

--- a/api/v1alpha1/nnf_node_types.go
+++ b/api/v1alpha1/nnf_node_types.go
@@ -96,8 +96,8 @@ type NnfDriveStatus struct {
 //+kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".spec.state",description="Current desired state"
 //+kubebuilder:printcolumn:name="HEALTH",type="string",JSONPath=".status.health",description="Health of node"
 //+kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.status",description="Current status of node"
-//+kubebuilder:printcolumn:name="POD",type="string",JSONPath=".spec.pod",description="Parent pod name"
 //+kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+//+kubebuilder:printcolumn:name="POD",type="string",JSONPath=".spec.pod",description="Parent pod name",priority=1
 
 // NnfNode is the Schema for the NnfNode API
 type NnfNode struct {

--- a/config/crd/bases/nnf.cray.hpe.com_nnfnodes.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfnodes.yaml
@@ -28,13 +28,14 @@ spec:
       jsonPath: .status.status
       name: STATUS
       type: string
-    - description: Parent pod name
-      jsonPath: .spec.pod
-      name: POD
-      type: string
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
+    - description: Parent pod name
+      jsonPath: .spec.pod
+      name: POD
+      priority: 1
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/nnf.cray.hpe.com_nnfnodes.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfnodes.yaml
@@ -28,6 +28,10 @@ spec:
       jsonPath: .status.status
       name: STATUS
       type: string
+    - description: Parent pod name
+      jsonPath: .spec.pod
+      name: POD
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date

--- a/controllers/nnf_node_controller.go
+++ b/controllers/nnf_node_controller.go
@@ -110,7 +110,7 @@ func (r *NnfNodeReconciler) Start(ctx context.Context) error {
 
 		node := &nnfv1alpha1.NnfNode{}
 		if err := r.Get(ctx, r.NamespacedName, node); err != nil {
-			
+
 			if !errors.IsNotFound(err) {
 				log.Error(err, "get node failed")
 				return err
@@ -138,13 +138,13 @@ func (r *NnfNodeReconciler) Start(ctx context.Context) error {
 				// but the pod name will change. Ensure the pod name is current.
 				if node.Spec.Pod != os.Getenv("NNF_POD_NAME") {
 					node.Spec.Pod = os.Getenv("NNF_POD_NAME")
-					
+
 					if err := r.Update(ctx, node); err != nil {
 						return err
 					}
 				}
 
-				// Mark the node status as starting
+				// Mark the node's status as starting
 				if node.Status.Status != nnfv1alpha1.ResourceStarting {
 					node.Status.Status = nnfv1alpha1.ResourceStarting
 
@@ -158,6 +158,7 @@ func (r *NnfNodeReconciler) Start(ctx context.Context) error {
 
 			if err != nil {
 				log.Error(err, "failed to initialize node")
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
- Ensure the NNF Node `status.status` field is "Starting" at start of day
- Ensure the NNF Node `status.status` and `status.health` fields reflective of the current NNF Storage Service values while it is initializing
- Clean up some rookie error handling mistakes in the NNF Node `Start()` routine
- Add some default conflict retry in updating the NNF Node in the `Start()` routine. I have never observed this but it's likely safer than the current implementation
- Add the associated Pod name to NNF Node's default printcolumns


Signed-off-by: Nate Thornton <nate.thornton@hpe.com>