### PR TITLE
RABSW-1159: Update deploy.sh to look at the deployment ready count

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -29,8 +29,8 @@ OVERLAY=$4
 if [[ $CMD == 'deploy' ]]; then
     echo "Waiting for the dws webhook to become ready..."
     while :; do
-        ready=$(kubectl get pods -n dws-operator-system -l control-plane=webhook --no-headers | awk '{print $2}')
-        [[ $ready == "1/1" ]] && break
+        ready=$(kubectl get deployments -n dws-operator-system dws-operator-webhook -o json | jq -Mr '.status.readyReplicas')
+        [[ $ready -ge 1 ]] && break
         sleep 1
     done
 


### PR DESCRIPTION
The deploy.sh was looking for a "1/1" ready field for the dws webhook. There may not be enough worker nodes on the system to run all 3 DWS webhooks, so some of the webhook pods may not be ready. If one of these pods shows up first in the pod list, then the deploy.sh script will hang forever. Instead, look at the number of ready replicas in the dws webhook deployment to be one or more.