### PR TITLE
Ensure unmount of nnfaccess only for gfs2 & lustre. Enable test in wo…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ env:
   TEST_TARGET: testing
 
   # DO_TEST - true to build and run unit tests, false to skip the tests
-  DO_TEST: false
+  DO_TEST: true
 
   # DO_PUSH - true to push to the HPE_DEPLOY_REPO, false to not push
   DO_PUSH: true

--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -907,9 +907,16 @@ func (r *NnfWorkflowReconciler) startPostRunState(ctx context.Context, workflow 
 		}
 	}
 
-	// Unmount the NnfAccess for the server nodes if necessary
-	if result, err := r.unmountNnfAccessIfNecessary(ctx, workflow, index, "servers"); result != nil || err != nil {
-		return result, err
+	// Unmount the NnfAccess for the servers resource if necessary.
+	fsType, err := r.getDirectiveFileSystemType(ctx, workflow, index)
+	if err != nil {
+		return nil, nnfv1alpha1.NewWorkflowError("Unable to determine directive file system type").WithError(err)
+	}
+
+	if fsType == "gfs2" || fsType == "lustre" {
+		if result, err := r.unmountNnfAccessIfNecessary(ctx, workflow, index, "servers"); result != nil || err != nil {
+			return result, err
+		}
 	}
 
 	return nil, nil


### PR DESCRIPTION
Attempt #2: Ensure unmount of nnfaccess only for gfs2 & lustre
Enable test in workflow. This failed earlier so you might see the github action fail in this PR

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>