### PR TITLE
RABSW-1158: Update nnf-ec and add timeout environment variable

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,8 +44,8 @@ spec:
           # use this node to create storage during setup phase
           - name: RABBIT_NODE
             value: "0"
-          - name: NNF_EC_COMMAND_TIMEOUT
-            value: "90s"
+          - name: NNF_EC_COMMAND_TIMEOUT_SECONDS
+            value: "90"
           - name: NNF_NODE_NAME
             valueFrom:
               fieldRef:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,6 +44,8 @@ spec:
           # use this node to create storage during setup phase
           - name: RABBIT_NODE
             value: "0"
+          - name: NNF_EC_COMMAND_TIMEOUT
+            value: "90s"
           - name: NNF_NODE_NAME
             valueFrom:
               fieldRef:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/HewlettPackard/dws v0.0.0-20230410193930-8fd6fbeff7f8
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20230322153812-315a443f315b
-	github.com/NearNodeFlash/nnf-ec v0.0.0-20230322150739-a8190e4ef79d
+	github.com/NearNodeFlash/nnf-ec v0.0.0-20230425135615-c60e6e460894
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/uuid v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/HewlettPackard/dws v0.0.0-20230410193930-8fd6fbeff7f8
-	github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20230322153812-315a443f315b
+	github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20230426150127-b7cba32758e5
 	github.com/NearNodeFlash/nnf-ec v0.0.0-20230427164720-dc73727a986f
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.3

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/HewlettPackard/dws v0.0.0-20230410193930-8fd6fbeff7f8
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20230322153812-315a443f315b
-	github.com/NearNodeFlash/nnf-ec v0.0.0-20230425135615-c60e6e460894
+	github.com/NearNodeFlash/nnf-ec v0.0.0-20230426152614-be78544c8f4a
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/uuid v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/HewlettPackard/dws v0.0.0-20230410193930-8fd6fbeff7f8
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20230322153812-315a443f315b
-	github.com/NearNodeFlash/nnf-ec v0.0.0-20230426152614-be78544c8f4a
+	github.com/NearNodeFlash/nnf-ec v0.0.0-20230427164720-dc73727a986f
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/HewlettPackard/dws v0.0.0-20230410193930-8fd6fbeff7f8 h1:xfn+nvgB6eNL
 github.com/HewlettPackard/dws v0.0.0-20230410193930-8fd6fbeff7f8/go.mod h1:LBdoJFhiqcjzqpnxLqCVzDyUrw1ncoEEhho7ni7nuxI=
 github.com/HewlettPackard/structex v1.0.4 h1:RVTdN5FWhDWr1IkjllU8wxuLjISo4gr6u5ryZpzyHcA=
 github.com/HewlettPackard/structex v1.0.4/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
-github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20230322153812-315a443f315b h1:vd/0mrYb/PmV+D9zLFVkeYRTtv0oeaXOfMNQflZ1WvI=
-github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20230322153812-315a443f315b/go.mod h1:jLFbZp8S+ByWknnZzpkGQUTp+RQNYi7RSwTD0xDhz84=
+github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20230426150127-b7cba32758e5 h1:Uo9kgHrI/ZfWfSlULuAl46FEMTDXXJeAsSqMS0d+oJI=
+github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20230426150127-b7cba32758e5/go.mod h1:jLFbZp8S+ByWknnZzpkGQUTp+RQNYi7RSwTD0xDhz84=
 github.com/NearNodeFlash/nnf-ec v0.0.0-20230427164720-dc73727a986f h1:kJetY6ACr44dAKEbJkXCwDdbnqqx4KKx63cjXPCHktQ=
 github.com/NearNodeFlash/nnf-ec v0.0.0-20230427164720-dc73727a986f/go.mod h1:11Ol46sAWdqlj3WmIFTzKO+UxQX3lvWBqpe6yaiMEIg=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/HewlettPackard/structex v1.0.4 h1:RVTdN5FWhDWr1IkjllU8wxuLjISo4gr6u5r
 github.com/HewlettPackard/structex v1.0.4/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20230322153812-315a443f315b h1:vd/0mrYb/PmV+D9zLFVkeYRTtv0oeaXOfMNQflZ1WvI=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20230322153812-315a443f315b/go.mod h1:jLFbZp8S+ByWknnZzpkGQUTp+RQNYi7RSwTD0xDhz84=
-github.com/NearNodeFlash/nnf-ec v0.0.0-20230322150739-a8190e4ef79d h1:Fq4ev963g4VkQy5S2QTq4R1ZBw/e5Qpv1uMCg3QcWRE=
-github.com/NearNodeFlash/nnf-ec v0.0.0-20230322150739-a8190e4ef79d/go.mod h1:11Ol46sAWdqlj3WmIFTzKO+UxQX3lvWBqpe6yaiMEIg=
+github.com/NearNodeFlash/nnf-ec v0.0.0-20230425135615-c60e6e460894 h1:qDCrqqAaM/d+wiNitTBxl/VKOYVRSTo7lAsmCGD7dEI=
+github.com/NearNodeFlash/nnf-ec v0.0.0-20230425135615-c60e6e460894/go.mod h1:11Ol46sAWdqlj3WmIFTzKO+UxQX3lvWBqpe6yaiMEIg=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/HewlettPackard/structex v1.0.4 h1:RVTdN5FWhDWr1IkjllU8wxuLjISo4gr6u5r
 github.com/HewlettPackard/structex v1.0.4/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20230322153812-315a443f315b h1:vd/0mrYb/PmV+D9zLFVkeYRTtv0oeaXOfMNQflZ1WvI=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20230322153812-315a443f315b/go.mod h1:jLFbZp8S+ByWknnZzpkGQUTp+RQNYi7RSwTD0xDhz84=
