### PR TITLE
RABSW-1150: Add ServiceAccount for NNF fencing agent

### DIFF
--- a/config/rbac/fencing_agent_role.yaml
+++ b/config/rbac/fencing_agent_role.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: fencing-agent-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - nnf.cray.hpe.com
+  resources:
+  - nnfnodes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - nnf.cray.hpe.com
+  resources:
+  - nnfnodes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - nnf.cray.hpe.com
+  resources:
+  - nnfnodes/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/config/rbac/fencing_agent_role_binding.yaml
+++ b/config/rbac/fencing_agent_role_binding.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fencing-agent-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fencing-agent-role
+subjects:
+- kind: ServiceAccount
+  name: fencing-agent
+  namespace: system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: fencing-agent-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: fencing-agent-role
+subjects:
+- kind: ServiceAccount
+  name: fencing-agent
+  namespace: system

--- a/config/rbac/fencing_agent_service_account.yaml
+++ b/config/rbac/fencing_agent_service_account.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fencing-agent
+  namespace: system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fencing-agent
+  namespace: system
+  annotations:
+    kubernetes.io/service-account.name: fencing-agent
+    kubernetes.io/service-account.namespace: system
+type: kubernetes.io/service-account-token

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -7,6 +7,9 @@ resources:
 - service_account.yaml
 - role.yaml
 - role_binding.yaml
+- fencing_agent_service_account.yaml
+- fencing_agent_role.yaml
+- fencing_agent_role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 # Comment the following 4 lines if you want to disable


### PR DESCRIPTION
Create a ServiceAccount for the NNF fencing agent that allows read and write access to Node and NnfNode resources.