### PR TITLE
Remove reliance on cray.nnf.manager node label.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,9 +244,9 @@ docker-push: .version ## Push docker image with the manager.
 
 kind-push: VERSION ?= $(shell cat .version)
 kind-push: .version ## Push docker image to kind
-	kind load docker-image --nodes `kubectl get node --no-headers -o custom-columns=":metadata.name" | paste -d, -s -` $(IMAGE_TAG_BASE):$(VERSION)
+	kind load docker-image $(IMAGE_TAG_BASE):$(VERSION)
 	${DOCKER} pull gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
-	kind load docker-image --nodes `kubectl get node -l cray.nnf.manager=true --no-headers -o custom-columns=":metadata.name" | paste -d, -s -` gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+	kind load docker-image gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
 
 ##@ Deployment
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -100,8 +100,6 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
-      nodeSelector:
-        cray.nnf.manager: "true"
       containers:
       - command:
         - /manager


### PR DESCRIPTION
This should just go to an available untainted worker node.