### PR TITLE
Containers: Check for XFS/Raw filesystems

### DIFF
--- a/controllers/nnf_workflow_controller_helpers.go
+++ b/controllers/nnf_workflow_controller_helpers.go
@@ -256,8 +256,8 @@ func (r *NnfWorkflowReconciler) validateContainerDirective(ctx context.Context, 
 			return args["type"]
 		}
 
-		if t := getDirectiveFsType(idx); strings.ToLower(t) == "raw" || strings.ToLower(t) == "xfs" {
-			return fmt.Errorf("containers can not be used with raw or xfs filesystems")
+		if t := getDirectiveFsType(idx); strings.ToLower(t) != "lustre" && strings.ToLower(t) != "gfs2" {
+			return fmt.Errorf("unsupported container filesystem: %s", t)
 		}
 
 		return nil


### PR DESCRIPTION
These filesystems can only be mounted once - they are not supported for
containers.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
