### PR TITLE
github-151: Fix LVM issues with gfs2

### DIFF
--- a/config/samples/placeholder_nnfstorageprofile.yaml
+++ b/config/samples/placeholder_nnfstorageprofile.yaml
@@ -28,7 +28,7 @@ data:
         deactivate: --activate n $VG_NAME
         lockStart: --lock-start $VG_NAME
       vgRemove: $VG_NAME
-      lvCreate: --activate ys -l 100%VG --stripes $DEVICE_NUM --stripesize=32KiB --name $LV_NAME $VG_NAME
+      lvCreate: --activate ys --extents 100%VG --stripes $DEVICE_NUM --stripesize=32KiB --name $LV_NAME $VG_NAME
       lvRemove: $VG_NAME
       mkfs: -j2 -p $PROTOCOL -t $CLUSTER_NAME:$LOCK_SPACE $DEVICE
   xfsStorage:
@@ -39,7 +39,7 @@ data:
         activate: --activate y $VG_NAME
         deactivate: --activate n $VG_NAME
       vgRemove: $VG_NAME
-      lvCreate: -l 100%VG --stripes $DEVICE_NUM --stripesize=32KiB --name $LV_NAME $VG_NAME
+      lvCreate: --extents 100%VG --stripes $DEVICE_NUM --stripesize=32KiB --name $LV_NAME $VG_NAME
       lvRemove: $VG_NAME
       mkfs: $DEVICE
   rawStorage:
@@ -50,7 +50,7 @@ data:
         activate: --activate y $VG_NAME
         deactivate: --activate n $VG_NAME
       vgRemove: $VG_NAME
-      lvCreate: -l 100%VG --stripes $DEVICE_NUM --stripesize=32KiB --name $LV_NAME $VG_NAME
+      lvCreate: --extents 100%VG --stripes $DEVICE_NUM --stripesize=32KiB --name $LV_NAME $VG_NAME
       lvRemove: $VG_NAME
 
 

--- a/config/samples/placeholder_nnfstorageprofile.yaml
+++ b/config/samples/placeholder_nnfstorageprofile.yaml
@@ -28,7 +28,7 @@ data:
         deactivate: --activate n $VG_NAME
         lockStart: --lock-start $VG_NAME
       vgRemove: $VG_NAME
-      lvCreate: -l 100%VG --stripes $DEVICE_NUM --stripesize=32KiB --name $LV_NAME $VG_NAME
+      lvCreate: --activate ys -l 100%VG --stripes $DEVICE_NUM --stripesize=32KiB --name $LV_NAME $VG_NAME
       lvRemove: $VG_NAME
       mkfs: -j2 -p $PROTOCOL -t $CLUSTER_NAME:$LOCK_SPACE $DEVICE
   xfsStorage:


### PR DESCRIPTION
This commit fixes two issues that were affecting gfs2 file systems:
 - The dlm lock manager was failing to lock because the VG name was too long
 - The lvcreate command needs an "--activate ys" to active a shared volume