### PR TITLE
RABSW-1128: Make fake mounts on kind Rabbit nodes

### DIFF
--- a/config/kind/kustomization.yaml
+++ b/config/kind/kustomization.yaml
@@ -2,5 +2,7 @@ bases:
 - ../top
 
 patchesStrategicMerge:
+# Let the node-manager daemonset mount host dir for /mnt
+- manager_volumes_patch.yaml
 # Arguments for the controller manager that are specific to kind
 - manager_environment_patch.yaml

--- a/config/kind/manager_volumes_patch.yaml
+++ b/config/kind/manager_volumes_patch.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          volumeMounts:
+            - mountPath: /mnt
+              name: mnt-dir
+              mountPropagation: Bidirectional
+      volumes:
+        - name: mnt-dir
+          hostPath:
+            path: /mnt
+

--- a/controllers/nnf_access_controller.go
+++ b/controllers/nnf_access_controller.go
@@ -22,6 +22,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -475,6 +476,12 @@ func (r *NnfAccessReconciler) mapClientNetworkStorage(ctx context.Context, acces
 			ObjectReference: access.Spec.StorageReference,
 		}
 
+		if os.Getenv("ENVIRONMENT") == "kind" {
+			mountInfo.UserID = access.Spec.UserID
+			mountInfo.GroupID = access.Spec.GroupID
+			mountInfo.SetPermissions = true
+		}
+
 		storageMapping[client] = append(storageMapping[client], mountInfo)
 	}
 
@@ -559,6 +566,12 @@ func (r *NnfAccessReconciler) mapClientLocalStorage(ctx context.Context, access 
 				} else {
 					mountInfo.TargetType = "directory"
 					mountInfo.Type = nnfStorage.Spec.FileSystemType
+				}
+
+				if os.Getenv("ENVIRONMENT") == "kind" {
+					mountInfo.UserID = access.Spec.UserID
+					mountInfo.GroupID = access.Spec.GroupID
+					mountInfo.SetPermissions = true
 				}
 
 				// If no ClientReference exists, then the mounts are for the Rabbit nodes. Use references

