### PR TITLE
Add environmental variables

### DIFF
--- a/controllers/nnf_workflow_controller_helpers.go
+++ b/controllers/nnf_workflow_controller_helpers.go
@@ -1360,7 +1360,7 @@ func (r *NnfWorkflowReconciler) getContainerVolumes(ctx context.Context, workflo
 			command:        cmd,
 			directiveName:  val,
 			directiveIndex: -1,
-			envVarName:     strings.Replace(arg, "-", "_", -1), // env vars can't have hyphens
+			envVarName:     strings.ReplaceAll(arg, "-", "_"), // env vars can't have hyphens
 		}
 
 		// Find the directive index for the given name so we can retrieve its NnfAccess


### PR DESCRIPTION
- Replace any hyphens in the storage names with underscores
- Add in hostname, subdomain, and domain variables

Full list added to the container:

```yaml
$ kubectl get pod blake-container-kind-worker2-g7nqn -oyaml | yq '.spec.containers[].env'
- name: DW_JOB_foo_local_storage
  value: /mnt/nnf/b696c436-fa56-4033-a26d-5063de8b84b8-0
- name: DW_PERSISTENT_foo_persistent_storage
  value: /mnt/nnf/b696c436-fa56-4033-a26d-5063de8b84b8-1
- name: NNF_CONTAINER_SUBDOMAIN
  value: blake-container
- name: NNF_CONTAINER_DOMAIN
  value: default.svc.cluster.local
- name: NNF_CONTAINER_HOSTNAMES
  value: kind-worker2 kind-worker3
```

Verified this by running a container with a script that attempts to use the env vars. This also verifies that the services is working with DNS:

```bash
sleep 3
for i in ${NNF_CONTAINER_HOSTNAMES}; do
    host="$i.$NNF_CONTAINER_SUBDOMAIN.$NNF_CONTAINER_DOMAIN"
    echo "host is $host, attempting nslookup..."
    nslookup $host
done

echo "local: $DW_JOB_foo_local_storage"
echo "persistent: $DW_PERSISTENT_foo_persistent_storage"

sleep 300

exit 0
```

Output:

```shell
$ kubectl logs blake-container-kind-worker2-w99bb
host is kind-worker2.blake-container.default.svc.cluster.local, attempting nslookup...
Server:		10.96.0.10
Address:	10.96.0.10:53

Name:	kind-worker2.blake-container.default.svc.cluster.local
Address: 10.244.3.12

host is kind-worker3.blake-container.default.svc.cluster.local, attempting nslookup...
Server:		10.96.0.10
Address:	10.96.0.10:53

Name:	kind-worker3.blake-container.default.svc.cluster.local
Address: 10.244.2.12

local: /mnt/nnf/205640b4-e699-4f2c-b837-de6e46f8d195-0
persistent: /mnt/nnf/205640b4-e699-4f2c-b837-de6e46f8d195-1
```

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>