### PR TITLE
Handle Retryable EC errors for File Share

### DIFF
--- a/controllers/nnf_node_storage_controller.go
+++ b/controllers/nnf_node_storage_controller.go
@@ -945,7 +945,7 @@ func (r *NnfNodeStorageReconciler) handleCreateError(storage *nnfv1alpha1.NnfNod
 	// If this is really Fatal, we should not retry. But not all of nnf-ec is supports the
 	// retryable classification of errors. Instead we mark the error as Fatal() but continue
 	// to retry with a modest delay. If the resource creation error occurs perpetually, an
-	// external entity should timeout the operation and therefore future create attempts.
+	// external entity should timeout the operation and therefore prevent future create attempts.
 	// Once nnf-ec has correctly classified all errors, there should be no need to requeue.
 
 	return &ctrl.Result{RequeueAfter: time.Minute}, nil

--- a/controllers/nnf_node_storage_controller.go
+++ b/controllers/nnf_node_storage_controller.go
@@ -942,7 +942,7 @@ func (r *NnfNodeStorageReconciler) handleCreateError(storage *nnfv1alpha1.NnfNod
 
 	resourceError = resourceError.WithFatal()
 
-	// If this is really Fatal, we should not retry. But not all of nnf-ec is supports the
+	// If this is really Fatal, we should not retry. But not all of nnf-ec supports the
 	// retryable classification of errors. Instead we mark the error as Fatal() but continue
 	// to retry with a modest delay. If the resource creation error occurs perpetually, an
 	// external entity should timeout the operation and therefore prevent future create attempts.

--- a/controllers/nnf_node_storage_controller.go
+++ b/controllers/nnf_node_storage_controller.go
@@ -249,10 +249,7 @@ func (r *NnfNodeStorageReconciler) allocateStorage(nodeStorage *nnfv1alpha1.NnfN
 	sp, err := r.createStoragePool(ss, storagePoolID, nodeStorage.Spec.Capacity)
 	if err != nil {
 		updateError(condition, &allocationStatus.StoragePool, err)
-		nodeStorage.Status.Error = dwsv1alpha1.NewResourceError("Could not create StoragePool", err)
-		log.Info(nodeStorage.Status.Error.Error())
-
-		return &ctrl.Result{Requeue: true}, nil
+		return r.handleCreateError(nodeStorage, "could not create storage pool", err)
 	}
 
 	allocationStatus.StoragePool.Status = nnfv1alpha1.ResourceStatus(sp.Status)
@@ -378,10 +375,7 @@ func (r *NnfNodeStorageReconciler) createBlockDevice(ctx context.Context, nodeSt
 			sg, err := r.createStorageGroup(ss, storageGroupID, allocationStatus.StoragePool.ID, endpointID)
 			if err != nil {
 				updateError(condition, &allocationStatus.StorageGroup, err)
-				nodeStorage.Status.Error = dwsv1alpha1.NewResourceError("Could not create storage group", err).WithFatal()
-				log.Info(nodeStorage.Status.Error.Error())
-
-				return &ctrl.Result{Requeue: true}, nil
+				return r.handleCreateError(nodeStorage, "could not create storage group", err)
 			}
 
 			allocationStatus.StorageGroup.Status = nnfv1alpha1.ResourceStatus(sg.Status)
@@ -524,10 +518,8 @@ func (r *NnfNodeStorageReconciler) formatFileSystem(ctx context.Context, nodeSto
 	fs, err := r.createFileSystem(ss, fileSystemID, allocationStatus.StoragePool.ID, oem)
 	if err != nil {
 		updateError(condition, &allocationStatus.FileSystem, err)
-		nodeStorage.Status.Error = dwsv1alpha1.NewResourceError("Could not create file system", err).WithFatal()
-		log.Info(nodeStorage.Status.Error.Error())
 
-		return &ctrl.Result{RequeueAfter: time.Minute * 2}, nil
+		return r.handleCreateError(nodeStorage, "could not create file system", err)
 	}
 
 	allocationStatus.FileSystem.Status = nnfv1alpha1.ResourceReady
@@ -584,18 +576,7 @@ func (r *NnfNodeStorageReconciler) formatFileSystem(ctx context.Context, nodeSto
 	sh, err = r.createFileShare(ss, fileShareID, allocationStatus.FileSystem.ID, os.Getenv("RABBIT_NODE"), mountPath, shareOptions)
 	if err != nil {
 		updateError(condition, &allocationStatus.FileShare, err)
-		nodeStorage.Status.Error = dwsv1alpha1.NewResourceError("Could not create file share", err)
-		log.Info(nodeStorage.Status.Error.Error())
-
-		ecErr := &ec.ControllerError{}
-		if errors.As(err, &ecErr) && ecErr.IsRetryable() {
-			return &ctrl.Result{RequeueAfter: ecErr.RetryDelay()}, nil
-		}
-
-		// NJT: If this is really Fatal, we shouldn't retry. Are all the nnf-ec errors reporting Retryable correctly?
-		nodeStorage.Status.Error = nodeStorage.Status.Error.WithFatal()
-
-		return &ctrl.Result{RequeueAfter: time.Minute * 2}, nil
+		return r.handleCreateError(nodeStorage, "could not create file share", err)
 	}
 
 	nid := ""
@@ -944,6 +925,30 @@ func (r *NnfNodeStorageReconciler) getFileSystem(ss nnf.StorageServiceApi, id st
 	}
 
 	return fs, nil
+}
+
+func (r *NnfNodeStorageReconciler) handleCreateError(storage *nnfv1alpha1.NnfNodeStorage, message string, err error) (*ctrl.Result, error) {
+
+	resourceError := dwsv1alpha1.NewResourceError(message, err)
+	defer func() {
+		r.Log.WithValues("NnfNodeStorage", client.ObjectKeyFromObject(storage).String()).Info(resourceError.Error())
+		storage.Status.Error = resourceError
+	}()
+
+	controllerError := &ec.ControllerError{}
+	if errors.As(err, &controllerError) && controllerError.IsRetryable() {
+		return &ctrl.Result{RequeueAfter: controllerError.RetryDelay()}, nil
+	}
+
+	resourceError = resourceError.WithFatal()
+
+	// If this is really Fatal, we should not retry. But not all of nnf-ec is supports the
+	// retryable classification of errors. Instead we mark the error as Fatal() but continue
+	// to retry with a modest delay. If the resource creation error occurs perpetually, an
+	// external entity should timeout the operation and therefore future create attempts.
+	// Once nnf-ec has correctly classified all errors, there should be no need to requeue.
+
+	return &ctrl.Result{RequeueAfter: time.Minute}, nil
 }
 
 func updateError(condition *metav1.Condition, status *nnfv1alpha1.NnfResourceStatus, err error) {


### PR DESCRIPTION
I'm thinking this is just a Part 1 - I really should be adding retryable error handling to all nnf-ec objects handling. Which means a function would be handy.

But this also introduces a problem - what if the Retryable occurs for ever (as currently happening on rabbit-node-1); Do we need a Retry Limit? Would it be time based, count based?

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>