### PR TITLE
Containers: Add specific linux capabilities for MPI workers

### DIFF
--- a/api/v1alpha1/nnfcontainerprofile_types.go
+++ b/api/v1alpha1/nnfcontainerprofile_types.go
@@ -92,7 +92,7 @@ type NnfContainerProfile struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Data NnfContainerProfileData `json:"data,omitempty"`
+	Data NnfContainerProfileData `json:"data"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/nnfcontainerprofile_webhook_test.go
+++ b/api/v1alpha1/nnfcontainerprofile_webhook_test.go
@@ -116,12 +116,44 @@ var _ = Describe("NnfContainerProfile Webhook", func() {
 		nnfProfile = nil
 	})
 
-	It("Should not allow an empty Launcher and Worker ReplicaSpecs", func() {
+	It("Should not allow both an empty Launcher and Worker ReplicaSpecs", func() {
 		nnfProfile.ObjectMeta.Name = pinnedResourceName
 		nnfProfile.Data.MPISpec = &mpiv2beta1.MPIJobSpec{
 			MPIReplicaSpecs: map[mpiv2beta1.MPIReplicaType]*mpicommonv1.ReplicaSpec{
 				mpiv2beta1.MPIReplicaTypeLauncher: nil,
 				mpiv2beta1.MPIReplicaTypeWorker:   nil,
+			},
+		}
+		Expect(k8sClient.Create(context.TODO(), nnfProfile)).ToNot(Succeed())
+		nnfProfile = nil
+	})
+
+	It("Should not allow an empty Launcher ReplicaSpec", func() {
+		nnfProfile.ObjectMeta.Name = pinnedResourceName
+		nnfProfile.Data.MPISpec = &mpiv2beta1.MPIJobSpec{
+			MPIReplicaSpecs: map[mpiv2beta1.MPIReplicaType]*mpicommonv1.ReplicaSpec{
+				mpiv2beta1.MPIReplicaTypeLauncher: nil,
+				mpiv2beta1.MPIReplicaTypeWorker: {
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(context.TODO(), nnfProfile)).ToNot(Succeed())
+		nnfProfile = nil
+	})
+
+	It("Should not allow an empty Worker ReplicaSpec", func() {
+		nnfProfile.ObjectMeta.Name = pinnedResourceName
+		nnfProfile.Data.MPISpec = &mpiv2beta1.MPIJobSpec{
+			MPIReplicaSpecs: map[mpiv2beta1.MPIReplicaType]*mpicommonv1.ReplicaSpec{
+				mpiv2beta1.MPIReplicaTypeLauncher: {
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{},
+					},
+				},
+				mpiv2beta1.MPIReplicaTypeWorker: nil,
 			},
 		}
 		Expect(k8sClient.Create(context.TODO(), nnfProfile)).ToNot(Succeed())

--- a/config/crd/bases/nnf.cray.hpe.com_nnfcontainerprofiles.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfcontainerprofiles.yaml
@@ -15757,6 +15757,8 @@ spec:
             type: string
           metadata:
             type: object
+        required:
+        - data
         type: object
     served: true
     storage: true

--- a/controllers/nnf_workflow_controller_container_helpers.go
+++ b/controllers/nnf_workflow_controller_container_helpers.go
@@ -74,10 +74,6 @@ func (c *nnfUserContainer) createMPIJob() error {
 		},
 	}
 
-	if c.profile.Data.MPISpec == nil {
-		return fmt.Errorf("Profile does not contain Data.MPISpec")
-	}
-
 	c.profile.Data.MPISpec.DeepCopyInto(&mpiJob.Spec)
 	c.username = nnfv1alpha1.ContainerMPIUser
 
@@ -90,17 +86,11 @@ func (c *nnfUserContainer) createMPIJob() error {
 		mpiJob.Spec.RunPolicy.BackoffLimit = &c.profile.Data.RetryLimit
 	}
 
-	// MPIJobs have two pod specs: one for the launcher and one for the workers
-	launcher, found := mpiJob.Spec.MPIReplicaSpecs[mpiv2beta1.MPIReplicaTypeLauncher]
-	if !found {
-		return fmt.Errorf("%s not found in MPIReplicaSpecs", mpiv2beta1.MPIReplicaTypeLauncher)
-	}
+	// MPIJobs have two pod specs: one for the launcher and one for the workers. The webhook ensures
+	// that the launcher/worker specs exist
+	launcher := mpiJob.Spec.MPIReplicaSpecs[mpiv2beta1.MPIReplicaTypeLauncher]
 	launcherSpec := &launcher.Template.Spec
-
-	worker, found := mpiJob.Spec.MPIReplicaSpecs[mpiv2beta1.MPIReplicaTypeWorker]
-	if !found {
-		return fmt.Errorf("%s not found in MPIReplicaSpecs", mpiv2beta1.MPIReplicaTypeWorker)
-	}
+	worker := mpiJob.Spec.MPIReplicaSpecs[mpiv2beta1.MPIReplicaTypeWorker]
 	workerSpec := &worker.Template.Spec
 
 	// Keep failed pods around for log inspection


### PR DESCRIPTION
On LLNL systems, the host's default capabilities are different than HPE systems due to the difference in container runtime and also configuration of those runtimes.

This change drops all capabilities and then adds in the required ones to ensure mpirun can access the worker pods.

Additionally, fix some bugs in the MPISpec of the NnfContainerProfile:
- Don't allow NnfContainerProfile Data to be empty, it's required
- Added check to ensure MPISpec is defined
- Added checks to ensure launcher/worker are defined in the MPISpec

Tested capabilities by:
- Drop ALL capabilities without the specific Adds (and failing)
- Then adding in the specific Adds (and passing)