### PR TITLE
use new dws functionality supporting regexp keys in the directive rul…

### DIFF
--- a/config/dws/nnf-ruleset.yaml
+++ b/config/dws/nnf-ruleset.yaml
@@ -103,12 +103,7 @@ spec:
         type: "string"
         isRequired: true
         isValueRequired: true
-        # TODO: add a regex type to support wildcards (e.g. foo-local-storage) in the key
-      - key: "DW_JOB_foo-local-storage"
-        type: "string"
-        isRequired: false
-        isValueRequired: true
-      - key: "DW_PERSISTENT_foo-persistent-storage"
+      - key: "^(DW_JOB_|DW_PERSISTENT_)[\\w-]+$"
         type: "string"
         isRequired: false
         isValueRequired: true

--- a/config/dws/nnf-ruleset.yaml
+++ b/config/dws/nnf-ruleset.yaml
@@ -103,7 +103,7 @@ spec:
         type: "string"
         isRequired: true
         isValueRequired: true
-      - key: "^(DW_JOB_|DW_PERSISTENT_)[\\w-]+$"
+      - key: '^(DW_JOB_|DW_PERSISTENT_)[A-Za-z][A-Za-z0-9-]+$'
         type: "string"
         isRequired: false
         isValueRequired: true


### PR DESCRIPTION
I know `[\w-]` is unusual from other patterns, but I think we DO want to support the whole \w character set. I have a question out to Tony to see why we currently do not.

If already deployed, make sure you have updated the dws repo, otherwise it wont work.