### PR TITLE
RABSW-1124: Change NnfAccess TeardownState for servers

### DIFF
--- a/api/v1alpha1/nnf_access_types.go
+++ b/api/v1alpha1/nnf_access_types.go
@@ -35,7 +35,7 @@ type NnfAccessSpec struct {
 
 	// TeardownState is the desired state of the workflow for this NNF Access resource to
 	// be torn down and deleted.
-	// +kubebuilder:validation:Enum:=DataIn;PreRun;PostRun;DataOut
+	// +kubebuilder:validation:Enum:=PreRun;PostRun;Teardown
 	// +kubebuilder:validation:Type:=string
 	TeardownState dwsv1alpha1.WorkflowState `json:"teardownState"`
 

--- a/config/crd/bases/nnf.cray.hpe.com_nnfaccesses.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfaccesses.yaml
@@ -163,10 +163,9 @@ spec:
                   - DataOut
                   - Teardown
                 - enum:
-                  - DataIn
                   - PreRun
                   - PostRun
-                  - DataOut
+                  - Teardown
                 description: TeardownState is the desired state of the workflow for
                   this NNF Access resource to be torn down and deleted.
                 type: string

--- a/controllers/integration_test.go
+++ b/controllers/integration_test.go
@@ -1130,11 +1130,11 @@ var _ = Describe("Integration Test", func() {
 				advanceStateAndCheckReady(dwsv1alpha1.StatePreRun, workflow)
 
 				By("Validate NNF Access is created, with deletion in data-out")
-				validateNnfAccessHasCorrectTeardownState(dwsv1alpha1.StateDataOut)
+				validateNnfAccessHasCorrectTeardownState(dwsv1alpha1.StateTeardown)
 
 				By("Advancing to post run, ensure NNF Access is still set for deletion in data-out")
 				advanceStateAndCheckReady(dwsv1alpha1.StatePostRun, workflow)
-				validateNnfAccessHasCorrectTeardownState(dwsv1alpha1.StateDataOut)
+				validateNnfAccessHasCorrectTeardownState(dwsv1alpha1.StateTeardown)
 
 				By("Advancing to data-out, ensure NNF Access is deleted")
 				advanceStateAndCheckReady(dwsv1alpha1.StateDataOut, workflow)
@@ -1155,7 +1155,7 @@ var _ = Describe("Integration Test", func() {
 				Expect(workflow.Status.State).To(Equal(dwsv1alpha1.StateDataIn))
 
 				By("Validate NNF Access is created, with deletion in data-out")
-				validateNnfAccessHasCorrectTeardownState(dwsv1alpha1.StateDataOut)
+				validateNnfAccessHasCorrectTeardownState(dwsv1alpha1.StateTeardown)
 
 				advanceStateAndCheckReady(dwsv1alpha1.StatePreRun, workflow)
 				advanceStateAndCheckReady(dwsv1alpha1.StatePostRun, workflow)

--- a/controllers/nnf_access_controller_test.go
+++ b/controllers/nnf_access_controller_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Access Controller Test", func() {
 				},
 				Spec: nnfv1alpha1.NnfAccessSpec{
 					DesiredState:    "mounted",
-					TeardownState:   dwsv1alpha1.StateDataIn,
+					TeardownState:   dwsv1alpha1.StatePreRun,
 					Target:          "all",
 					ClientReference: corev1.ObjectReference{},
 					MountPath:       "./",

--- a/controllers/nnf_workflow_controller_helpers.go
+++ b/controllers/nnf_workflow_controller_helpers.go
@@ -695,7 +695,7 @@ func (r *NnfWorkflowReconciler) unmountNnfAccessIfNecessary(ctx context.Context,
 	// find it in the cache and it really does exist, we'll eventually get an event from the API server and
 	// do the unmount then.
 	if err := r.Get(ctx, client.ObjectKeyFromObject(access), access); err != nil {
-		return nil, nil
+		return nil, client.IgnoreNotFound(err)
 	}
 
 	teardownState, found := access.Labels[nnfv1alpha1.DataMovementTeardownStateLabel]


### PR DESCRIPTION
The data movement code was mounting and unmounting the Rabbit nodes during the DataIn and DataOut phases of the workflow. A stale workflow resource in the client cache could cause the NnfAccess to be re-mounted after it had already been unmounted. This commit changes the NnfAccess Teardown state logic to do the unmounts in PreRun and Teardown instead of DataIn and DataOut.

Signed-off-by: Matt Richerson <matthew.richerson@hpe.com>