### PR TITLE
Prepare container profiles for int-test

### DIFF
--- a/config/examples/nnf_v1alpha1_nnfcontainerprofiles.yaml
+++ b/config/examples/nnf_v1alpha1_nnfcontainerprofiles.yaml
@@ -1,15 +1,33 @@
 apiVersion: nnf.cray.hpe.com/v1alpha1
 kind: NnfContainerProfile
 metadata:
-  name: randomly-fail
+  name: example-success
 data:
-  retryLimit: 6
-  # postRunTimeoutSeconds: 0
   storages:
     - name: DW_JOB_foo-local-storage
       optional: false
     - name: DW_PERSISTENT_foo-persistent-storage
+      optional: true
+  template:
+    spec:
+      containers:
+      - name: forever
+        image: alpine:latest
+        command:
+        - /bin/sh
+        - -c
+        - "sleep 15 && exit 0"
+---
+apiVersion: nnf.cray.hpe.com/v1alpha1
+kind: NnfContainerProfile
+metadata:
+  name: example-randomly-fail
+data:
+  storages:
+    - name: DW_JOB_foo-local-storage
       optional: false
+    - name: DW_PERSISTENT_foo-persistent-storage
+      optional: true
   template:
     spec:
       containers:
@@ -28,7 +46,7 @@ data:
 apiVersion: nnf.cray.hpe.com/v1alpha1
 kind: NnfContainerProfile
 metadata:
-  name: forever
+  name: example-forever
 data:
   template:
     spec:

--- a/config/examples/nnf_v1alpha1_nnfcontainerprofiles.yaml
+++ b/config/examples/nnf_v1alpha1_nnfcontainerprofiles.yaml
@@ -11,7 +11,7 @@ data:
   template:
     spec:
       containers:
-      - name: forever
+      - name: example-success
         image: alpine:latest
         command:
         - /bin/sh
@@ -31,7 +31,7 @@ data:
   template:
     spec:
       containers:
-        - name: foo
+        - name: example-randomly-fail
           image: alpine:latest
           command:
             - /bin/sh
@@ -51,7 +51,7 @@ data:
   template:
     spec:
       containers:
-      - name: forever
+      - name: example-forever
         image: alpine:latest
         command:
         - /bin/sh

--- a/config/samples/nnf_v1alpha1_nnfcontainerprofile.yaml
+++ b/config/samples/nnf_v1alpha1_nnfcontainerprofile.yaml
@@ -4,13 +4,30 @@ metadata:
   name: nnfcontainerprofile-sample
   namespace: nnf-system
 data:
+  # Specifies the number of times a container will be retried upon a failure. A
+  # new pod is deployed on each retry. Defaults to 6 by kubernetes itself and
+  # must be set. A value of 0 disables retries.
   retryLimit: 6
-  # postRunTimeoutSeconds: 0
+
+  # Stop any containers after X seconds once a workflow has transitioned to
+  # PostRun. A value of 0 disables this behavior.
+  postRunTimeoutSeconds: 0
+
+  # List of possible filesystems supported by this container profile. These
+  # storages are mounted inside of the container. Any non-optional storage must
+  # be supplied with the container directive as an argument and must reference
+  # a valid jobdw or persistentdw directive's name.
+  #
+  # Example:
+  #   DW jobdw name=my-gfs2 type=gfs2 capacity=50GB
+  #   DW container name=my-container profile=nnfcontainerprofile-sample DW_JOB_foo-local-storage=my-gfs2
   storages:
     - name: DW_JOB_foo-local-storage
       optional: false
     - name: DW_PERSISTENT_foo-persistent-storage
-      optional: false
+      optional: true
+
+  # Template defines the containers that will be created from container profile.
   template:
     spec:
       containers:
@@ -25,19 +42,3 @@ data:
               x=$(($RANDOM % 2))
               echo "exiting: $x"
               exit $x
----
-apiVersion: nnf.cray.hpe.com/v1alpha1
-kind: NnfContainerProfile
-metadata:
-  name: forever
-  namespace: nnf-system
-data:
-  template:
-    spec:
-      containers:
-      - name: forever
-        image: alpine:latest
-        command:
-        - /bin/sh
-        - -c
-        - "while true; do date && sleep 5; done"

--- a/config/samples/nnf_v1alpha1_nnfcontainerprofile.yaml
+++ b/config/samples/nnf_v1alpha1_nnfcontainerprofile.yaml
@@ -1,7 +1,7 @@
 apiVersion: nnf.cray.hpe.com/v1alpha1
 kind: NnfContainerProfile
 metadata:
-  name: nnfcontainerprofile-sample
+  name: sample-nnfcontainerprofile
   namespace: nnf-system
 data:
   # Specifies the number of times a container will be retried upon a failure. A
@@ -31,7 +31,7 @@ data:
   template:
     spec:
       containers:
-        - name: foo
+        - name: sample-nnfcontainerprofile
           image: alpine:latest
           command:
             - /bin/sh

--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -1078,9 +1078,6 @@ func (r *NnfWorkflowReconciler) finishTeardownState(ctx context.Context, workflo
 		if err != nil {
 			return nil, nnfv1alpha1.NewWorkflowError("Could not remove persistent storage reference").WithError(err)
 		}
-	case "container":
-		// TODO delete pinned profile?
-		// TODO: remove service, jobs, pods
 	default:
 	}
 


### PR DESCRIPTION
A few changes to aid in running int-test at containers. Updated the sample profile with some documentation. Removed the container empty block from teardown.

This will be the last PR against the feature branch.

I used these changes to write container tests for int-test. Those changes will be coming after I merge the feature branch.