### PR TITLE
Restrict the name of the storage

### DIFF
--- a/config/dws/nnf-ruleset.yaml
+++ b/config/dws/nnf-ruleset.yaml
@@ -20,13 +20,13 @@ spec:
         isValueRequired: true
       - key: "^name$"
         type: "string"
-        pattern: "^[A-Za-z][A-Za-z0-9-]+$"
+        pattern: "^[a-z][a-z0-9-]+$"
         isRequired: true
         isValueRequired: true
         uniqueWithin: "jobdw_name"
       - key: "^profile$"
         type: "string"
-        pattern: "^[A-Za-z][A-Za-z0-9-]+$"
+        pattern: "^[a-z][a-z0-9-]+$"
         isRequired: false
         isValueRequired: true
   - command: "create_persistent"
@@ -44,13 +44,13 @@ spec:
         isValueRequired: true
       - key: "^name$"
         type: "string"
-        pattern: "^[A-Za-z][A-Za-z0-9-]+$"
+        pattern: "^[a-z][a-z0-9-]+$"
         isRequired: true
         isValueRequired: true
         uniqueWithin: "create_persistent_name"
       - key: "^profile$"
         type: "string"
-        pattern: "^[A-Za-z][A-Za-z0-9-]+$"
+        pattern: "^[a-z][a-z0-9-]+$"
         isRequired: false
         isValueRequired: true
   - command: "destroy_persistent"
@@ -58,7 +58,7 @@ spec:
     ruleDefs:
       - key: "^name$"
         type: "string"
-        pattern: "^[A-Za-z][A-Za-z0-9-]+$"
+        pattern: "^[a-z][a-z0-9-]+$"
         isRequired: true
         isValueRequired: true
         uniqueWithin: "destroy_persistent_name"
@@ -67,7 +67,7 @@ spec:
     ruleDefs:
       - key: "^name$"
         type: "string"
-        pattern: "^[A-Za-z][A-Za-z0-9-]+$"
+        pattern: "^[a-z][a-z0-9-]+$"
         isRequired: true
         isValueRequired: true
   - command: "copy_in"
@@ -97,13 +97,15 @@ spec:
     ruleDefs:
       - key: "^name$"
         type: "string"
+        pattern: "^[a-z][a-z0-9-]+$"
         isRequired: true
         isValueRequired: true
       - key: "^profile$"
         type: "string"
+        pattern: "^[a-z][a-z0-9-]+$"
         isRequired: true
         isValueRequired: true
-      - key: '^(DW_JOB_|DW_PERSISTENT_)[A-Za-z][A-Za-z0-9-]+$'
+      - key: '^(DW_JOB_|DW_PERSISTENT_)[a-z][a-z0-9_]+$'
         type: "string"
         isRequired: false
         isValueRequired: true

--- a/config/examples/nnf_v1alpha1_nnfcontainerprofiles.yaml
+++ b/config/examples/nnf_v1alpha1_nnfcontainerprofiles.yaml
@@ -5,9 +5,9 @@ metadata:
 data:
   retryLimit: 6
   storages:
-    - name: DW_JOB_foo-local-storage
+    - name: DW_JOB_foo_local_storage
       optional: false
-    - name: DW_PERSISTENT_foo-persistent-storage
+    - name: DW_PERSISTENT_foo_persistent_storage
       optional: true
   spec:
     containers:
@@ -25,9 +25,9 @@ metadata:
 data:
   retryLimit: 6
   storages:
-    - name: DW_JOB_foo-local-storage
+    - name: DW_JOB_foo_local_storage
       optional: false
-    - name: DW_PERSISTENT_foo-persistent-storage
+    - name: DW_PERSISTENT_foo_persistent_storage
       optional: true
   spec:
     containers:
@@ -50,9 +50,9 @@ metadata:
 data:
   retryLimit: 6
   storages:
-    - name: DW_JOB_foo-local-storage
+    - name: DW_JOB_foo_local_storage
       optional: false
-    - name: DW_PERSISTENT_foo-persistent-storage
+    - name: DW_PERSISTENT_foo_persistent_storage
       optional: true
   spec:
     containers:
@@ -70,9 +70,9 @@ metadata:
 data:
   retryLimit: 6
   storages:
-    - name: DW_JOB_foo-local-storage
+    - name: DW_JOB_foo_local_storage
       optional: false
-    - name: DW_PERSISTENT_foo-persistent-storage
+    - name: DW_PERSISTENT_foo_persistent_storage
       optional: true
   mpiSpec:
     runPolicy:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -17,4 +17,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/nearnodeflash/nnf-sos
