### PR TITLE
PostRun Ready Logic

### DIFF
--- a/api/v1alpha1/nnfcontainerprofile_types.go
+++ b/api/v1alpha1/nnfcontainerprofile_types.go
@@ -37,19 +37,13 @@ type NnfContainerProfileData struct {
 	// List of possible filesystems supported by this container profile
 	Storages []NnfContainerProfileStorage `json:"storages,omitempty"`
 
-	// TODO: This is a development option for now. This will most likely be renamed or removed in
-	// order to hide the k8s job implementation from the user.
-	// Specifies the duration in seconds relative to the startTime that the job may be continuously
-	// active before the system tries to terminate it; value must be positive integer. If a Job is
-	// suspended (at creation or through an update), this timer will effectively be stopped and
-	// reset when the Job is resumed again. +optional
-	ActiveDeadlineSeconds int64 `json:"activeDeadlineSeconds,omitempty"`
+	// Stop any containers after X seconds once a workflow has transitioned to PostRun. A value of 0 disables this behavior.
+	PostRunTimeoutSeconds int64 `json:"postRunTimeoutSeconds,omitempty"`
 
-	// TODO: This is a development option for now. This will most likely be renamed or removed in
-	// order to hide the k8s job implementation from the user.
-	// Specifies the number of retries before marking this job failed. Defaults to 6 by Kubernetes itself.
+	// Specifies the number of times a container will be retried upon a failure. A new pod is deployed on each retry.
+	// Defaults to 6 by kubernetes itself and must be set. A value of 0 disables retries.
 	// +kubebuilder:default:=6
-	BackoffLimit int32 `json:"backoffLimit"`
+	RetryLimit int32 `json:"retryLimit"`
 
 	// Template defines the containers that will be created from container profile
 	Template corev1.PodTemplateSpec `json:"template"`

--- a/config/crd/bases/nnf.cray.hpe.com_nnfcontainerprofiles.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfcontainerprofiles.yaml
@@ -29,29 +29,22 @@ spec:
           data:
             description: NnfContainerProfileSpec defines the desired state of NnfContainerProfile
             properties:
-              activeDeadlineSeconds:
-                description: 'TODO: This is a development option for now. This will
-                  most likely be renamed or removed in order to hide the k8s job implementation
-                  from the user. Specifies the duration in seconds relative to the
-                  startTime that the job may be continuously active before the system
-                  tries to terminate it; value must be positive integer. If a Job
-                  is suspended (at creation or through an update), this timer will
-                  effectively be stopped and reset when the Job is resumed again.
-                  +optional'
-                format: int64
-                type: integer
-              backoffLimit:
-                default: 6
-                description: 'TODO: This is a development option for now. This will
-                  most likely be renamed or removed in order to hide the k8s job implementation
-                  from the user. Specifies the number of retries before marking this
-                  job failed. Defaults to 6 by Kubernetes itself.'
-                format: int32
-                type: integer
               pinned:
                 default: false
                 description: Pinned is true if this instance is an immutable copy
                 type: boolean
+              postRunTimeoutSeconds:
+                description: Stop any containers after X seconds once a workflow has
+                  transitioned to PostRun. A value of 0 disables this behavior.
+                format: int64
+                type: integer
+              retryLimit:
+                default: 6
+                description: Specifies the number of times a container will be retried
+                  upon a failure. A new pod is deployed on each retry. Defaults to
+                  6 by kubernetes itself and must be set. A value of 0 disables retries.
+                format: int32
+                type: integer
               storages:
                 description: List of possible filesystems supported by this container
                   profile
@@ -7255,7 +7248,7 @@ spec:
                     type: object
                 type: object
             required:
-            - backoffLimit
+            - retryLimit
             - template
             type: object
           kind:

--- a/config/samples/nnf_v1alpha1_nnfcontainerprofile.yaml
+++ b/config/samples/nnf_v1alpha1_nnfcontainerprofile.yaml
@@ -4,7 +4,8 @@ metadata:
   name: nnfcontainerprofile-sample
   namespace: nnf-system
 data:
-  backoffLimit: 6
+  retryLimit: 6
+  # postRunTimeoutSeconds: 0
   storages:
     - name: DW_JOB_foo-local-storage
       optional: false
@@ -24,14 +25,6 @@ data:
               x=$(($RANDOM % 2))
               echo "exiting: $x"
               exit $x
-          # TODO get volumes working
-          # volumeMounts:
-          # - name: foo-local-storage
-          #   mountPath: /foo/local
-          # - name: foo-persistent-storage
-          #   mountPath: /foo/persistent
-          # - name: nnf-config
-          #   mountPath: /nnf/config
 ---
 apiVersion: nnf.cray.hpe.com/v1alpha1
 kind: NnfContainerProfile

--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -846,8 +846,8 @@ func (r *NnfWorkflowReconciler) startPreRunState(ctx context.Context, workflow *
 		}
 
 		// Set the teardown state to post run. If there is a copy_out or container directive that
-		// uses this storage instance, set the teardown state so NNF Access is preserved through
-		// DataOut.
+		// uses this storage instance, set the teardown state so NNF Access is preserved up until
+		// Teardown
 		teardownState := dwsv1alpha1.StatePostRun
 		if findCopyOutDirectiveIndexByName(workflow, dwArgs["name"]) >= 0 || findContainerDirectiveIndexByName(workflow, dwArgs["name"]) >= 0 {
 			teardownState = dwsv1alpha1.StateTeardown

--- a/controllers/nnf_workflow_controller_helpers.go
+++ b/controllers/nnf_workflow_controller_helpers.go
@@ -1054,7 +1054,6 @@ func (r *NnfWorkflowReconciler) createContainerJobs(ctx context.Context, workflo
 	labels[nnfv1alpha1.PinnedContainerProfileLabelName] = profile.GetName()
 	labels[nnfv1alpha1.PinnedContainerProfileLabelNameSpace] = profile.GetNamespace()
 	labels[nnfv1alpha1.DirectiveIndexLabel] = strconv.Itoa(index)
-	labels[nnfv1alpha1.DirectiveIndexLabel] = strconv.Itoa(index)
 	job.SetLabels(labels)
 
 	if err := ctrl.SetControllerReference(workflow, job, r.Scheme); err != nil {


### PR DESCRIPTION
PostRun will go `Ready:true` only if all jobs/pods have finished successfully. If containers are still running, PostRun requeues every 2 seconds until the jobs/containers have indicated a finish (pass or fail).

Once containers have finished, the results are checked. If all jobs are successful, then PostRun goes `Ready:true`. If not, then it stays `Ready:false`. Jobs are successful when a child pod has completed successfully (i.e. exited non-zero).

Additionally, a check now occurs when creating `NnfAccesses` for the rabbits to see if the `NnfAccess` is referenced by a container directive. If so, the `teardownState` is set to Teardown to ensure that mounts are present during the potential life of the containers through the PostRun state. This case only occurs during the PostRun state when a pod fails and a retry is attempted.

Additionally, `backoffLimit` and `activeDeadlineSeconds` in the NnfContainerProfile have been renamed to `retryLimit` and `postRunTimeoutSeconds` to make them more meaningful to the user.

`postRunTimeoutSeconds` is used to set a timeout on the jobs/pods once PostRun is started. When the timeout is hit, the job will stop the pods and the job will finish with a timeout failure condition.