### PR TITLE
RABSW-1139: Fix ClientMount directory create/remove for kind environment

### DIFF
--- a/controllers/nnf_clientmount_controller.go
+++ b/controllers/nnf_clientmount_controller.go
@@ -197,13 +197,23 @@ func (r *NnfClientMountReconciler) changeMount(ctx context.Context, clientMountI
 
 	if os.Getenv("ENVIRONMENT") == "kind" {
 		if shouldMount {
+			// Return if the directory already exists
+			if _, err := os.Stat(clientMountInfo.MountPath); !os.IsNotExist(err) {
+				return nil
+			}
+
 			if err := os.MkdirAll(clientMountInfo.MountPath, 0755); err != nil {
 				return dwsv1alpha1.NewResourceError(fmt.Sprintf("Make directory failed: %s", clientMountInfo.MountPath), err)
 			}
 
 			log.Info("Fake mounted file system", "Mount path", clientMountInfo.MountPath)
 		} else {
-			if err := os.Remove(clientMountInfo.MountPath); err != nil {
+			// Return if the directory was already removed
+			if _, err := os.Stat(clientMountInfo.MountPath); os.IsNotExist(err) {
+				return nil
+			}
+
+			if err := os.RemoveAll(clientMountInfo.MountPath); err != nil {
 				return dwsv1alpha1.NewResourceError(fmt.Sprintf("Remove directory failed: %s", clientMountInfo.MountPath), err)
 			}
 

--- a/controllers/nnf_clientmount_controller.go
+++ b/controllers/nnf_clientmount_controller.go
@@ -197,11 +197,6 @@ func (r *NnfClientMountReconciler) changeMount(ctx context.Context, clientMountI
 
 	if os.Getenv("ENVIRONMENT") == "kind" {
 		if shouldMount {
-			// Return if the directory already exists
-			if _, err := os.Stat(clientMountInfo.MountPath); !os.IsNotExist(err) {
-				return nil
-			}
-
 			if err := os.MkdirAll(clientMountInfo.MountPath, 0755); err != nil {
 				return dwsv1alpha1.NewResourceError(fmt.Sprintf("Make directory failed: %s", clientMountInfo.MountPath), err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/NearNodeFlash/nnf-sos
 go 1.19
 
 require (
-	github.com/HewlettPackard/dws v0.0.0-20230120203803-669e57232455
+	github.com/HewlettPackard/dws v0.0.0-20230207202213-c34dae8573e2
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220929204230-5dcfe552c9e0
 	github.com/NearNodeFlash/nnf-ec v0.0.0-20230126164635-a87929e88089
 	github.com/ghodss/yaml v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/NearNodeFlash/nnf-sos
 go 1.19
 
 require (
-	github.com/HewlettPackard/dws v0.0.0-20230207202213-c34dae8573e2
+	github.com/HewlettPackard/dws v0.0.0-20230207214424-016335e15075
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20220929204230-5dcfe552c9e0
 	github.com/NearNodeFlash/nnf-ec v0.0.0-20230126164635-a87929e88089
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/HewlettPackard/dws v0.0.0-20230120203803-669e57232455 h1:LIuI3Z7nSdm+hnNmJY/TLV//nloL6cqMlqWqclq9yNo=
-github.com/HewlettPackard/dws v0.0.0-20230120203803-669e57232455/go.mod h1:OxTK/qLMVBktON5wHI6zGuKEsoT8iLpPtUX+y02/m10=
+github.com/HewlettPackard/dws v0.0.0-20230207202213-c34dae8573e2 h1:qZAj8OJPWwa32LBRF15eGgpk+jmCvkqeHMZ7jaAp3Xs=
+github.com/HewlettPackard/dws v0.0.0-20230207202213-c34dae8573e2/go.mod h1:OxTK/qLMVBktON5wHI6zGuKEsoT8iLpPtUX+y02/m10=
 github.com/HewlettPackard/structex v1.0.2 h1:p2EH/p6zvUd5fSa0onudAUvLWdKsvQSRP0jGKeblA5E=
 github.com/HewlettPackard/structex v1.0.2/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
 github.com/Masterminds/squirrel v1.5.0/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/HewlettPackard/dws v0.0.0-20230207202213-c34dae8573e2 h1:qZAj8OJPWwa32LBRF15eGgpk+jmCvkqeHMZ7jaAp3Xs=
-github.com/HewlettPackard/dws v0.0.0-20230207202213-c34dae8573e2/go.mod h1:OxTK/qLMVBktON5wHI6zGuKEsoT8iLpPtUX+y02/m10=
+github.com/HewlettPackard/dws v0.0.0-20230207214424-016335e15075 h1:847PiLepVQ10SoPQEc3OKdxWg6LXt70WXcCQj7ih3Bc=
+github.com/HewlettPackard/dws v0.0.0-20230207214424-016335e15075/go.mod h1:OxTK/qLMVBktON5wHI6zGuKEsoT8iLpPtUX+y02/m10=
 github.com/HewlettPackard/structex v1.0.2 h1:p2EH/p6zvUd5fSa0onudAUvLWdKsvQSRP0jGKeblA5E=
 github.com/HewlettPackard/structex v1.0.2/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
 github.com/Masterminds/squirrel v1.5.0/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=

--- a/vendor/github.com/HewlettPackard/dws/config/webhook/kustomization.yaml
+++ b/vendor/github.com/HewlettPackard/dws/config/webhook/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
 - manifests.yaml
 - service.yaml
+- service_account.yaml
 
 configurations:
 - kustomizeconfig.yaml

--- a/vendor/github.com/HewlettPackard/dws/config/webhook/service.yaml
+++ b/vendor/github.com/HewlettPackard/dws/config/webhook/service.yaml
@@ -9,4 +9,5 @@ spec:
     - port: 443
       targetPort: 9443
   selector:
-    control-plane: controller-manager
+    control-plane: webhook
+  type: LoadBalancer

--- a/vendor/github.com/HewlettPackard/dws/config/webhook/service_account.yaml
+++ b/vendor/github.com/HewlettPackard/dws/config/webhook/service_account.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: webhook
+  namespace: system
+---
+# As of Kubernetes 1.24, ServiceAccount tokens are no longer automatically
+# generated. Instead, manually create the secret and the token key in the
+# data field will be automatically set.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook
+  namespace: system
+  annotations:
+    kubernetes.io/service-account.name: webhook
+    kubernetes.io/service-account.namespace: system
+type: kubernetes.io/service-account-token

--- a/vendor/github.com/HewlettPackard/dws/controllers/clientmount_controller.go
+++ b/vendor/github.com/HewlettPackard/dws/controllers/clientmount_controller.go
@@ -21,7 +21,6 @@ package controllers
 
 import (
 	"context"
-	"os"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -116,20 +115,16 @@ func (r *ClientMountReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	return ctrl.Result{}, nil
 }
 
-func filterByNonRabbitNamespacePrefixForTest() predicate.Predicate {
+func filterByComputeNamespacePrefix() predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(object client.Object) bool {
-		return !strings.HasPrefix(object.GetNamespace(), "rabbit")
+		return strings.HasPrefix(object.GetNamespace(), "compute")
 	})
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClientMountReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	builder := ctrl.NewControllerManagedBy(mgr).
-		For(&dwsv1alpha1.ClientMount{})
-
-	if _, found := os.LookupEnv("NNF_TEST_ENVIRONMENT"); found {
-		builder = builder.WithEventFilter(filterByNonRabbitNamespacePrefixForTest())
-	}
-
-	return builder.Complete(r)
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&dwsv1alpha1.ClientMount{}).
+		WithEventFilter(filterByComputeNamespacePrefix()).
+		Complete(r)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -20,7 +20,7 @@ github.com/Azure/go-autorest/logger
 # github.com/Azure/go-autorest/tracing v0.6.0
 ## explicit; go 1.12
 github.com/Azure/go-autorest/tracing
-# github.com/HewlettPackard/dws v0.0.0-20230207202213-c34dae8573e2
+# github.com/HewlettPackard/dws v0.0.0-20230207214424-016335e15075
 ## explicit; go 1.19
 github.com/HewlettPackard/dws/api/v1alpha1
 github.com/HewlettPackard/dws/config/crd/bases

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -20,7 +20,7 @@ github.com/Azure/go-autorest/logger
 # github.com/Azure/go-autorest/tracing v0.6.0
 ## explicit; go 1.12
 github.com/Azure/go-autorest/tracing
-# github.com/HewlettPackard/dws v0.0.0-20230120203803-669e57232455
+# github.com/HewlettPackard/dws v0.0.0-20230207202213-c34dae8573e2
 ## explicit; go 1.19
 github.com/HewlettPackard/dws/api/v1alpha1
 github.com/HewlettPackard/dws/config/crd/bases


### PR DESCRIPTION
In the ClientMount controller for kind nodes, check whether the directory exists before creating or removing it.

Re-vendor dws

Signed-off-by: Matt Richerson <matthew.richerson@hpe.com>