### PR TITLE
Tighten the tests that verify the profile webhooks are hooked up.

### DIFF
--- a/controllers/nnf_workflow_controller_test.go
+++ b/controllers/nnf_workflow_controller_test.go
@@ -1238,9 +1238,10 @@ var _ = Describe("NnfContainerProfile Webhook test", func() {
 	// The nnfcontainer_webhook_test.go covers testing of the webhook.
 	// This spec exists only to verify that the webhook is also running for
 	// the controller tests.
-	It("Fails to create an invalid profile, to verify that the webhook is installed", func() {
-		profileInvalid := basicNnfContainerProfile("an-invalid-profile", nil)
-		profileInvalid.Data.RetryLimit = -100
+	It("fails to create an invalid profile to verify that the webhook is installed", func() {
+		profileInvalid := basicNnfContainerProfile("invalid-"+uuid.NewString()[:8], nil)
+		profileInvalid.Data.Spec = nil
+		profileInvalid.Data.MPISpec = nil
 		Expect(createNnfContainerProfile(profileInvalid, false)).To(BeNil())
 	})
 })
@@ -1249,8 +1250,8 @@ var _ = Describe("NnfStorageProfile Webhook test", func() {
 	// The nnfstorageprofile_webhook_test.go covers testing of the webhook.
 	// This spec exists only to verify that the webhook is also running for
 	// the controller tests.
-	It("Fails to create an invalid profile, to verify that the webhook is installed", func() {
-		profileInvalid := basicNnfStorageProfile("an-invalid-profile")
+	It("fails to create an invalid profile to verify that the webhook is installed", func() {
+		profileInvalid := basicNnfStorageProfile("invalid-" + uuid.NewString()[:8])
 		profileInvalid.Data.LustreStorage.ExternalMGS = "10.0.0.1@tcp"
 		profileInvalid.Data.LustreStorage.CombinedMGTMDT = true
 		Expect(createNnfStorageProfile(profileInvalid, false)).To(BeNil())

--- a/controllers/nnfstorageprofile_test.go
+++ b/controllers/nnfstorageprofile_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -14,22 +15,26 @@ import (
 )
 
 // createNnfStorageProfile creates the given profile in the "default" namespace.
+// When expectSuccess=false, we expect to find that it was failed by the webhook.
 func createNnfStorageProfile(storageProfile *nnfv1alpha1.NnfStorageProfile, expectSuccess bool) *nnfv1alpha1.NnfStorageProfile {
 	// Place NnfStorageProfiles in "default" for the test environment.
 	storageProfile.ObjectMeta.Namespace = corev1.NamespaceDefault
 
 	profKey := client.ObjectKeyFromObject(storageProfile)
 	profExpected := &nnfv1alpha1.NnfStorageProfile{}
-	Expect(k8sClient.Get(context.TODO(), profKey, profExpected)).ToNot(Succeed())
+	err := k8sClient.Get(context.TODO(), profKey, profExpected)
+	Expect(err).ToNot(BeNil())
+	Expect(apierrors.IsNotFound(err)).To(BeTrue())
 
 	if expectSuccess {
 		Expect(k8sClient.Create(context.TODO(), storageProfile)).To(Succeed(), "create nnfstorageprofile")
-		//err := k8sClient.Create(context.TODO(), storageProfile)
 		Eventually(func(g Gomega) {
 			g.Expect(k8sClient.Get(context.TODO(), profKey, profExpected)).To(Succeed())
 		}, "3s", "1s").Should(Succeed(), "wait for create of NnfStorageProfile")
 	} else {
-		Expect(k8sClient.Create(context.TODO(), storageProfile)).ToNot(Succeed(), "expect to fail to create nnfstorageprofile")
+		err = k8sClient.Create(context.TODO(), storageProfile)
+		Expect(err).ToNot(BeNil())
+		Expect(err.Error()).To(MatchRegexp("webhook .* denied the request"))
 		storageProfile = nil
 	}
 


### PR DESCRIPTION
The NnfContainerProfile test was targeting a failure in the kube-apiserver, by tripping a kubebuilder:validation for RetryLimit.  That has been changed to something that will pass the kube-apiserver, and then will proceed on to fail in the webhook.

Now we can distinguish when Create() errors are responses from the webhook, versus when they are errors about the webhook not being installed.