### PR TITLE
Update controller-tools to v0.12.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v4.5.7
-CONTROLLER_TOOLS_VERSION ?= v0.11.1
+CONTROLLER_TOOLS_VERSION ?= v0.12.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/config/crd/bases/nnf.cray.hpe.com_nnfaccesses.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfaccesses.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: nnfaccesses.nnf.cray.hpe.com
 spec:
   group: nnf.cray.hpe.com

--- a/config/crd/bases/nnf.cray.hpe.com_nnfcontainerprofiles.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfcontainerprofiles.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: nnfcontainerprofiles.nnf.cray.hpe.com
 spec:
   group: nnf.cray.hpe.com

--- a/config/crd/bases/nnf.cray.hpe.com_nnfdatamovements.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfdatamovements.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: nnfdatamovements.nnf.cray.hpe.com
 spec:
   group: nnf.cray.hpe.com

--- a/config/crd/bases/nnf.cray.hpe.com_nnfnodeecdata.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfnodeecdata.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: nnfnodeecdata.nnf.cray.hpe.com
 spec:
   group: nnf.cray.hpe.com

--- a/config/crd/bases/nnf.cray.hpe.com_nnfnodes.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfnodes.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: nnfnodes.nnf.cray.hpe.com
 spec:
   group: nnf.cray.hpe.com

--- a/config/crd/bases/nnf.cray.hpe.com_nnfnodestorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfnodestorages.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: nnfnodestorages.nnf.cray.hpe.com
 spec:
   group: nnf.cray.hpe.com

--- a/config/crd/bases/nnf.cray.hpe.com_nnfportmanagers.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfportmanagers.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: nnfportmanagers.nnf.cray.hpe.com
 spec:
   group: nnf.cray.hpe.com

--- a/config/crd/bases/nnf.cray.hpe.com_nnfstorageprofiles.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfstorageprofiles.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: nnfstorageprofiles.nnf.cray.hpe.com
 spec:
   group: nnf.cray.hpe.com

--- a/config/crd/bases/nnf.cray.hpe.com_nnfstorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfstorages.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: nnfstorages.nnf.cray.hpe.com
 spec:
   group: nnf.cray.hpe.com

--- a/config/rbac/fencing_agent_role.yaml
+++ b/config/rbac/fencing_agent_role.yaml
@@ -2,7 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: fencing-agent-role
 rules:
 - apiGroups:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: manager-role
 rules:
 - apiGroups:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -2,7 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/NearNodeFlash/nnf-sos
 
+replace github.com/NearNodeFlash/lustre-fs-operator => ../lustre-fs-operator
+replace github.com/HewlettPackard/dws => ../dws
+
 go 1.19
 
 require (

--- a/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_clientmounts.yaml
+++ b/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_clientmounts.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: clientmounts.dws.cray.hpe.com
 spec:
   group: dws.cray.hpe.com

--- a/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_computes.yaml
+++ b/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_computes.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: computes.dws.cray.hpe.com
 spec:
   group: dws.cray.hpe.com

--- a/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_directivebreakdowns.yaml
+++ b/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_directivebreakdowns.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: directivebreakdowns.dws.cray.hpe.com
 spec:
   group: dws.cray.hpe.com

--- a/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_dwdirectiverules.yaml
+++ b/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_dwdirectiverules.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: dwdirectiverules.dws.cray.hpe.com
 spec:
   group: dws.cray.hpe.com

--- a/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_persistentstorageinstances.yaml
+++ b/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_persistentstorageinstances.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: persistentstorageinstances.dws.cray.hpe.com
 spec:
   group: dws.cray.hpe.com

--- a/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_servers.yaml
+++ b/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_servers.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: servers.dws.cray.hpe.com
 spec:
   group: dws.cray.hpe.com

--- a/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_storages.yaml
+++ b/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_storages.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: storages.dws.cray.hpe.com
 spec:
   group: dws.cray.hpe.com

--- a/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_systemconfigurations.yaml
+++ b/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_systemconfigurations.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: systemconfigurations.dws.cray.hpe.com
 spec:
   group: dws.cray.hpe.com

--- a/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_workflows.yaml
+++ b/vendor/github.com/HewlettPackard/dws/config/crd/bases/dws.cray.hpe.com_workflows.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: workflows.dws.cray.hpe.com
 spec:
   group: dws.cray.hpe.com

--- a/vendor/github.com/HewlettPackard/dws/config/webhook/manifests.yaml
+++ b/vendor/github.com/HewlettPackard/dws/config/webhook/manifests.yaml
@@ -2,7 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -29,7 +28,6 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/vendor/github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases/lus.cray.hpe.com_lustrefilesystems.yaml
+++ b/vendor/github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases/lus.cray.hpe.com_lustrefilesystems.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: lustrefilesystems.lus.cray.hpe.com
 spec:
   group: lus.cray.hpe.com

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/HewlettPackard/dws v0.0.1-0.20230602182741-44a9b200eedd
+# github.com/HewlettPackard/dws v0.0.1-0.20230602182741-44a9b200eedd => ../dws
 ## explicit; go 1.19
 github.com/HewlettPackard/dws/api/v1alpha2
 github.com/HewlettPackard/dws/config/crd/bases
@@ -11,7 +11,7 @@ github.com/HewlettPackard/dws/utils/updater
 # github.com/HewlettPackard/structex v1.0.4
 ## explicit; go 1.14
 github.com/HewlettPackard/structex
-# github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20230505195900-67d257c69292
+# github.com/NearNodeFlash/lustre-fs-operator v0.0.0-20230505195900-67d257c69292 => ../lustre-fs-operator
 ## explicit; go 1.19
 github.com/NearNodeFlash/lustre-fs-operator/api/v1beta1
 github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
@@ -769,3 +769,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# github.com/NearNodeFlash/lustre-fs-operator => ../lustre-fs-operator
+# github.com/HewlettPackard/dws => ../dws


### PR DESCRIPTION
The older controller-tools would put a creationTimestamp in the resources and would give it a "null" value.

Re-run "make manifests" to let the new controller-gen cleanup this stuff.
