### PR TITLE
Add jobs and service deployment for containers

### DIFF
--- a/api/v1alpha1/nnfcontainerprofile_types.go
+++ b/api/v1alpha1/nnfcontainerprofile_types.go
@@ -24,6 +24,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	ContainerLabel = "nnf.cray.hpe.com/container"
+)
+
 // NnfContainerProfileSpec defines the desired state of NnfContainerProfile
 type NnfContainerProfileData struct {
 	// Pinned is true if this instance is an immutable copy
@@ -32,6 +36,20 @@ type NnfContainerProfileData struct {
 
 	// List of possible filesystems supported by this container profile
 	Storages []NnfContainerProfileStorage `json:"storages,omitempty"`
+
+	// TODO: This is a development option for now. This will most likely be renamed or removed in
+	// order to hide the k8s job implementation from the user.
+	// Specifies the duration in seconds relative to the startTime that the job may be continuously
+	// active before the system tries to terminate it; value must be positive integer. If a Job is
+	// suspended (at creation or through an update), this timer will effectively be stopped and
+	// reset when the Job is resumed again. +optional
+	ActiveDeadlineSeconds int64 `json:"activeDeadlineSeconds,omitempty"`
+
+	// TODO: This is a development option for now. This will most likely be renamed or removed in
+	// order to hide the k8s job implementation from the user.
+	// Specifies the number of retries before marking this job failed. Defaults to 6 by Kubernetes itself.
+	// +kubebuilder:default:=6
+	BackoffLimit int32 `json:"backoffLimit"`
 
 	// Template defines the containers that will be created from container profile
 	Template corev1.PodTemplateSpec `json:"template"`

--- a/config/crd/bases/nnf.cray.hpe.com_nnfcontainerprofiles.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfcontainerprofiles.yaml
@@ -29,11 +29,25 @@ spec:
           data:
             description: NnfContainerProfileSpec defines the desired state of NnfContainerProfile
             properties:
-              default:
-                default: false
-                description: Default is true if this instance is the default resource
-                  to use
-                type: boolean
+              activeDeadlineSeconds:
+                description: 'TODO: This is a development option for now. This will
+                  most likely be renamed or removed in order to hide the k8s job implementation
+                  from the user. Specifies the duration in seconds relative to the
+                  startTime that the job may be continuously active before the system
+                  tries to terminate it; value must be positive integer. If a Job
+                  is suspended (at creation or through an update), this timer will
+                  effectively be stopped and reset when the Job is resumed again.
+                  +optional'
+                format: int64
+                type: integer
+              backoffLimit:
+                default: 6
+                description: 'TODO: This is a development option for now. This will
+                  most likely be renamed or removed in order to hide the k8s job implementation
+                  from the user. Specifies the number of retries before marking this
+                  job failed. Defaults to 6 by Kubernetes itself.'
+                format: int32
+                type: integer
               pinned:
                 default: false
                 description: Pinned is true if this instance is an immutable copy
@@ -7241,6 +7255,7 @@ spec:
                     type: object
                 type: object
             required:
+            - backoffLimit
             - template
             type: object
           kind:

--- a/config/dws/nnf-ruleset.yaml
+++ b/config/dws/nnf-ruleset.yaml
@@ -104,11 +104,11 @@ spec:
         isRequired: true
         isValueRequired: true
         # TODO: add a regex type to support wildcards (e.g. foo-local-storage) in the key
-      - key: "JOB_DW_foo-local-storage"
+      - key: "DW_JOB_foo-local-storage"
         type: "string"
         isRequired: false
         isValueRequired: true
-      - key: "PERSISTENT_DW_foo-persistent-storage"
+      - key: "DW_PERSISTENT_foo-persistent-storage"
         type: "string"
         isRequired: false
         isValueRequired: true

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,12 +6,13 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - apps
+  - batch
   resources:
-  - daemonsets
+  - jobs
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -52,6 +53,19 @@ rules:
   - get
   - list
   - update
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - cray.hpe.com
   resources:

--- a/config/samples/nnf_v1alpha1_nnfcontainerprofile.yaml
+++ b/config/samples/nnf_v1alpha1_nnfcontainerprofile.yaml
@@ -4,10 +4,11 @@ metadata:
   name: nnfcontainerprofile-sample
   namespace: nnf-system
 data:
+  backoffLimit: 6
   storages:
-    - name: JOB_DW_foo-local-storage
+    - name: DW_JOB_foo-local-storage
       optional: false
-    - name: PERSISTENT_DW_foo-persistent-storage
+    - name: DW_PERSISTENT_foo-persistent-storage
       optional: false
   template:
     spec:
@@ -19,8 +20,15 @@ data:
       containers:
         - name: foo
           image: alpine:latest
-          command: ["/bin/sh", "-c", "--"]
-          args: ["while true; do sleep 30; done;"]
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "starting..."
+              sleep 30
+              x=$(($RANDOM % 2))
+              echo "exiting: $x"
+              exit $x
           # TODO get volumes working
           # volumeMounts:
           # - name: foo-local-storage

--- a/controllers/directivebreakdown_controller.go
+++ b/controllers/directivebreakdown_controller.go
@@ -277,7 +277,16 @@ func (r *DirectiveBreakdownReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, err
 		}
 	case "container":
-		// TODO
+		pinnedContainerProfile, err := createPinnedContainerProfile(ctx, r.Client, r.Scheme, argsMap, dbd, commonResourceName)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		if pinnedContainerProfile == nil {
+			return ctrl.Result{Requeue: true}, nil
+		}
+
+		// TODO: refer to the job/persistent servers
 	default:
 	}
 

--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -83,7 +83,8 @@ type NnfWorkflowReconciler struct {
 //+kubebuilder:rbac:groups=cray.hpe.com,resources=lustrefilesystems,verbs=get;list;watch
 
 //+kubebuilder:rbac:groups=nnf.cray.hpe.com,resources=nnfcontainerprofiles,verbs=get;create;list;watch;update;patch;delete;deletecollection
-//+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete;deletecollection
+//+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete;deletecollection
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -775,6 +776,18 @@ func (r *NnfWorkflowReconciler) startPreRunState(ctx context.Context, workflow *
 		},
 	}
 
+	// Create container service and jobs
+	if dwArgs["command"] == "container" {
+		if err := r.createOrUpdateContainerServiceIfNecessary(ctx, workflow); err != nil {
+			return nil, nnfv1alpha1.NewWorkflowError("Unable to create/update Container Service").WithFatal().WithError(err)
+		}
+		if err := r.createOrUpdateContainerJobsIfNecessary(ctx, workflow); err != nil {
+			return nil, nnfv1alpha1.NewWorkflowError("Unable to create/update Container Jobs").WithFatal().WithError(err)
+		}
+
+		return nil, nil
+	}
+
 	// Create an NNFAccess for the compute clients
 	result, err := ctrl.CreateOrUpdate(ctx, r.Client, access,
 		func() error {
@@ -860,13 +873,6 @@ func (r *NnfWorkflowReconciler) startPreRunState(ctx context.Context, workflow *
 		return readyResult, nil
 	}
 
-	// TODO: Create container DS or Job. Need to determine which is the best route to handle communication and termination of the container.
-	if dwArgs["command"] == "container" {
-		if err := r.createOrUpdateContainerDaemonSetIfNecessary(ctx, workflow); err != nil {
-			return nil, nnfv1alpha1.NewWorkflowError("Unable to create/update Container DaemonSet").WithError(err)
-		}
-	}
-
 	return nil, nil
 }
 
@@ -886,6 +892,8 @@ func (r *NnfWorkflowReconciler) finishPreRunState(ctx context.Context, workflow 
 		envName = "DW_JOB_" + dwArgs["name"]
 	case "persistentdw":
 		envName = "DW_PERSISTENT_" + dwArgs["name"]
+	case "container":
+		// TODO: set env variables for containers; job names? ports? container storage args?
 	default:
 		return nil, nnfv1alpha1.NewWorkflowErrorf("Unexpected directive %v", dwArgs["command"])
 	}
@@ -896,6 +904,30 @@ func (r *NnfWorkflowReconciler) finishPreRunState(ctx context.Context, workflow 
 }
 
 func (r *NnfWorkflowReconciler) startPostRunState(ctx context.Context, workflow *dwsv1alpha1.Workflow, index int) (*result, error) {
+
+	dwArgs, _ := dwdparse.BuildArgsMap(workflow.Spec.DWDirectives[index])
+
+	if dwArgs["command"] == "container" {
+		// TODO: This is definitely half baked. This area will need some work once we get approval
+		// on the container RFC. More time can be spent on this once we get confirmation on the approach.
+
+		// TODO: I think these errors are going to need to be Fatal errors in order to set the Status.
+		done, result, err := r.checkContainerJobs(ctx, workflow)
+		if err != nil {
+			return nil, nnfv1alpha1.NewWorkflowErrorf("failed to check the container Jobs").WithError(err)
+		}
+
+		// TODO: Not sure if this requeue is working.
+		if !done {
+			return Requeue("waiting for container jobs to finish"), nil
+		}
+
+		if !result {
+			return nil, nnfv1alpha1.NewWorkflowErrorf("one or more container jobs were not successful: ").WithError(err)
+		}
+
+		return nil, nil
+	}
 
 	// Unmount the NnfAccess for the compute nodes. This will free the compute nodes to be used
 	// in a different job even if there is data movement happening on the Rabbits.
@@ -934,6 +966,12 @@ func (r *NnfWorkflowReconciler) startPostRunState(ctx context.Context, workflow 
 }
 
 func (r *NnfWorkflowReconciler) finishPostRunState(ctx context.Context, workflow *dwsv1alpha1.Workflow, index int) (*result, error) {
+	dwArgs, _ := dwdparse.BuildArgsMap(workflow.Spec.DWDirectives[index])
+
+	if dwArgs["command"] == "container" {
+		// TODO: anything to do here for container? Report Job incompletion as errors to the workflow like DM below?
+		return nil, nil
+	}
 
 	result, err := r.waitForNnfAccessStateAndReady(ctx, workflow, index, "unmounted")
 	if err != nil {
@@ -1066,6 +1104,9 @@ func (r *NnfWorkflowReconciler) finishTeardownState(ctx context.Context, workflo
 		if err != nil {
 			return nil, nnfv1alpha1.NewWorkflowError("Could not remove persistent storage reference").WithError(err)
 		}
+	case "container":
+		// TODO delete pinned profile?
+		// TODO: remove service, jobs, pods
 	default:
 	}
 

--- a/controllers/nnf_workflow_controller_helpers.go
+++ b/controllers/nnf_workflow_controller_helpers.go
@@ -33,7 +33,7 @@ import (
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
 
 	"github.com/go-logr/logr"
-	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,6 +42,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	containerServiceName = "container"
 )
 
 // NNF Workflow stages all return a `result` structure when successful that describes
@@ -217,7 +221,7 @@ func (r *NnfWorkflowReconciler) validateContainerDirective(ctx context.Context, 
 		return fmt.Errorf("storage '%s' not found in container profile '%s'", storageName, profile.Name)
 	}
 
-	// Find the wildcard JOB_DW and PERSISTENT_DW arguments. Verify that they exist in the
+	// Find the wildcard DW_JOB and DW_PERSISTENT arguments. Verify that they exist in the
 	// preceeding directives and in the container profile. For persistent arguments, ensure there
 	// is a persistent storage instance.
 	var suppliedStorageArguments []string // use this list later to validate non-optional storages
@@ -225,7 +229,7 @@ func (r *NnfWorkflowReconciler) validateContainerDirective(ctx context.Context, 
 		switch arg {
 		case "command", "name", "profile":
 		default:
-			if strings.HasPrefix(arg, "JOB_DW_") {
+			if strings.HasPrefix(arg, "DW_JOB_") {
 				if findDirectiveIndexByName(wf, storageName) == -1 {
 					return nnfv1alpha1.NewWorkflowError(fmt.Sprintf("jobdw directive mentioning '%s' not found", storageName)).WithFatal()
 				}
@@ -233,7 +237,7 @@ func (r *NnfWorkflowReconciler) validateContainerDirective(ctx context.Context, 
 					return nnfv1alpha1.NewWorkflowError(err.Error()).WithFatal()
 				}
 				suppliedStorageArguments = append(suppliedStorageArguments, arg)
-			} else if strings.HasPrefix(arg, "PERSISTENT_DW_") {
+			} else if strings.HasPrefix(arg, "DW_PERSISTENT_") {
 				if err := r.validatePersistentInstanceByName(ctx, storageName, wf.Namespace); err != nil {
 					return nnfv1alpha1.NewWorkflowError(fmt.Sprintf("persistent storage instance '%s' not found", storageName)).WithFatal()
 				}
@@ -339,8 +343,8 @@ func (r *NnfWorkflowReconciler) generateDirectiveBreakdown(ctx context.Context, 
 	// #DW jobdw name=my-gfs2 type=gfs2 capacity=1TB
 	// #DW persistentdw name=some-lustre
 	// #DW container name=my-foo profile=foo
-	//     JOB_DW_foo-local-storage=my-gfs2
-	//     PERSISTENT_DW_foo-persistent-storage=some-lustre
+	//     DW_JOB_foo-local-storage=my-gfs2
+	//     DW_PERSISTENT_foo-persistent-storage=some-lustre
 
 	// #DW commands that require a dwDirectiveBreakdown
 	breakDownCommands := []string{
@@ -941,86 +945,258 @@ func (r *NnfWorkflowReconciler) removeAllPersistentStorageReferences(ctx context
 	return nil
 }
 
-func (r *NnfWorkflowReconciler) createOrUpdateContainerDaemonSetIfNecessary(ctx context.Context, workflow *dwsv1alpha1.Workflow) error {
+// func (r *NnfWorkflowReconciler) createOrUpdateContainerServiceIfNecessary(ctx context.Context, workflow *dwsv1alpha1.Workflow) error {
+
+// 	log := log.FromContext(ctx)
+// 	log.Info("TODO: createOrUpdateContainerServiceIfNecessary() not implemented")
+
+// 	return nil
+// }
+
+func (r *NnfWorkflowReconciler) createOrUpdateContainerServiceIfNecessary(ctx context.Context, workflow *dwsv1alpha1.Workflow) error {
 	log := log.FromContext(ctx)
 
-	// TODO: check the directive or the workflow itself to determine if containers are requested
-	// I would imagine a change to dws (workflow type) would be necessary here but perhaps we can
-	// skirt around it with the directivebreakdown?
-
-	// TODO move this to helpers and use pinned profiles like storage profiles
-	// TODO: name is hardcoded
-	container := &nnfv1alpha1.NnfContainerProfile{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: "default", Name: "nnfcontainerprofile-sample"}, container); err != nil {
-		return err
-	}
-
-	ds := &appsv1.DaemonSet{
+	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "nnfcontainerprofile-sample-12345",
-			Namespace: "nnf-system",
+			Name:      workflow.Name,
+			Namespace: workflow.Namespace,
 		},
 	}
 
 	mutateFn := func() error {
-		podTemplateSpec := container.Data.Template.DeepCopy()
-		// podTemplateSpec.Labels = manager.Spec.Selector.DeepCopy().MatchLabels
-
-		// if podTemplateSpec.Labels == nil {
-		// 	podTemplateSpec.Labels = make(map[string]string)
-		// }
-		// podTemplateSpec.Labels[dmv1alpha1.DataMovementWorkerLabel] = "true"
-		podTemplateSpec.Labels = map[string]string{
-			"cray.nnf.node": "true",
+		service.Spec.Selector = map[string]string{
+			nnfv1alpha1.ContainerLabel: workflow.Name,
 		}
 
-		podSpec := &podTemplateSpec.Spec
-		// podSpec.NodeSelector = manager.Spec.Selector.MatchLabels
-		podSpec.NodeSelector = map[string]string{"cray.nnf.node": "true"}
-		// podSpec.Subdomain = serviceName
+		service.Spec.ClusterIP = corev1.ClusterIPNone
 
-		// setupSSHAuthVolumes(manager, podSpec)
-		// setupLustreVolumes(ctx, manager, podSpec, filesystems.Items)
-
-		ds.Spec = appsv1.DaemonSetSpec{
-			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
-				"cray.nnf.node": "true",
-			}},
-			Template: *podTemplateSpec,
+		if err := ctrl.SetControllerReference(workflow, service, r.Scheme); err != nil {
+			return fmt.Errorf("setting Service controller reference failed for '%s': %w", service.Name, err)
 		}
-		// ds.Spec = appsv1.DaemonSetSpec{
-		// 	Selector: &manager.Spec.Selector,
-		// 	Template: *podTemplateSpec,
-		// }
-
-		dwsv1alpha1.InheritParentLabels(ds, workflow)
-		dwsv1alpha1.AddOwnerLabels(ds, workflow)
-		// labels := ds.GetLabels()
-		// labels[nnfv1alpha1.AllocationSetLabel] = allocationSet.Name
-		// nnfNodeStorage.SetLabels(labels)
-
-		// TODO: add Volumes to DS, append if customer specifies; check for conflicts
-		vol := corev1.Volume{
-			Name: "foo-local-storage",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/path/to/thing"}}}
-		podTemplateSpec.Spec.Volumes = append(podTemplateSpec.Spec.Volumes, vol)
-		// TODO: get mounts from workflow
 
 		return nil
 	}
 
-	result, err := ctrl.CreateOrUpdate(ctx, r.Client, ds, mutateFn)
+	result, err := ctrl.CreateOrUpdate(ctx, r.Client, service, mutateFn)
 	if err != nil {
 		return err
 	}
 
 	if result == controllerutil.OperationResultCreated {
-		log.Info("Created DaemonSet", "object", client.ObjectKeyFromObject(ds).String())
+		log.Info("Created Service", "object", client.ObjectKeyFromObject(service).String())
 	} else if result == controllerutil.OperationResultUpdated {
-		log.Info("Updated DaemonSet", "object", client.ObjectKeyFromObject(ds).String())
+		log.Info("Updated Service", "object", client.ObjectKeyFromObject(service).String())
 	}
 
 	return nil
+}
+
+func (r *NnfWorkflowReconciler) createOrUpdateContainerJobsIfNecessary(ctx context.Context, workflow *dwsv1alpha1.Workflow) error {
+	log := log.FromContext(ctx)
+
+	// TODO: name is hardcoded to the non-pinned profile
+	// TODO Use pinned profiles like storage profiles; however, storage
+	// profiles use <workflow-name>-<directive breakdown index> (e.g. blake-container-2). I think
+	// we'll want to just have these named after the workflow
+	containerProfile := &nnfv1alpha1.NnfContainerProfile{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: "nnf-system", Name: "nnfcontainerprofile-sample"}, containerProfile); err != nil {
+		return err
+	}
+
+	// Get the targeted NNF nodes for the container jobs
+	nnfNodes, err := r.getNnfNodesForContainers(ctx, workflow)
+	if err != nil {
+		return nnfv1alpha1.NewWorkflowError("error obtaining the target NNF nodes for containers:").WithError(err).WithFatal()
+	}
+
+	// For each NNF node, create a job
+	for _, nnfNode := range nnfNodes {
+		jobName := fmt.Sprintf("%s-%s", workflow.Name, nnfNode)
+
+		job := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      jobName,
+				Namespace: workflow.Namespace,
+			},
+		}
+
+		// Apply Job Labels
+		// TODO: confirm labels here; any missing?
+		dwsv1alpha1.InheritParentLabels(job, workflow)
+		dwsv1alpha1.AddOwnerLabels(job, workflow)
+		dwsv1alpha1.AddWorkflowLabels(job, workflow)
+		labels := job.GetLabels()
+		labels[nnfv1alpha1.ContainerLabel] = workflow.Name
+		job.SetLabels(labels)
+
+		if err := ctrl.SetControllerReference(workflow, job, r.Scheme); err != nil {
+			return fmt.Errorf("setting Job controller reference failed for '%s': %w", job.Name, err)
+		}
+
+		mutateFn := func() error {
+			// The template is immutable, so only do this on creation
+			if job.ObjectMeta.CreationTimestamp.IsZero() {
+				podTemplateSpec := containerProfile.Data.Template.DeepCopy()
+
+				// Use the same labels as the job
+				podTemplateSpec.Labels = job.DeepCopy().Labels
+
+				podSpec := &podTemplateSpec.Spec
+
+				// We want to keep the restart policy to Never. This way, any pods that failed are
+				// kept around for inspection. The job attempts to retry pods until the number of
+				// completions are hit or the number of max retries (BackoffLimit) have been hit.
+				// A retry with a restart policy of Never will not restart the pod, but spin up a new one
+				// with a new IP. A retry is not the same as a restart.  If we set this to
+				// OnFailure, the pods will truly restart but we will lose any log history outside
+				// of (kubectl logs --previous).
+				//
+				// TODO: consider allowing `OnFailure` as well and make it configurable via the
+				// containerprofile. However, it might be a good idea not to allow this for the
+				// reasons above.
+				podSpec.RestartPolicy = corev1.RestartPolicyNever
+
+				// Because the IP changes, we need to have deterministic hostname for the pod
+				podSpec.Hostname = jobName
+				podSpec.Subdomain = workflow.Name // service name == workflow name
+
+				// In our case, the target is only 1 node for the job, so a restartPolicy of Never
+				// is ok because any retry (i.e. new pod) will land on the same node.
+				podSpec.NodeSelector = map[string]string{"kubernetes.io/hostname": nnfNode}
+				podSpec.Tolerations = []corev1.Toleration{
+					{
+						Effect:   "NoSchedule",
+						Key:      "cray.nnf.node",
+						Operator: "Equal",
+						Value:    "true",
+					},
+				}
+
+				// TODO Volumes
+				// podSpec.Volumes
+				// ssh is necessary for mpi
+				// setupSSHAuthVolumes(manager, podSpec)
+				// setupLustreVolumes(ctx, manager, podSpec, filesystems.Items)
+				// TODO: add Volumes to DS, append if customer specifies; check for conflicts
+				// vol := corev1.Volume{
+				// 	Name: "foo-local-storage",
+				// 	VolumeSource: corev1.VolumeSource{
+				// 		HostPath: &corev1.HostPathVolumeSource{
+				// 			Path: "/path/to/thing"}}}
+				// podTemplateSpec.Spec.Volumes = append(podTemplateSpec.Spec.Volumes, vol)
+				// TODO: get mounts from workflow
+
+				job.Spec.Template = *podTemplateSpec
+			}
+
+			// This is a timeout for the job, if set, when the deadline hits, the job will kill all
+			// pods and fail the job.
+			if containerProfile.Data.ActiveDeadlineSeconds > 0 {
+				job.Spec.ActiveDeadlineSeconds = &containerProfile.Data.ActiveDeadlineSeconds
+			}
+			// This defaults to 6 and is the maximum number of pod started before considering the
+			// job failed. I don't believe this can be turned off.
+			job.Spec.BackoffLimit = &containerProfile.Data.BackoffLimit
+
+			return nil
+		}
+
+		result, err := ctrl.CreateOrUpdate(ctx, r.Client, job, mutateFn)
+		if err != nil {
+			return err
+		}
+
+		if result == controllerutil.OperationResultCreated {
+			log.Info("Created Job", "object", client.ObjectKeyFromObject(job).String())
+		} else if result == controllerutil.OperationResultUpdated {
+			log.Info("Updated Job", "object", client.ObjectKeyFromObject(job).String())
+		}
+	}
+
+	return nil
+}
+
+func (r *NnfWorkflowReconciler) getNnfNodesForContainers(ctx context.Context, workflow *dwsv1alpha1.Workflow) ([]string, error) {
+	// return []string{"kind-worker2", "kind-worker3"}, nil
+
+	var nnfNodes []string
+	var computeNodes []string
+
+	// Get the compute resources
+	computes := dwsv1alpha1.Computes{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      workflow.Name,
+			Namespace: workflow.Namespace,
+		},
+	}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(&computes), &computes); err != nil {
+		return nnfNodes, nnfv1alpha1.NewWorkflowError("could not find Computes resource for workflow")
+	}
+
+	// Build the list of computes
+	for _, c := range computes.Data {
+		computeNodes = append(computeNodes, c.Name)
+	}
+	if len(computeNodes) == 0 {
+		return computeNodes, nnfv1alpha1.NewWorkflowError("the Computes resources does not specify any compute nodes")
+	}
+
+	systemConfig := &dwsv1alpha1.SystemConfiguration{}
+	if err := r.Get(ctx, types.NamespacedName{Name: "default", Namespace: corev1.NamespaceDefault}, systemConfig); err != nil {
+		return nnfNodes, nnfv1alpha1.NewWorkflowError("could not get system configuration")
+	}
+
+	// The SystemConfiguration is organized by rabbit. Make a map of computes:rabbit for easy lookup.
+	computeMap := make(map[string]string)
+	for _, storageNode := range systemConfig.Spec.StorageNodes {
+		if storageNode.Type != "Rabbit" {
+			continue
+		}
+		for _, ca := range storageNode.ComputesAccess {
+			computeMap[ca.Name] = storageNode.Name
+		}
+	}
+
+	// For each supplied compute, use the map to lookup its local Rabbit
+	for _, c := range computeNodes {
+		nnfNode, found := computeMap[c]
+		if !found {
+			return nnfNodes, nnfv1alpha1.NewWorkflowErrorf("supplied compute node '%s' not found in SystemConfiguration", c)
+		}
+		nnfNodes = append(nnfNodes, nnfNode)
+	}
+
+	return nnfNodes, nil
+}
+
+func (r *NnfWorkflowReconciler) checkContainerJobs(ctx context.Context, workflow *dwsv1alpha1.Workflow) (done bool, result bool, error error) {
+	jobList := &batchv1.JobList{}
+	matchLabels := dwsv1alpha1.MatchingWorkflow(workflow)
+
+	if err := r.List(ctx, jobList, matchLabels); err != nil {
+		return false, false, nnfv1alpha1.NewWorkflowErrorf("could not retrieve Jobs for workflow '%s'", workflow.Name).WithError(err)
+	}
+
+	// TODO: There seems like there's a better way of doing this with Pod failure policies: https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-failure-policy
+
+	// Ensure all the jobs are done running before we check the conditions.
+	for _, job := range jobList.Items {
+		if len(job.Status.Conditions) <= 0 {
+			return false, false, nil
+		}
+	}
+
+	// Once we know everything is done, we can check the conditions
+	for _, job := range jobList.Items {
+		for _, condition := range job.Status.Conditions {
+			if condition.Type != batchv1.JobComplete {
+				return true, false, nnfv1alpha1.NewWorkflowErrorf("container job %s (%s): %s", condition.Type, condition.Reason, condition.Message)
+			}
+		}
+	}
+
+	// TODO: Once postrun starts, we will want a timeout that starts and eventually kills/fails job pods
+	// once that timeout is hit.
+
+	return true, true, nil
 }


### PR DESCRIPTION
Jobs/pods are now being deployed and you can get through all of the workflow stages. The only exception is that PostRun won't go ready if jobs are still running while you transition. The completion logic is still a work in progress.

There are a lot of TODOs littered throughout, but here are the main milestones:

- Added container job deployment to the PreRun stage
- Added headless service deployment
- Jobs/Pods are now deployed to rabbits attached to the supplied compute nodes via the Workflow's Computes resource
- Added first attempt at completion logic to the PostRun stage
- Updated nnfcontainerprofile with development options to control job completion logic
- Update sample container profile to run a job that randomly exits pass/fail
- Jobs/pods/service are removed when the workflow is removed
- Pinned Container Profiles (i.e. workflow specific copies) are being created, but not yet used in the deployment

#### Major TODOs:

- Volume Support
- Completion Logic in PostRun
- Flexible container storage argument names (i.e. regexes for dws directive keys)