-github.com/NearNodeFlash/nnf-ec v0.0.0-20230425135615-c60e6e460894 h1:qDCrqqAaM/d+wiNitTBxl/VKOYVRSTo7lAsmCGD7dEI=
-github.com/NearNodeFlash/nnf-ec v0.0.0-20230425135615-c60e6e460894/go.mod h1:11Ol46sAWdqlj3WmIFTzKO+UxQX3lvWBqpe6yaiMEIg=
+github.com/NearNodeFlash/nnf-ec v0.0.0-20230426152614-be78544c8f4a h1:vmTKewxuyrbr92mtFZFdA6uZhzECwCZDTSxV5qUcD84=
+github.com/NearNodeFlash/nnf-ec v0.0.0-20230426152614-be78544c8f4a/go.mod h1:11Ol46sAWdqlj3WmIFTzKO+UxQX3lvWBqpe6yaiMEIg=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/HewlettPackard/structex v1.0.4 h1:RVTdN5FWhDWr1IkjllU8wxuLjISo4gr6u5r
 github.com/HewlettPackard/structex v1.0.4/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20230322153812-315a443f315b h1:vd/0mrYb/PmV+D9zLFVkeYRTtv0oeaXOfMNQflZ1WvI=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20230322153812-315a443f315b/go.mod h1:jLFbZp8S+ByWknnZzpkGQUTp+RQNYi7RSwTD0xDhz84=
-github.com/NearNodeFlash/nnf-ec v0.0.0-20230426152614-be78544c8f4a h1:vmTKewxuyrbr92mtFZFdA6uZhzECwCZDTSxV5qUcD84=
-github.com/NearNodeFlash/nnf-ec v0.0.0-20230426152614-be78544c8f4a/go.mod h1:11Ol46sAWdqlj3WmIFTzKO+UxQX3lvWBqpe6yaiMEIg=
+github.com/NearNodeFlash/nnf-ec v0.0.0-20230427164720-dc73727a986f h1:kJetY6ACr44dAKEbJkXCwDdbnqqx4KKx63cjXPCHktQ=
+github.com/NearNodeFlash/nnf-ec v0.0.0-20230427164720-dc73727a986f/go.mod h1:11Ol46sAWdqlj3WmIFTzKO+UxQX3lvWBqpe6yaiMEIg=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-server/file_system_api.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-server/file_system_api.go
@@ -213,7 +213,7 @@ func (*FileSystem) run(cmd string) ([]byte, error) {
 		shellCmd.Stderr = &fsError.stderr
 		err := shellCmd.Run()
 		if err != nil {
-			// Command failed, return stderr
+			// Command failed, return FileSystemError with stdout and stderr
 			return nil, &fsError
 		}
 		// Command success, return stdout

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-server/file_system_api.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-server/file_system_api.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
+	"strconv"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -191,17 +192,17 @@ func (*FileSystem) run(cmd string) ([]byte, error) {
 	return logging.Cli.Trace2(logging.LogToStdout, cmd, func(cmd string) ([]byte, error) {
 
 		ctx := context.Background()
-		timeoutString, found := os.LookupEnv("NNF_EC_COMMAND_TIMEOUT")
+		timeoutString, found := os.LookupEnv("NNF_EC_COMMAND_TIMEOUT_SECONDS")
 		if found {
 			var cancel context.CancelFunc
 
-			timeout, err := time.ParseDuration(timeoutString)
+			timeout, err := strconv.Atoi(timeoutString)
 			if err != nil {
 				return nil, err
 			}
 
 			if timeout > 0 {
-				ctx, cancel = context.WithTimeout(context.Background(), timeout)
+				ctx, cancel = context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 				defer cancel()
 			}
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -15,7 +15,7 @@ github.com/HewlettPackard/structex
 ## explicit; go 1.19
 github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1
 github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
-# github.com/NearNodeFlash/nnf-ec v0.0.0-20230322150739-a8190e4ef79d
+# github.com/NearNodeFlash/nnf-ec v0.0.0-20230425135615-c60e6e460894
 ## explicit; go 1.18
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/switchtec

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -15,7 +15,7 @@ github.com/HewlettPackard/structex
 ## explicit; go 1.19
 github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1
 github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
-# github.com/NearNodeFlash/nnf-ec v0.0.0-20230426152614-be78544c8f4a
+# github.com/NearNodeFlash/nnf-ec v0.0.0-20230427164720-dc73727a986f
 ## explicit; go 1.18
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/switchtec

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -15,7 +15,7 @@ github.com/HewlettPackard/structex
 ## explicit; go 1.19
 github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1
 github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
-# github.com/NearNodeFlash/nnf-ec v0.0.0-20230425135615-c60e6e460894
+# github.com/NearNodeFlash/nnf-ec v0.0.0-20230426152614-be78544c8f4a
 ## explicit; go 1.18
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/switchtec


### PR DESCRIPTION
Make use of the new timeout in nnf-ec when running commands. Timeout commands after 90 seconds and return an error.