### PR TITLE
Containers: Add global lustre support

### DIFF
--- a/api/v1alpha1/nnfcontainerprofile_types.go
+++ b/api/v1alpha1/nnfcontainerprofile_types.go
@@ -83,6 +83,11 @@ type NnfContainerProfileStorage struct {
 	// the user not supplying this filesystem in the #DW directives
 	//+kubebuilder:default:=false
 	Optional bool `json:"optional"`
+
+	// For DW_GLOBAL_ (global lustre) storages, the access mode must match what is configured in
+	// the LustreFilesystem resource for the namespace. Defaults to `ReadWriteMany` for global
+	// lustre, otherwise empty.
+	PVCMode corev1.PersistentVolumeAccessMode `json:"pvcMode,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/nnf.cray.hpe.com_nnfcontainerprofiles.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfcontainerprofiles.yaml
@@ -15736,6 +15736,12 @@ spec:
                         to be mounted, but can be ignored by the user not supplying
                         this filesystem in the #DW directives'
                       type: boolean
+                    pvcMode:
+                      description: For DW_GLOBAL_ (global lustre) storages, the access
+                        mode must match what is configured in the LustreFilesystem
+                        resource for the namespace. Defaults to `ReadWriteMany` for
+                        global lustre, otherwise empty.
+                      type: string
                   required:
                   - name
                   - optional

--- a/config/dws/nnf-ruleset.yaml
+++ b/config/dws/nnf-ruleset.yaml
@@ -105,7 +105,7 @@ spec:
         pattern: "^[a-z][a-z0-9-]+$"
         isRequired: true
         isValueRequired: true
-      - key: '^(DW_JOB_|DW_PERSISTENT_)[a-z][a-z0-9_]+$'
+      - key: '^(DW_JOB_|DW_PERSISTENT_|DW_GLOBAL_)[a-z][a-z0-9_]+$'
         type: "string"
         isRequired: false
         isValueRequired: true

--- a/config/examples/nnf_v1alpha1_nnfcontainerprofiles.yaml
+++ b/config/examples/nnf_v1alpha1_nnfcontainerprofiles.yaml
@@ -74,6 +74,9 @@ data:
       optional: false
     - name: DW_PERSISTENT_foo_persistent_storage
       optional: true
+    - name: DW_GLOBAL_foo_global_lustre
+      optional: true
+      pvcMode: ReadWriteMany
   mpiSpec:
     runPolicy:
       cleanPodPolicy: Running

--- a/config/samples/nnf_v1alpha1_nnfcontainerprofile.yaml
+++ b/config/samples/nnf_v1alpha1_nnfcontainerprofile.yaml
@@ -16,7 +16,7 @@ data:
   # List of possible filesystems supported by this container profile. These
   # storages are mounted inside of the container. Any non-optional storage must
   # be supplied with the container directive as an argument and must reference
-  # a valid jobdw or persistentdw directive's name.
+  # a valid jobdw/persistentdw directive's name or refer to a LustreFilesystem path.
   #
   # Example:
   #   DW jobdw name=my-gfs2 type=gfs2 capacity=50GB
@@ -26,9 +26,15 @@ data:
       optional: false
     - name: DW_PERSISTENT_foo_persistent_storage
       optional: true
+    # For Global lustre pvcMode is supported and must match the mode configured in the
+    # LustreFilesystem Resource
+    - name: DW_GLOBAL_foo_global_lustre
+      optional: true
+      pvcMode: ReadWriteMany
 
   # Template defines the containers that will be created from container profile.
   template:
+    # TODO: Update for mpiSpec
     spec:
       containers:
         - name: sample-nnfcontainerprofile

--- a/controllers/nnfcontainerprofile_test.go
+++ b/controllers/nnfcontainerprofile_test.go
@@ -69,6 +69,7 @@ func basicNnfContainerProfile(name string, storages []nnfv1alpha1.NnfContainerPr
 		storages = []nnfv1alpha1.NnfContainerProfileStorage{
 			{Name: "DW_JOB_foo_local_storage", Optional: true},
 			{Name: "DW_PERSISTENT_foo_persistent_storage", Optional: true},
+			{Name: "DW_GLOBAL_foo_global_lustre", Optional: true},
 		}
 	}
 


### PR DESCRIPTION
This adds `DW_GLOBAL_*` storage support to container workflows/profiles, which are backed by the `LustreFilesystem` resource. This allows users to mount global lustre fileystems into user containers.

An administrator must first edit the `LustreFilesystem` resource to add the workflow's namespace (e.g. `default`) to the list of namespaces along with a mode. The mode defaults to `ReadWriteMany` if not set. Doing so will create a PVC that can be used to mount the fileystem.

A `DW_GLOBAL_*` storage must also be added to the NnfContainer Profile. See `config/examples` and `config/samples` for more detail.

The value for the `DW_GLOBAL_*` parameter is the path of the lustre filesystem, e.g.:

```
#DW jobdw type=gfs2 name=my-local-storage capacity=100GB
#DW container name=my-container-workflow profile=example-mpi \
    DW_JOB_foo_local_storage=my-local-storage \
    DW_GLOBAL_foo_global_lustre=/lus/sawbill
```