### PR TITLE
RABSW-1107: Add container directive validation

### DIFF
--- a/api/v1alpha1/nnfcontainerprofile_types.go
+++ b/api/v1alpha1/nnfcontainerprofile_types.go
@@ -26,6 +26,14 @@ import (
 
 // NnfContainerProfileSpec defines the desired state of NnfContainerProfile
 type NnfContainerProfileData struct {
+	// Default is true if this instance is the default resource to use
+	// +kubebuilder:default:=false
+	Default bool `json:"default,omitempty"`
+
+	// Pinned is true if this instance is an immutable copy
+	// +kubebuilder:default:=false
+	Pinned bool `json:"pinned,omitempty"`
+
 	// List of possible filesystems supported by this container profile
 	Storages []NnfContainerProfileStorage `json:"storages,omitempty"`
 

--- a/api/v1alpha1/nnfcontainerprofile_types.go
+++ b/api/v1alpha1/nnfcontainerprofile_types.go
@@ -26,10 +26,6 @@ import (
 
 // NnfContainerProfileSpec defines the desired state of NnfContainerProfile
 type NnfContainerProfileData struct {
-	// Default is true if this instance is the default resource to use
-	// +kubebuilder:default:=false
-	Default bool `json:"default,omitempty"`
-
 	// Pinned is true if this instance is an immutable copy
 	// +kubebuilder:default:=false
 	Pinned bool `json:"pinned,omitempty"`

--- a/api/v1alpha1/workflow_helpers.go
+++ b/api/v1alpha1/workflow_helpers.go
@@ -33,4 +33,12 @@ const (
 	// PinnedStorageProfileLabelNameSpace is a label applied to NnfStorage objects to show
 	// which pinned storage profile is being used.
 	PinnedStorageProfileLabelNameSpace = "nnf.cray.hpe.com/pinned_storage_profile_namespace"
+
+	// PinnedContainerProfileLabelName is a label applied to NnfStorage objects to show
+	// which pinned container profile is being used.
+	PinnedContainerProfileLabelName = "nnf.cray.hpe.com/pinned_container_profile_name"
+
+	// PinnedContainerProfileLabelNameSpace is a label applied to NnfStorage objects to show
+	// which pinned container profile is being used.
+	PinnedContainerProfileLabelNameSpace = "nnf.cray.hpe.com/pinned_container_profile_namespace"
 )

--- a/config/crd/bases/nnf.cray.hpe.com_nnfcontainerprofiles.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfcontainerprofiles.yaml
@@ -29,6 +29,15 @@ spec:
           data:
             description: NnfContainerProfileSpec defines the desired state of NnfContainerProfile
             properties:
+              default:
+                default: false
+                description: Default is true if this instance is the default resource
+                  to use
+                type: boolean
+              pinned:
+                default: false
+                description: Pinned is true if this instance is an immutable copy
+                type: boolean
               storages:
                 description: List of possible filesystems supported by this container
                   profile

--- a/config/dws/nnf-ruleset.yaml
+++ b/config/dws/nnf-ruleset.yaml
@@ -106,9 +106,9 @@ spec:
         # TODO: add a regex type to support wildcards (e.g. foo-local-storage) in the key
       - key: "JOB_DW_foo-local-storage"
         type: "string"
-        isRequired: true
+        isRequired: false
         isValueRequired: true
       - key: "PERSISTENT_DW_foo-persistent-storage"
         type: "string"
-        isRequired: true
+        isRequired: false
         isValueRequired: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -113,6 +113,8 @@ spec:
             value: "2000"
           - name: NNF_STORAGE_PROFILE_NAMESPACE
             value: nnf-system
+          - name: NNF_CONTAINER_PROFILE_NAMESPACE
+            value: nnf-system
         ports:
           - containerPort: 50057
             name: nnf-ec

--- a/config/samples/nnf_v1alpha1_nnfcontainerprofile.yaml
+++ b/config/samples/nnf_v1alpha1_nnfcontainerprofile.yaml
@@ -2,12 +2,14 @@ apiVersion: nnf.cray.hpe.com/v1alpha1
 kind: NnfContainerProfile
 metadata:
   name: nnfcontainerprofile-sample
-spec:
+  namespace: nnf-system
+data:
+  # default: true
   storages:
     - name: JOB_DW_foo-local-storage
-      type: gfs2
+      optional: false
     - name: PERSISTENT_DW_foo-persistent-storage
-      type: lustre
+      optional: false
   template:
     spec:
       # TODO: non-root
@@ -28,8 +30,6 @@ spec:
           #   mountPath: /foo/persistent
           # - name: nnf-config
           #   mountPath: /nnf/config
-          securityContext:
-            allowPrivilegeEscalation: false
       tolerations:
         - effect: NoSchedule
           key: cray.nnf.node

--- a/config/samples/nnf_v1alpha1_nnfcontainerprofile.yaml
+++ b/config/samples/nnf_v1alpha1_nnfcontainerprofile.yaml
@@ -4,7 +4,6 @@ metadata:
   name: nnfcontainerprofile-sample
   namespace: nnf-system
 data:
-  # default: true
   storages:
     - name: JOB_DW_foo-local-storage
       optional: false

--- a/controllers/nnf_workflow_controller_helpers.go
+++ b/controllers/nnf_workflow_controller_helpers.go
@@ -160,18 +160,18 @@ func (r *NnfWorkflowReconciler) validateStagingDirective(ctx context.Context, wf
 		name, _ := splitStagingArgumentIntoNameAndPath(arg)
 		if strings.HasPrefix(arg, "$JOB_DW_") {
 			if findDirectiveIndexByName(wf, name) == -1 {
-				return nnfv1alpha1.NewWorkflowError(fmt.Sprintf("Job storage instance '%s' not found", name)).WithFatal()
+				return nnfv1alpha1.NewWorkflowError(fmt.Sprintf("jobdw directive mentioning '%s' not found", name)).WithFatal()
 			}
 		} else if strings.HasPrefix(arg, "$PERSISTENT_DW_") {
 			if err := r.validatePersistentInstanceByName(ctx, name, wf.Namespace); err != nil {
-				return nnfv1alpha1.NewWorkflowError(fmt.Sprintf("Persistent storage instance '%s' not found", name)).WithFatal()
+				return nnfv1alpha1.NewWorkflowError(fmt.Sprintf("persistent storage instance '%s' not found", name)).WithFatal()
 			}
 			if findDirectiveIndexByName(wf, name) == -1 {
 				return nnfv1alpha1.NewWorkflowError(fmt.Sprintf("persistentdw directive mentioning '%s' not found", name)).WithFatal()
 			}
 		} else {
 			if r.findLustreFileSystemForPath(ctx, arg, r.Log) == nil {
-				return nnfv1alpha1.NewWorkflowError(fmt.Sprintf("Global Lustre file system containing '%s' not found", arg)).WithFatal()
+				return nnfv1alpha1.NewWorkflowError(fmt.Sprintf("global Lustre file system containing '%s' not found", arg)).WithFatal()
 			}
 		}
 
@@ -198,36 +198,81 @@ func (r *NnfWorkflowReconciler) validateStagingDirective(ctx context.Context, wf
 func (r *NnfWorkflowReconciler) validateContainerDirective(ctx context.Context, wf *dwsv1alpha1.Workflow, directive string) error {
 	args, err := dwdparse.BuildArgsMap(directive)
 	if err != nil {
-		return nnfv1alpha1.NewWorkflowError("Invalid DW directive: " + directive).WithFatal()
+		return nnfv1alpha1.NewWorkflowError("invalid DW directive: " + directive).WithFatal()
 	}
 
-	// Find the wildcard JOB_DW and PERSISTENT_DW arguments
-	for arg, val := range args {
-		// log.Log.Info("BLAKE: arg", "arg", arg)
+	// Ensure the supplied profile exists or use the default
+	profile, err := findContainerProfileToUse(ctx, r.Client, args)
+	if err != nil {
+		return nnfv1alpha1.NewWorkflowError(err.Error())
+	}
+
+	// Check to see if the directive argument is in the list of storages in the container profile
+	checkDirectiveIsInProfile := func(storageName string) error {
+		for _, storage := range profile.Data.Storages {
+			if storage.Name == storageName {
+				return nil
+			}
+		}
+		return fmt.Errorf("storage '%s' not found in container profile '%s'", storageName, profile.Name)
+	}
+
+	// Find the wildcard JOB_DW and PERSISTENT_DW arguments and verify that JOB_DW and PERSISTENT_DW
+	// instances exist and that they are found in the container profile
+	var directiveStorages []string // use this list later to validate non-optional storages
+	for arg, storageName := range args {
 		switch arg {
 		case "command", "name", "profile":
 		default:
-			name := val
-			// log.Log.Info("BLAKE: ", "arg", arg, "fsname", name)
-			if strings.HasPrefix(arg, "$JOB_DW_") {
-				if findDirectiveIndexByName(wf, name) == -1 {
-					return nnfv1alpha1.NewWorkflowError(fmt.Sprintf("Job storage instance '%s' not found", name)).WithFatal()
+			if strings.HasPrefix(arg, "JOB_DW_") {
+				if findDirectiveIndexByName(wf, storageName) == -1 {
+					return nnfv1alpha1.NewWorkflowError(fmt.Sprintf("jobdw directive mentioning '%s' not found", storageName)).WithFatal()
 				}
-			} else if strings.HasPrefix(arg, "$PERSISTENT_DW_") {
-				if err := r.validatePersistentInstanceByName(ctx, name, wf.Namespace); err != nil {
-					return nnfv1alpha1.NewWorkflowError(fmt.Sprintf("Persistent storage instance '%s' not found", name)).WithFatal()
+				if err := checkDirectiveIsInProfile(arg); err != nil {
+					return nnfv1alpha1.NewWorkflowError(err.Error()).WithFatal()
 				}
-				if findDirectiveIndexByName(wf, name) == -1 {
-					return nnfv1alpha1.NewWorkflowError(fmt.Sprintf("persistentdw directive mentioning '%s' not found", name)).WithFatal()
+				directiveStorages = append(directiveStorages, arg)
+			} else if strings.HasPrefix(arg, "PERSISTENT_DW_") {
+				if err := r.validatePersistentInstanceByName(ctx, storageName, wf.Namespace); err != nil {
+					return nnfv1alpha1.NewWorkflowError(fmt.Sprintf("persistent storage instance '%s' not found", storageName)).WithFatal()
 				}
+				if findDirectiveIndexByName(wf, storageName) == -1 {
+					return nnfv1alpha1.NewWorkflowError(fmt.Sprintf("persistentdw directive mentioning '%s' not found", storageName)).WithFatal()
+				}
+				if err := checkDirectiveIsInProfile(arg); err != nil {
+					return nnfv1alpha1.NewWorkflowError(err.Error()).WithFatal()
+				}
+				directiveStorages = append(directiveStorages, arg)
 			}
 			// TODO: just ignore anything that doesn't start with JOB_DW/PERSISTENT_DW?
-			// TODO: global lustre?
 		}
 	}
 
-	// TODO: validate profile exists
-	// TODO: validate that supplied storage directives are in the profile storages
+	// Ensure that any storage in the profile that isn't marked as optional is present in the directives
+	checkNonOptionalStorages := func(directiveStorageNames []string) error {
+		for _, storage := range profile.Data.Storages {
+			if !storage.Optional {
+				foundInDirectives := false
+
+				for _, directive := range directiveStorageNames {
+					if storage.Name == directive {
+						foundInDirectives = true
+						break
+					}
+				}
+
+				if !foundInDirectives {
+					return fmt.Errorf("storage '%s' in container profile '%s' is not optional: directive mentioning '%s' not found",
+						storage.Name, profile.Name, storage.Name)
+				}
+			}
+		}
+		return nil
+	}
+
+	if err := checkNonOptionalStorages(directiveStorages); err != nil {
+		return nnfv1alpha1.NewWorkflowError(err.Error()).WithFatal()
+	}
 
 	return nil
 }

--- a/controllers/nnfcontainerprofile_helpers.go
+++ b/controllers/nnfcontainerprofile_helpers.go
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2023 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TODO: This file has duplicate functionality with nnfstorageprofile_helpers.go. These two files
+// should be combined and made generic.
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	dwsv1alpha1 "github.com/HewlettPackard/dws/api/v1alpha1"
+	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
+)
+
+// findProfileToUse verifies a NnfContainerProfile named in the directive or verifies that a default can be found.
+func findContainerProfileToUse(ctx context.Context, clnt client.Client, args map[string]string) (*nnfv1alpha1.NnfContainerProfile, error) {
+	var profileName string
+
+	NnfContainerProfile := &nnfv1alpha1.NnfContainerProfile{}
+
+	profileNamespace := os.Getenv("NNF_CONTAINER_PROFILE_NAMESPACE")
+
+	// If a profile is named then verify that it exists.  Otherwise, verify
+	// that a default profile can be found.
+	profileName, present := args["profile"]
+	if present == false {
+		NnfContainerProfiles := &nnfv1alpha1.NnfContainerProfileList{}
+		if err := clnt.List(ctx, NnfContainerProfiles, &client.ListOptions{Namespace: profileNamespace}); err != nil {
+			return nil, err
+		}
+		profilesFound := make([]string, 0, len(NnfContainerProfiles.Items))
+		for _, profile := range NnfContainerProfiles.Items {
+			if profile.Data.Default {
+				objkey := client.ObjectKeyFromObject(&profile)
+				profilesFound = append(profilesFound, objkey.Name)
+			}
+		}
+		// Require that there be one and only one default.
+		if len(profilesFound) == 0 {
+			return nil, fmt.Errorf("Unable to find a default NnfContainerProfile to use")
+		} else if len(profilesFound) > 1 {
+			return nil, fmt.Errorf("More than one default NnfContainerProfile found; unable to pick one: %v", profilesFound)
+		}
+		profileName = profilesFound[0]
+	}
+	if len(profileName) == 0 {
+		return nil, fmt.Errorf("Unable to find an NnfContainerProfile name")
+	}
+	err := clnt.Get(ctx, types.NamespacedName{Namespace: profileNamespace, Name: profileName}, NnfContainerProfile)
+	if err != nil {
+		return nil, err
+	}
+	return NnfContainerProfile, nil
+}
+
+// findPinnedProfile finds the specified pinned profile.
+func findPinnedContainerProfile(ctx context.Context, clnt client.Client, namespace string, pinnedName string) (*nnfv1alpha1.NnfContainerProfile, error) {
+
+	NnfContainerProfile := &nnfv1alpha1.NnfContainerProfile{}
+	err := clnt.Get(ctx, types.NamespacedName{Namespace: namespace, Name: pinnedName}, NnfContainerProfile)
+	if err != nil {
+		return nil, err
+	}
+	if !NnfContainerProfile.Data.Pinned {
+		return nil, fmt.Errorf("Expected pinned NnfContainerProfile, but it was not pinned: %s", pinnedName)
+	}
+	return NnfContainerProfile, nil
+}
+
+// createPinnedProfile finds the specified profile and makes a pinned copy of it.
+func createPinnedContainerProfile(ctx context.Context, clnt client.Client, clntScheme *runtime.Scheme, args map[string]string, owner metav1.Object, pinnedName string) (*nnfv1alpha1.NnfContainerProfile, error) {
+
+	// If we've already pinned a profile, then we're done and
+	// we no longer have a use for the original profile.
+	NnfContainerProfile, err := findPinnedContainerProfile(ctx, clnt, owner.GetNamespace(), pinnedName)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+	} else {
+		// The pinned profile already exists.
+		return NnfContainerProfile, nil
+	}
+
+	// Find the original profile so we can pin a copy of it.
+	NnfContainerProfile, err = findContainerProfileToUse(ctx, clnt, args)
+	if err != nil {
+		return nil, err
+	}
+
+	newProfile := NnfContainerProfile.DeepCopy()
+	newProfile.ObjectMeta = metav1.ObjectMeta{
+		Name:      pinnedName,
+		Namespace: owner.GetNamespace(),
+	}
+	newProfile.Data.Pinned = true
+	newProfile.Data.Default = false
+	controllerutil.SetControllerReference(owner, newProfile, clntScheme)
+
+	dwsv1alpha1.AddOwnerLabels(newProfile, owner)
+	err = clnt.Create(ctx, newProfile)
+	if err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return nil, err
+		}
+	}
+
+	return newProfile, nil
+}
+
+// addPinnedContainerProfileLabel adds name/namespace labels to a resource to indicate
+// which pinned storage profile is being used with that resource.
+func addPinnedContainerProfileLabel(object metav1.Object, NnfContainerProfile *nnfv1alpha1.NnfContainerProfile) {
+	labels := object.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	labels[nnfv1alpha1.PinnedContainerProfileLabelName] = NnfContainerProfile.GetName()
+	labels[nnfv1alpha1.PinnedContainerProfileLabelNameSpace] = NnfContainerProfile.GetNamespace()
+	object.SetLabels(labels)
+}
+
+// getPinnedContainerProfileFromLabel finds the pinned storage profile via the labels on the
+// specified resource.
+func getPinnedContainerProfileFromLabel(ctx context.Context, clnt client.Client, object metav1.Object) (*nnfv1alpha1.NnfContainerProfile, error) {
+	labels := object.GetLabels()
+	if labels == nil {
+		return nil, fmt.Errorf("unable to find labels")
+	}
+
+	pinnedName, okName := labels[nnfv1alpha1.PinnedContainerProfileLabelName]
+	if !okName {
+		return nil, fmt.Errorf("unable to find %s label", nnfv1alpha1.PinnedContainerProfileLabelName)
+	}
+	pinnedNamespace, okNamespace := labels[nnfv1alpha1.PinnedContainerProfileLabelNameSpace]
+	if !okNamespace {
+		return nil, fmt.Errorf("unable to find %s label", nnfv1alpha1.PinnedContainerProfileLabelNameSpace)
+	}
+
+	return findPinnedContainerProfile(ctx, clnt, pinnedNamespace, pinnedName)
+}


### PR DESCRIPTION
These changes allow a user to create a container workflow and have it go ready in the `Proposal` state. It validates that:
- the supplied container profile exists
- if any non-optional storage in the container profile exists, ensure it is present in the supplied arguments to the container directive
- any supplied storage argument in the container directive must exist in the container profile

In order to support validation of the `container` directive, the `NnfStorageProfile` pinning and default functionality has been duplicated and refactored for `NnfContainerProfile`. Ideally in the future, we combine the two.

The following directives were used to test this container workflow:
```
#DW jobdw name=blake-gfs2 type=gfs2 capacity=50GB
#DW persistentdw name=blake-persistent
#DW container name=blake-container profile=nnfcontainerprofile-sample \
      JOB_DW_foo-local-storage=blake-gfs2 \
      PERSISTENT_DW_foo-persistent-storage=blake-persistent
```

This requires that a persistent storage instance is present prior to creating the container workflow. This means that you need a workflow with a `create_persistent` directive prior to creating a container.

Work still needs to be done on the directive breakdown controller.