### PR TITLE
Containers: Add non-root support

### DIFF
--- a/controllers/nnf_workflow_controller_helpers.go
+++ b/controllers/nnf_workflow_controller_helpers.go
@@ -1102,6 +1102,20 @@ func (r *NnfWorkflowReconciler) createContainerJobs(ctx context.Context, workflo
 		},
 	}
 
+	// Add non-root permissions from the workflow's user/group ID
+	if podSpec.SecurityContext == nil {
+		podSpec.SecurityContext = &corev1.PodSecurityContext{}
+	}
+	uid := int64(workflow.Spec.UserID)
+	gid := int64(workflow.Spec.GroupID)
+	podSpec.SecurityContext.RunAsUser = &uid
+	podSpec.SecurityContext.RunAsGroup = &gid
+	nonRoot := false
+	if uid != 0 {
+		nonRoot = true
+	}
+	podSpec.SecurityContext.RunAsNonRoot = &nonRoot
+
 	// Get the volumes to mount into the containers
 	volumes, err := r.getContainerVolumes(ctx, workflow, dwArgs)
 	if err != nil {


### PR DESCRIPTION
This uses SecurityContext and inherits the Workflow's user/group ID.