### PR TITLE
Fix and use verifyPinnedContainerProfile() in tests

### DIFF
--- a/controllers/integration_test.go
+++ b/controllers/integration_test.go
@@ -1263,6 +1263,7 @@ var _ = Describe("Integration Test", func() {
 			}).Should(Succeed())
 
 			advanceStateAndCheckReady("Proposal", workflow)
+			Expect(verifyPinnedContainerProfile(context.TODO(), k8sClient, workflow, 0)).To(Succeed())
 		})
 
 		AfterEach(func() {
@@ -1307,7 +1308,7 @@ var _ = Describe("Integration Test", func() {
 				matchLabels[nnfv1alpha1.DirectiveIndexLabel] = "0"
 
 				jobList := &batchv1.JobList{}
-				Eventually(func(g Gomega) int {
+				Eventually(func() int {
 					Expect(k8sClient.List(context.TODO(), jobList, matchLabels)).To(Succeed())
 					return len(jobList.Items)
 				}).Should(Equal(2))

--- a/controllers/nnf_workflow_controller.go
+++ b/controllers/nnf_workflow_controller.go
@@ -287,7 +287,7 @@ func (r *NnfWorkflowReconciler) startProposalState(ctx context.Context, workflow
 	// only jobdw, persistentdw, and create_persistent need a directive breakdown
 	switch dwArgs["command"] {
 	case "container":
-		return nil, r.createPinnedContainerProfileIfNecessary(ctx, workflow, index)
+		return nil, createPinnedContainerProfileIfNecessary(ctx, r.Client, r.Scheme, workflow, index, r.Log)
 	case "jobdw", "persistentdw", "create_persistent":
 		break
 	default:

--- a/controllers/nnf_workflow_controller_test.go
+++ b/controllers/nnf_workflow_controller_test.go
@@ -1094,6 +1094,7 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 					g.Expect(k8sClient.Get(context.TODO(), key, workflow)).To(Succeed())
 					return workflow.Status.Ready && workflow.Status.State == dwsv1alpha2.StateProposal
 				}).Should(BeTrue(), "reach desired Proposal state")
+				Expect(verifyPinnedContainerProfile(context.TODO(), k8sClient, workflow, 2)).To(Succeed())
 			})
 		})
 
@@ -1118,6 +1119,7 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 					g.Expect(k8sClient.Get(context.TODO(), key, workflow)).To(Succeed())
 					return workflow.Status.Ready && workflow.Status.State == dwsv1alpha2.StateProposal
 				}).Should(BeTrue(), "reach desired Proposal state")
+				Expect(verifyPinnedContainerProfile(context.TODO(), k8sClient, workflow, 1)).To(Succeed())
 			})
 		})
 
@@ -1159,7 +1161,7 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 			})
 		})
 