--- a/controllers/nnf_clientmount_controller.go
+++ b/controllers/nnf_clientmount_controller.go
@@ -57,9 +57,8 @@ const (
 // NnfClientMountReconciler contains the pieces used by the reconciler
 type NnfClientMountReconciler struct {
 	client.Client
-	Log       logr.Logger
-	Scheme    *kruntime.Scheme
-	FakeMount bool
+	Log    logr.Logger
+	Scheme *kruntime.Scheme
 }
 
 //+kubebuilder:rbac:groups=dws.cray.hpe.com,resources=clientmounts,verbs=get;list;watch;create;update;patch;delete
@@ -196,7 +195,7 @@ func (r *NnfClientMountReconciler) changeMountAll(ctx context.Context, clientMou
 // changeMount mount or unmounts a single mount point described in the ClientMountInfo object
 func (r *NnfClientMountReconciler) changeMount(ctx context.Context, clientMountInfo dwsv1alpha1.ClientMountInfo, shouldMount bool, log logr.Logger) error {
 
-	if r.FakeMount {
+	if os.Getenv("ENVIRONMENT") == "kind" {
 		if shouldMount {
 			if err := os.MkdirAll(clientMountInfo.MountPath, 0755); err != nil {
 				return dwsv1alpha1.NewResourceError(fmt.Sprintf("Make directory failed: %s", clientMountInfo.MountPath), err)

--- a/controllers/nnf_clientmount_controller.go
+++ b/controllers/nnf_clientmount_controller.go
@@ -57,8 +57,9 @@ const (
 // NnfClientMountReconciler contains the pieces used by the reconciler
 type NnfClientMountReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *kruntime.Scheme
+	Log       logr.Logger
+	Scheme    *kruntime.Scheme
+	FakeMount bool
 }
 
 //+kubebuilder:rbac:groups=dws.cray.hpe.com,resources=clientmounts,verbs=get;list;watch;create;update;patch;delete
@@ -194,6 +195,30 @@ func (r *NnfClientMountReconciler) changeMountAll(ctx context.Context, clientMou
 
 // changeMount mount or unmounts a single mount point described in the ClientMountInfo object
 func (r *NnfClientMountReconciler) changeMount(ctx context.Context, clientMountInfo dwsv1alpha1.ClientMountInfo, shouldMount bool, log logr.Logger) error {
+
+	if r.FakeMount {
+		if shouldMount {
+			if err := os.MkdirAll(clientMountInfo.MountPath, 0755); err != nil {
+				return dwsv1alpha1.NewResourceError(fmt.Sprintf("Make directory failed: %s", clientMountInfo.MountPath), err)
+			}
+
+			log.Info("Fake mounted file system", "Mount path", clientMountInfo.MountPath)
+		} else {
+			if err := os.Remove(clientMountInfo.MountPath); err != nil {
+				return dwsv1alpha1.NewResourceError(fmt.Sprintf("Remove directory failed: %s", clientMountInfo.MountPath), err)
+			}
+
+			log.Info("Fake unmounted file system", "Mount path", clientMountInfo.MountPath)
+		}
+
+		if clientMountInfo.SetPermissions {
+			if err := os.Chown(clientMountInfo.MountPath, int(clientMountInfo.UserID), int(clientMountInfo.GroupID)); err != nil {
+				return dwsv1alpha1.NewResourceError(fmt.Sprintf("Chown failed: %s", clientMountInfo.MountPath), err)
+			}
+		}
+
+		return nil
+	}
 
 	switch clientMountInfo.Device.Type {
 	case dwsv1alpha1.ClientMountDeviceTypeLustre:

--- a/controllers/nnf_workflow_controller_helpers.go
+++ b/controllers/nnf_workflow_controller_helpers.go
@@ -499,8 +499,10 @@ func (r *NnfWorkflowReconciler) setupNnfAccessForServers(ctx context.Context, st
 				DesiredState:    "mounted",
 				TeardownState:   teardownState,
 				Target:          "all",
-				MountPath:       buildMountPath(workflow, index),
-				MountPathPrefix: buildMountPath(workflow, index),
+				UserID:          workflow.Spec.UserID,
+				GroupID:         workflow.Spec.GroupID,
+				MountPath:       buildMountPath(workflow, parentDwIndex),
+				MountPathPrefix: buildMountPath(workflow, parentDwIndex),
 
 				// NNF Storage is Namespaced Name to the servers object
 				StorageReference: corev1.ObjectReference{

--- a/controllers/nnf_workflow_controller_test.go
+++ b/controllers/nnf_workflow_controller_test.go
@@ -393,7 +393,7 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 						"Namespace": Equal(lustre.Namespace),
 					}))
 
-				Expect(dm.Spec.Destination.Path).To(Equal(buildMountPath(workflow, 1) + "/my-file.out"))
+				Expect(dm.Spec.Destination.Path).To(Equal(buildMountPath(workflow, 0) + "/my-file.out"))
 				Expect(dm.Spec.Destination.StorageReference).ToNot(BeNil())
 				Expect(dm.Spec.Destination.StorageReference).To(MatchFields(IgnoreExtras,
 					Fields{
@@ -525,7 +525,7 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 						"Namespace": Equal(lustre.Namespace),
 					}))
 
-				Expect(dm.Spec.Destination.Path).To(Equal(buildMountPath(workflow, 1) + "/my-persistent-file.out"))
+				Expect(dm.Spec.Destination.Path).To(Equal(buildMountPath(workflow, 0) + "/my-persistent-file.out"))
 				Expect(dm.Spec.Destination.StorageReference).ToNot(BeNil())
 				Expect(dm.Spec.Destination.StorageReference).To(MatchFields(IgnoreExtras,
 					Fields{

--- a/main.go
+++ b/main.go
@@ -192,23 +192,12 @@ func (c *nodeLocalController) SetupReconcilers(mgr manager.Manager, opts *nnf.Op
 		return err
 	}
 
-	if os.Getenv("ENVIRONMENT") == "kind" {
-		if err := (&controllers.NnfClientMountReconciler{
-			Client:    mgr.GetClient(),
-			Log:       ctrl.Log.WithName("controllers").WithName("NnfClientMount"),
-			Scheme:    mgr.GetScheme(),
-			FakeMount: true,
-		}).SetupWithManager(mgr); err != nil {
-			return err
-		}
-	} else {
-		if err := (&controllers.NnfClientMountReconciler{
-			Client: mgr.GetClient(),
-			Log:    ctrl.Log.WithName("controllers").WithName("NnfClientMount"),
-			Scheme: mgr.GetScheme(),
-		}).SetupWithManager(mgr); err != nil {
-			return err
-		}
+	if err := (&controllers.NnfClientMountReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("NnfClientMount"),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		return err
 	}
 
 	return (&controllers.NnfNodeStorageReconciler{

--- a/main.go
+++ b/main.go
@@ -192,7 +192,16 @@ func (c *nodeLocalController) SetupReconcilers(mgr manager.Manager, opts *nnf.Op
 		return err
 	}
 
-	if os.Getenv("ENVIRONMENT") != "kind" {
+	if os.Getenv("ENVIRONMENT") == "kind" {
+		if err := (&controllers.NnfClientMountReconciler{
+			Client:    mgr.GetClient(),
+			Log:       ctrl.Log.WithName("controllers").WithName("NnfClientMount"),
+			Scheme:    mgr.GetScheme(),
+			FakeMount: true,
+		}).SetupWithManager(mgr); err != nil {
+			return err
+		}
+	} else {
 		if err := (&controllers.NnfClientMountReconciler{
 			Client: mgr.GetClient(),
 			Log:    ctrl.Log.WithName("controllers").WithName("NnfClientMount"),


### PR DESCRIPTION
Create empty directories on the Rabbit nodes in the clientmount reconciler to better fake out data movement and user containers.

Signed-off-by: Matt Richerson <matthew.richerson@hpe.com>