-  newTag: 8d1d7ba8655c7cee86d54a036deffe931038ebdd 
+  newTag: 53297ed0c2ce52ddc2113671b3dd3c79f5894dce

--- a/config/samples/nnf_v1alpha1_nnfcontainerprofile.yaml
+++ b/config/samples/nnf_v1alpha1_nnfcontainerprofile.yaml
@@ -20,11 +20,11 @@ data:
   #
   # Example:
   #   DW jobdw name=my-gfs2 type=gfs2 capacity=50GB
-  #   DW container name=my-container profile=nnfcontainerprofile-sample DW_JOB_foo-local-storage=my-gfs2
+  #   DW container name=my-container profile=nnfcontainerprofile-sample DW_JOB_foo_local_storage=my-gfs2
   storages:
-    - name: DW_JOB_foo-local-storage
+    - name: DW_JOB_foo_local_storage
       optional: false
-    - name: DW_PERSISTENT_foo-persistent-storage
+    - name: DW_PERSISTENT_foo_persistent_storage
       optional: true
 
   # Template defines the containers that will be created from container profile.

--- a/controllers/integration_test.go
+++ b/controllers/integration_test.go
@@ -1102,7 +1102,7 @@ var _ = Describe("Integration Test", func() {
 			BeforeEach(func() {
 				workflow.Spec.DWDirectives = []string{
 					"#DW jobdw name=test-dm-0 type=gfs2 capacity=1GiB",
-					"#DW copy_in source=/lus/maui/file destination=$DW_JOB_test-dm-0/file",
+					"#DW copy_in source=/lus/maui/file destination=$DW_JOB_test_dm_0/file",
 				}
 			})
 
@@ -1125,7 +1125,7 @@ var _ = Describe("Integration Test", func() {
 			BeforeEach(func() {
 				workflow.Spec.DWDirectives = []string{
 					"#DW jobdw name=test-dm-0 type=gfs2 capacity=1GiB",
-					"#DW copy_out source=$DW_JOB_test-dm-0/file destination=/lus/maui/file",
+					"#DW copy_out source=$DW_JOB_test_dm_0/file destination=/lus/maui/file",
 				}
 			})
 
@@ -1152,8 +1152,8 @@ var _ = Describe("Integration Test", func() {
 			BeforeEach(func() {
 				workflow.Spec.DWDirectives = []string{
 					"#DW jobdw name=test-dm-0 type=gfs2 capacity=1GiB",
-					"#DW copy_in source=/lus/maui/file destination=$DW_JOB_test-dm-0/file",
-					"#DW copy_out source=$DW_JOB_test-dm-0/file destination=/lus/maui/file",
+					"#DW copy_in source=/lus/maui/file destination=$DW_JOB_test_dm_0/file",
+					"#DW copy_out source=$DW_JOB_test_dm_0/file destination=/lus/maui/file",
 				}
 			})
 
@@ -1653,7 +1653,7 @@ var _ = Describe("Integration Test", func() {
 			})
 			BeforeEach(func() {
 				directives = []string{
-					"#DW copy_in source=/lus/maui/my-file.in destination=$DW_JOB_notThere/my-file.out",
+					"#DW copy_in source=/lus/maui/my-file.in destination=$DW_JOB_not_there/my-file.out",
 				}
 			})
 

--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -869,9 +869,9 @@ func (r *NnfWorkflowReconciler) finishPreRunState(ctx context.Context, workflow 
 	envName := ""
 	switch dwArgs["command"] {
 	case "jobdw":
-		envName = "DW_JOB_" + dwArgs["name"]
+		envName = "DW_JOB_" + strings.ReplaceAll(dwArgs["name"], "-", "_")
 	case "persistentdw":
-		envName = "DW_PERSISTENT_" + dwArgs["name"]
+		envName = "DW_PERSISTENT_" + strings.ReplaceAll(dwArgs["name"], "-", "_")
 	case "container":
 		return r.waitForContainersToStart(ctx, workflow, index)
 	default:

--- a/controllers/nnf_workflow_controller_helpers.go
+++ b/controllers/nnf_workflow_controller_helpers.go
@@ -420,8 +420,8 @@ func (r *NnfWorkflowReconciler) generateDirectiveBreakdown(ctx context.Context, 
 	// #DW jobdw name=my-gfs2 type=gfs2 capacity=1TB
 	// #DW persistentdw name=some-lustre
 	// #DW container name=my-foo profile=foo
-	//     DW_JOB_foo-local-storage=my-gfs2
-	//     DW_PERSISTENT_foo-persistent-storage=some-lustre
+	//     DW_JOB_foo_local_storage=my-gfs2
+	//     DW_PERSISTENT_foo_persistent_storage=some-lustre
 
 	// #DW commands that require a dwDirectiveBreakdown
 	breakDownCommands := []string{

--- a/controllers/nnf_workflow_controller_helpers.go
+++ b/controllers/nnf_workflow_controller_helpers.go
@@ -810,22 +810,25 @@ func findContainerDirectiveIndexByName(workflow *dwsv1alpha1.Workflow, name stri
 	return -1
 }
 
-// Returns a <name, path> pair for the given staging argument (typically source or destination)
-// i.e. $DW_JOB_my-file-system-name/path/to/a/file into "my-file-system-name" and "/path/to/a/file"
+// Returns a <name, path> pair for the given staging argument (typically source or destination).
+// Convert underscores in the variable name to dashs in the FS name.
+// i.e. $DW_JOB_my_file_system_name/path/to/a/file into:
+//   - "my-file-system-name"
+//   - "/path/to/a/file"
 func splitStagingArgumentIntoNameAndPath(arg string) (string, string) {
 
-	var name = ""
+	var varname = ""
 	if strings.HasPrefix(arg, "$DW_JOB_") {
-		name = strings.SplitN(strings.Replace(arg, "$DW_JOB_", "", 1), "/", 2)[0]
+		varname = strings.SplitN(strings.Replace(arg, "$DW_JOB_", "", 1), "/", 2)[0]
 	} else if strings.HasPrefix(arg, "$DW_PERSISTENT_") {
-		name = strings.SplitN(strings.Replace(arg, "$DW_PERSISTENT_", "", 1), "/", 2)[0]
+		varname = strings.SplitN(strings.Replace(arg, "$DW_PERSISTENT_", "", 1), "/", 2)[0]
 	}
+	name := strings.ReplaceAll(varname, "_", "-")
 	var path = "/"
 	if strings.Count(arg, "/") >= 1 {
 		path = "/" + strings.SplitN(arg, "/", 2)[1]
 	}
 	return name, path
-
 }
 
 // indexedResourceName returns a name for a workflow child resource based on the index of the #DW directive

--- a/controllers/nnf_workflow_controller_test.go
+++ b/controllers/nnf_workflow_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -493,7 +494,7 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 			BeforeEach(func() {
 				workflow.Spec.DWDirectives = []string{
 					fmt.Sprintf("#DW persistentdw name=%s", persistentStorageName),
-					fmt.Sprintf("#DW copy_in source=/lus/maui/my-file.in destination=$DW_PERSISTENT_%s/my-persistent-file.out", persistentStorageName),
+					fmt.Sprintf("#DW copy_in source=/lus/maui/my-file.in destination=$DW_PERSISTENT_%s/my-persistent-file.out", strings.ReplaceAll(persistentStorageName, "-", "_")),
 				}
 
 				createPersistentStorageInstance(persistentStorageName)

--- a/controllers/nnf_workflow_controller_test.go
+++ b/controllers/nnf_workflow_controller_test.go
@@ -187,7 +187,7 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 	When("Negative tests for storage profiles", func() {
 		It("Fails to achieve proposal state when the named profile cannot be found", func() {
 			workflow.Spec.DWDirectives = []string{
-				"#DW jobdw name=test profile=noneSuch type=lustre capacity=1GiB",
+				"#DW jobdw name=test profile=none-such type=lustre capacity=1GiB",
 			}
 
 			Expect(k8sClient.Create(context.TODO(), workflow)).To(Succeed(), "create workflow")
@@ -1082,8 +1082,8 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 					"#DW jobdw name=container-storage type=gfs2 capacity=1GB",
 					"#DW persistentdw name=" + persistentStorageName,
 					fmt.Sprintf("#DW container name=container profile=%s "+
-						"DW_JOB_foo-local-storage=container-storage "+
-						"DW_PERSISTENT_foo-persistent-storage=container-persistent",
+						"DW_JOB_foo_local_storage=container-storage "+
+						"DW_PERSISTENT_foo_persistent_storage=container-persistent",
 						containerProfile.Name),
 				}
 				Expect(k8sClient.Create(context.TODO(), workflow)).Should(Succeed())
@@ -1098,8 +1098,8 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 		Context("when an optional storage in the container profile is not present in the container arguments", func() {
 			BeforeEach(func() {
 				containerProfileStorages = []nnfv1alpha1.NnfContainerProfileStorage{
-					{Name: "DW_JOB_foo-local-storage", Optional: false},
-					{Name: "DW_PERSISTENT_foo-persistent-storage", Optional: true},
+					{Name: "DW_JOB_foo_local_storage", Optional: false},
+					{Name: "DW_PERSISTENT_foo_persistent_storage", Optional: true},
 				}
 			})
 
@@ -1107,7 +1107,7 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 				workflow.Spec.DWDirectives = []string{
 					"#DW jobdw name=container-storage type=gfs2 capacity=1GB",
 					fmt.Sprintf("#DW container name=container profile=%s "+
-						"DW_JOB_foo-local-storage=container-storage ",
+						"DW_JOB_foo_local_storage=container-storage ",
 						containerProfile.Name),
 				}
 				Expect(k8sClient.Create(context.TODO(), workflow)).Should(Succeed())
@@ -1125,8 +1125,8 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 					// persistent storage is missing
 					"#DW jobdw name=container-storage type=gfs2 capacity=1GB",
 					fmt.Sprintf("#DW container name=container profile=%s "+
-						"DW_JOB_foo-local-storage=container-storage "+
-						"DW_PERSISTENT_foo-persistent-storage=container-persistent",
+						"DW_JOB_foo_local_storage=container-storage "+
+						"DW_PERSISTENT_foo_persistent_storage=container-persistent",
 						containerProfile.Name),
 				}
 				Expect(k8sClient.Create(context.TODO(), workflow)).Should(Succeed())
@@ -1145,7 +1145,7 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 					"#DW persistentdw name=" + persistentStorageName,
 					fmt.Sprintf("#DW container name=container profile=%s "+
 						// local storage is missing
-						"DW_PERSISTENT_foo-persistent-storage=container-persistent",
+						"DW_PERSISTENT_foo_persistent_storage=container-persistent",
 						containerProfile.Name),
 				}
 				Expect(k8sClient.Create(context.TODO(), workflow)).Should(Succeed())
@@ -1160,14 +1160,14 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 		Context("when a argument is not in the container profile", func() {
 			BeforeEach(func() {
 				containerProfileStorages = []nnfv1alpha1.NnfContainerProfileStorage{
-					{Name: "DW_PERSISTENT_foo-persistent-storage", Optional: true},
+					{Name: "DW_PERSISTENT_foo_persistent_storage", Optional: true},
 				}
 			})
 			It("should go to error", func() {
 				workflow.Spec.DWDirectives = []string{
 					"#DW jobdw name=container-storage type=gfs2 capacity=1GB",
 					fmt.Sprintf("#DW container name=container profile=%s "+
-						"DW_JOB_foo-local-storage=container-storage ",
+						"DW_JOB_foo_local_storage=container-storage ",
 						containerProfile.Name),
 				}
 				Expect(k8sClient.Create(context.TODO(), workflow)).Should(Succeed())
@@ -1182,7 +1182,7 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 })
 
 var _ = Describe("NnfContainerProfile Webhook test", func() {
-	// The nnfcontainer.go covers testing of the webhook.
+	// The nnfcontainer_webhook_test.go covers testing of the webhook.
 	// This spec exists only to verify that the webhook is also running for
 	// the controller tests.
 	It("Fails to create an invalid profile, to verify that the webhook is installed", func() {

--- a/controllers/nnfcontainerprofile_test.go
+++ b/controllers/nnfcontainerprofile_test.go
@@ -61,8 +61,8 @@ func basicNnfContainerProfile(name string, storages []nnfv1alpha1.NnfContainerPr
 	// default storages if not supplied, optional by default
 	if len(storages) == 0 {
 		storages = []nnfv1alpha1.NnfContainerProfileStorage{
-			{Name: "DW_JOB_foo-local-storage", Optional: true},
-			{Name: "DW_PERSISTENT_foo-persistent-storage", Optional: true},
+			{Name: "DW_JOB_foo_local_storage", Optional: true},
+			{Name: "DW_PERSISTENT_foo_persistent_storage", Optional: true},
 		}
 	}
 


### PR DESCRIPTION
Restrict the name of the storage to something that can also be used as the name of a k8s resource.  This means the name must be made up of lowercase letters, numbers, and dashes.

When using that name in a DW_JOB_ or DW_PERSISTENT_ environment variable, swap the dashes for underscores in the storage name.