-		Context("when a argument is not in the container profile", func() {
+		Context("when an argument is not in the container profile", func() {
 			BeforeEach(func() {
 				containerProfileStorages = []nnfv1alpha1.NnfContainerProfileStorage{
 					{Name: "DW_PERSISTENT_foo_persistent_storage", Optional: true},

--- a/controllers/nnfcontainerprofile_helpers.go
+++ b/controllers/nnfcontainerprofile_helpers.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2023 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	dwsv1alpha2 "github.com/HewlettPackard/dws/api/v1alpha2"
+	"github.com/HewlettPackard/dws/utils/dwdparse"
+	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
+	"github.com/go-logr/logr"
+)
+
+func getContainerProfile(ctx context.Context, clnt client.Client, workflow *dwsv1alpha2.Workflow, index int) (*nnfv1alpha1.NnfContainerProfile, error) {
+	profile, err := findPinnedContainerProfile(ctx, clnt, workflow, index)
+	if err != nil {
+		return nil, err
+	}
+
+	if profile == nil {
+		return nil, nnfv1alpha1.NewWorkflowErrorf("container profile '%s' not found", indexedResourceName(workflow, index)).WithFatal()
+	}
+
+	return profile, nil
+}
+
+func findPinnedContainerProfile(ctx context.Context, clnt client.Client, workflow *dwsv1alpha2.Workflow, index int) (*nnfv1alpha1.NnfContainerProfile, error) {
+	profile := &nnfv1alpha1.NnfContainerProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      indexedResourceName(workflow, index),
+			Namespace: workflow.Namespace,
+		},
+	}
+
+	if err := clnt.Get(ctx, client.ObjectKeyFromObject(profile), profile); err != nil {
+		return nil, err
+	}
+
+	if !profile.Data.Pinned {
+		return nil, nnfv1alpha1.NewWorkflowErrorf("expected a pinned container profile '%s', but found one that is not pinned", indexedResourceName(workflow, index)).WithFatal()
+	}
+
+	return profile, nil
+}
+
+func findContainerProfile(ctx context.Context, clnt client.Client, workflow *dwsv1alpha2.Workflow, index int) (*nnfv1alpha1.NnfContainerProfile, error) {
+	args, err := dwdparse.BuildArgsMap(workflow.Spec.DWDirectives[index])
+	if err != nil {
+		return nil, err
+	}
+
+	name, found := args["profile"]
+	if !found {
+		return nil, fmt.Errorf("container directive '%s' has no profile key", workflow.Spec.DWDirectives[index])
+	}
+
+	profile := &nnfv1alpha1.NnfContainerProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: os.Getenv("NNF_CONTAINER_PROFILE_NAMESPACE"),
+		},
+	}
+
+	if err := clnt.Get(ctx, client.ObjectKeyFromObject(profile), profile); err != nil {
+		return nil, err
+	}
+
+	if profile.Data.Pinned {
+		return nil, nnfv1alpha1.NewWorkflowErrorf("expected container profile that is not pinned '%s', but found one that is pinned", indexedResourceName(workflow, index)).WithFatal()
+	}
+
+	return profile, nil
+}
+
+func createPinnedContainerProfileIfNecessary(ctx context.Context, clnt client.Client, scheme *kruntime.Scheme, workflow *dwsv1alpha2.Workflow, index int, log logr.Logger) error {
+	profile, err := findPinnedContainerProfile(ctx, clnt, workflow, index)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	if profile != nil {
+		return nil
+	}
+
+	profile, err = findContainerProfile(ctx, clnt, workflow, index)
+	if err != nil {
+		return err
+	}
+
+	pinnedProfile := &nnfv1alpha1.NnfContainerProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      indexedResourceName(workflow, index),
+			Namespace: workflow.Namespace,
+		},
+	}
+
+	profile.Data.DeepCopyInto(&pinnedProfile.Data)
+
+	pinnedProfile.Data.Pinned = true
+
+	dwsv1alpha2.AddOwnerLabels(pinnedProfile, workflow)
+
+	if err := controllerutil.SetControllerReference(workflow, pinnedProfile, scheme); err != nil {
+		log.Error(err, "failed to set controller reference on profile", "profile", pinnedProfile)
+		return fmt.Errorf("failed to set controller reference on profile %s", client.ObjectKeyFromObject(pinnedProfile))
+	}
+
+	if err := clnt.Create(ctx, pinnedProfile); err != nil {
+		return err
+	}
+	log.Info("Created pinned container profile", "resource", client.ObjectKeyFromObject(pinnedProfile))
+
+	return nil
+}

--- a/controllers/nnfcontainerprofile_test.go
+++ b/controllers/nnfcontainerprofile_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	dwsv1alpha2 "github.com/HewlettPackard/dws/api/v1alpha2"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
 )
 
@@ -90,9 +91,9 @@ func createBasicNnfContainerProfile(storages []nnfv1alpha1.NnfContainerProfileSt
 	return createNnfContainerProfile(containerProfile, true)
 }
 
-func verifyPinnedContainerProfile(ctx context.Context, clnt client.Client, namespace string, profileName string) error {
+func verifyPinnedContainerProfile(ctx context.Context, clnt client.Client, workflow *dwsv1alpha2.Workflow, index int) error {
 
-	nnfContainerProfile, err := findPinnedProfile(ctx, clnt, namespace, profileName)
+	nnfContainerProfile, err := findPinnedContainerProfile(ctx, clnt, workflow, index)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	ExpectWithOffset(1, nnfContainerProfile.Data.Pinned).To(BeTrue())
 	refs := nnfContainerProfile.GetOwnerReferences()


### PR DESCRIPTION
This affected some related functions, so I ended up reworking their function signatures and collecting them in a new nnfcontainerprofile_helpers.go.  The functions that were moved to the new file have  more consistent pinned-versus-notpinned checks now.
