### PR TITLE
Wait for Container pods to start before going PreRun:Ready

### DIFF
--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -884,7 +884,7 @@ func (r *NnfWorkflowReconciler) finishPreRunState(ctx context.Context, workflow 
 	case "persistentdw":
 		envName = "DW_PERSISTENT_" + dwArgs["name"]
 	case "container":
-		return r.checkIfContainerJobsStarted(ctx, workflow)
+		return r.waitForContainersToStart(ctx, workflow, index)
 
 	default:
 		return nil, nnfv1alpha1.NewWorkflowErrorf("Unexpected directive %v", dwArgs["command"])

--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -213,13 +213,14 @@ func (r *NnfWorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 
 		driverStatus.Status = dwsv1alpha1.StatusRunning
-		driverStatus.Message = ""
 		driverStatus.Error = ""
 
 		if result != nil {
 			log.Info("Start wait", result.info()...)
+			driverStatus.Message = result.reason
 			return result.Result, nil
 		}
+		driverStatus.Message = ""
 
 		log.Info("Start done")
 	}
@@ -251,13 +252,14 @@ func (r *NnfWorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 
 		driverStatus.Status = dwsv1alpha1.StatusRunning
-		driverStatus.Message = ""
 		driverStatus.Error = ""
 
 		if result != nil {
 			log.Info("Finish wait", result.info()...)
+			driverStatus.Message = result.reason
 			return result.Result, nil
 		}
+		driverStatus.Message = ""
 
 		log.Info("Finish done")
 
@@ -885,7 +887,6 @@ func (r *NnfWorkflowReconciler) finishPreRunState(ctx context.Context, workflow 
 		envName = "DW_PERSISTENT_" + dwArgs["name"]
 	case "container":
 		return r.waitForContainersToStart(ctx, workflow, index)
-
 	default:
 		return nil, nnfv1alpha1.NewWorkflowErrorf("Unexpected directive %v", dwArgs["command"])
 	}

--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -884,9 +884,8 @@ func (r *NnfWorkflowReconciler) finishPreRunState(ctx context.Context, workflow 
 	case "persistentdw":
 		envName = "DW_PERSISTENT_" + dwArgs["name"]
 	case "container":
-		// TODO: set env variables for containers; job names? ports? container storage args?
-		// TODO: Check to see that jobs and pods have started. Example: pod volumes aren't ready -
-		// we shouldn't go ready in that case
+		return r.checkIfContainerJobsStarted(ctx, workflow)
+
 	default:
 		return nil, nnfv1alpha1.NewWorkflowErrorf("Unexpected directive %v", dwArgs["command"])
 	}
@@ -912,7 +911,7 @@ func (r *NnfWorkflowReconciler) startPostRunState(ctx context.Context, workflow 
 
 		// TODO: Not sure if this requeue is working.
 		if !done {
-			return Requeue("waiting for container jobs to finish"), nil
+			return Requeue("pending container finish").after(2 * time.Second), nil
 		}
 
 		if !result {

--- a/controllers/nnf_workflow_controller_helpers.go
+++ b/controllers/nnf_workflow_controller_helpers.go
@@ -1236,7 +1236,7 @@ func (r *NnfWorkflowReconciler) waitForContainersToStart(ctx context.Context, wo
 
 		// Ready should be non-zero to indicate the a pod is running for the job
 		if job.Status.Ready == nil || *job.Status.Ready < 1 {
-			return Requeue("pending container start").after(2 * time.Second), nil
+			return Requeue(fmt.Sprintf("pending container start for job '%s'", job.Name)).after(2 * time.Second), nil
 		}
 	}
 


### PR DESCRIPTION
This change only lets PreRun go to Ready if the container jobs/pods have successfully started. A container could get stuck in the creation state (i.e. not running) for a number of reasons.

Tested by trying to mount a volume with a hostPath that doesn't exist, which causes the Containers to get stuck.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>