### PR TITLE
Use the seq(1) command to loop over nslookup in the init container.

### DIFF
--- a/controllers/nnf_workflow_controller_helpers.go
+++ b/controllers/nnf_workflow_controller_helpers.go
@@ -1142,7 +1142,7 @@ exit 0
 		// assumes nslookup is available in the container. The nnf-mfu image provides this.
 		script := `# use nslookup to contact workers
 echo "contacting $HOST..."
-for i in {1..100}; do
+for i in $(seq 1 100); do
    sleep 1
    echo "attempt $i of 100..."
    nslookup $HOST


### PR DESCRIPTION
Switch to using seq(1), which works with sh(1).