### PR TITLE
EC Data Controller StorageProvider for unit tests

### DIFF
--- a/controllers/nnf_node_ec_data_controller.go
+++ b/controllers/nnf_node_ec_data_controller.go
@@ -78,10 +78,10 @@ func (r *NnfNodeECDataReconciler) Start(ctx context.Context) error {
 				return err
 			}
 		}
-	}
 
-	// This resource acts as the storage provider for the NNF Element Controller
-	persistent.StorageProvider = r
+		// This resource acts as the storage provider for the NNF Element Controller
+		persistent.StorageProvider = r
+	}
 
 	// Start the NNF Element Controller
 	c := nnfec.NewController(r.Options)


### PR DESCRIPTION
The unit test code doesn't sufficiently create the EC Data resource for each "node" in the system, so using it entirely by unit test is a problem.

Matt hit an error with the latest nnf-ec ; this will resolve that.

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>