### PR TITLE
Remove resource limits for controller manager and node manager

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -73,10 +73,6 @@ spec:
             port: 8081
           initialDelaySeconds: 15
           periodSeconds: 10
-        resources:
-          requests:
-            cpu: 100m
-            memory: 60Mi
         securityContext:
           privileged: true
       serviceAccountName: controller-manager
@@ -130,9 +126,5 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-        resources:
-          requests:
-            cpu: 100m
-            memory: 30Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
This is to be consistent with the removal of these limits for nnf-dm, which were causing overhead during mpirun initialization.