### PR TITLE
Add known controller-manager secret

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -16,3 +16,6 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/rbac/kustomizeconfig.yaml
+++ b/config/rbac/kustomizeconfig.yaml
@@ -1,0 +1,4 @@
+namePrefix:
+- path: metadata/annotations/kubernetes.io\/service-account.name
+namespace:
+- path: metadata/annotations/kubernetes.io\/service-account.namespace

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -3,3 +3,13 @@ kind: ServiceAccount
 metadata:
   name: controller-manager
   namespace: system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: controller-manager
+  namespace: system
+  annotations:
+    kubernetes.io/service-account.name: controller-manager
+    kubernetes.io/service-account.namespace: system
+type: kubernetes.io/service-account-token


### PR DESCRIPTION
This creates a secret for managing nnf-sos resources; useful to the NNF Fencing agent

A similar change was made to dws and nnf-dm

Use it to grab token and cert like so
```bash
#!/bin/bash

SECRET=${1:-nnf-controller-manager}
NAMESPACE=${2:-nnf-system}

kubectl get secret ${SECRET} -n ${NAMESPACE} -o json | jq -Mr '.data.token' | base64 --decode > ./service.token
kubectl get secret ${SECRET} -n ${NAMESPACE} -o json | jq -Mr '.data["ca.crt"]' | base64 --decode > ./service.cert
```

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>