### PR TITLE
RABSW-1122: Don't allow staging to Raw allocations

### DIFF
--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -471,7 +471,14 @@ func (r *NnfWorkflowReconciler) startDataInOutState(ctx context.Context, workflo
 		if strings.HasPrefix(param, "$DW_JOB_") || strings.HasPrefix(param, "$DW_PERSISTENT_") {
 
 			// Find the parent directive index that corresponds to this copy_in/copy_out directive
-			parentDwIndex := findDirectiveIndexByName(workflow, name)
+			parentDwIndex := 0
+
+			if strings.HasPrefix(param, "$DW_PERSISTENT_") {
+				parentDwIndex = findDirectiveIndexByName(workflow, name, "persistentdw")
+			} else {
+				parentDwIndex = findDirectiveIndexByName(workflow, name, "jobdw")
+			}
+
 			if parentDwIndex < 0 {
 				return nil, nil, nil, nnfv1alpha1.NewWorkflowError("No directive matching '" + name + "' found in workflow").WithFatal()
 			}
@@ -740,7 +747,13 @@ func (r *NnfWorkflowReconciler) finishDataInOutState(ctx context.Context, workfl
 		name, _ := splitStagingArgumentIntoNameAndPath(param)
 
 		if strings.HasPrefix(param, "$DW_JOB_") || strings.HasPrefix(param, "$DW_PERSISTENT_") {
-			parentDwIndex := findDirectiveIndexByName(workflow, name)
+			parentDwIndex := 0
+			if strings.HasPrefix(param, "$DW_PERSISTENT_") {
+				parentDwIndex = findDirectiveIndexByName(workflow, name, "persistentdw")
+			} else {
+				parentDwIndex = findDirectiveIndexByName(workflow, name, "jobdw")
+			}
+
 			if parentDwIndex < 0 {
 				return nil, nnfv1alpha1.NewWorkflowErrorf("No directive matching '%s' found in workflow", name).WithFatal()
 			}


### PR DESCRIPTION
Do some more sanity checks on staging directives:
 - Don't allow staging to/from raw allocations
 - Match allocation directives based on name and command "jobdw/persistentdw" since names can collide between the two types.

Signed-off-by: Matt Richerson <matthew.richerson@hpe.com>