### PR TITLE
github-83: Add standaloneMgt option to StorageProfile

### DIFF
--- a/api/v1alpha1/nnfstorageprofile_types.go
+++ b/api/v1alpha1/nnfstorageprofile_types.go
@@ -83,6 +83,10 @@ type NnfStorageProfileLustreData struct {
 	// +kubebuilder:default:=false
 	ExclusiveMDT bool `json:"exclusiveMdt,omitempty"`
 
+	// StandAloneMGT creates only a Lustre MGT without an MDT or OST
+	// +kubebuilder:default:=false
+	StandaloneMGT bool `json:"standaloneMgt,omitempty"`
+
 	// MgtCmdLines contains commands to create an MGT target.
 	MgtCmdLines NnfStorageProfileLustreCmdLines `json:"mgtCommandlines,omitempty"`
 

--- a/api/v1alpha1/nnfstorageprofile_webhook.go
+++ b/api/v1alpha1/nnfstorageprofile_webhook.go
@@ -116,6 +116,14 @@ func (r *NnfStorageProfile) validateContentLustre() error {
 		return fmt.Errorf("cannot set both combinedMgtMdt and externalMgs")
 	}
 
+	if r.Data.LustreStorage.StandaloneMGT && len(r.Data.LustreStorage.ExternalMGS) > 0 {
+		return fmt.Errorf("cannot set both standaloneMgt and externalMgs")
+	}
+
+	if r.Data.LustreStorage.StandaloneMGT && r.Data.LustreStorage.CombinedMGTMDT {
+		return fmt.Errorf("cannot set standaloneMgt and combinedMgtMdt")
+	}
+
 	for _, target := range []string{"mgt", "mdt", "mgtmdt", "ost"} {
 		targetMiscOptions := r.GetLustreMiscOptions(target)
 		err := r.validateLustreTargetMiscOptions(targetMiscOptions)

--- a/api/v1alpha1/nnfstorageprofile_webhook_test.go
+++ b/api/v1alpha1/nnfstorageprofile_webhook_test.go
@@ -114,6 +114,13 @@ var _ = Describe("NnfStorageProfile Webhook", func() {
 		Expect(newProfile.Data.Default).ToNot(BeTrue())
 	})
 
+	It("should accept standaloneMgt", func() {
+		nnfProfile.Data.LustreStorage.StandaloneMGT = true
+		Expect(k8sClient.Create(context.TODO(), nnfProfile)).To(Succeed())
+		Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(nnfProfile), newProfile)).To(Succeed())
+		Expect(newProfile.Data.Default).ToNot(BeTrue())
+	})
+
 	It("should accept combinedMgtMdt", func() {
 		nnfProfile.Data.LustreStorage.CombinedMGTMDT = true
 		Expect(k8sClient.Create(context.TODO(), nnfProfile)).To(Succeed())
@@ -139,6 +146,20 @@ var _ = Describe("NnfStorageProfile Webhook", func() {
 	It("should not accept combinedMgtMdt with externalMgs", func() {
 		nnfProfile.Data.LustreStorage.CombinedMGTMDT = true
 		nnfProfile.Data.LustreStorage.ExternalMGS = "10.0.0.1@tcp"
+		Expect(k8sClient.Create(context.TODO(), nnfProfile)).ToNot(Succeed())
+		nnfProfile = nil
+	})
+
+	It("should not accept standaloneMgt with externalMgs", func() {
+		nnfProfile.Data.LustreStorage.StandaloneMGT = true
+		nnfProfile.Data.LustreStorage.ExternalMGS = "10.0.0.1@tcp"
+		Expect(k8sClient.Create(context.TODO(), nnfProfile)).ToNot(Succeed())
+		nnfProfile = nil
+	})
+
+	It("should not accept standaloneMgt with combinedMgtMdt", func() {
+		nnfProfile.Data.LustreStorage.StandaloneMGT = true
+		nnfProfile.Data.LustreStorage.CombinedMGTMDT = true
 		Expect(k8sClient.Create(context.TODO(), nnfProfile)).ToNot(Succeed())
 		nnfProfile = nil
 	})

--- a/config/crd/bases/nnf.cray.hpe.com_nnfstorageprofiles.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfstorageprofiles.yaml
@@ -337,6 +337,11 @@ spec:
                     required:
                     - colocateComputes
                     type: object
+                  standaloneMgt:
+                    default: false
+                    description: StandAloneMGT creates only a Lustre MGT without an
+                      MDT or OST
+                    type: boolean
                 type: object
               pinned:
                 default: false

--- a/controllers/directivebreakdown_controller.go
+++ b/controllers/directivebreakdown_controller.go
@@ -504,6 +504,12 @@ func (r *DirectiveBreakdownReconciler) populateStorageBreakdown(ctx context.Cont
 			lustreComponents = append(lustreComponents, lustreComponentType{dwsv1alpha2.AllocateAcrossServers, mdtCapacity, "mgtmdt", useKey})
 		} else if len(nnfStorageProfile.Data.LustreStorage.ExternalMGS) > 0 {
 			lustreComponents = append(lustreComponents, lustreComponentType{dwsv1alpha2.AllocateAcrossServers, mdtCapacity, "mdt", mdtKey})
+		} else if nnfStorageProfile.Data.LustreStorage.StandaloneMGT {
+			if argsMap["command"] != "create_persistent" {
+				return dwsv1alpha2.NewResourceError("").WithUserMessage("standaloneMgt option can only be used with 'create_persistent' directive").WithFatal().WithUser()
+			}
+
+			lustreComponents = []lustreComponentType{lustreComponentType{dwsv1alpha2.AllocateSingleServer, mgtCapacity, "mgt", mgtKey}}
 		} else {
 			lustreComponents = append(lustreComponents, lustreComponentType{dwsv1alpha2.AllocateAcrossServers, mdtCapacity, "mdt", mdtKey})
 			lustreComponents = append(lustreComponents, lustreComponentType{dwsv1alpha2.AllocateSingleServer, mgtCapacity, "mgt", mgtKey})

--- a/controllers/directivebreakdown_controller_test.go
+++ b/controllers/directivebreakdown_controller_test.go
@@ -138,4 +138,85 @@ var _ = Describe("DirectiveBreakdown test", func() {
 			return k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(persistentStorage), persistentStorage)
 		}).ShouldNot(Succeed())
 	})
+
+	It("Creates a DirectiveBreakdown with a lustre jobdw and standaloneMgt", func() {
+		By("Setting standaloneMgt in the storage profile")
+		Eventually(func(g Gomega) error {
+			g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(storageProfile), storageProfile)).To(Succeed())
+			storageProfile.Data.LustreStorage.StandaloneMGT = true
+			return k8sClient.Update(context.TODO(), storageProfile)
+		}).Should(Succeed())
+
+		By("Creating a DirectiveBreakdown")
+		directiveBreakdown := &dwsv1alpha2.DirectiveBreakdown{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "standalone-lustre-jobdw-test",
+				Namespace: corev1.NamespaceDefault,
+			},
+			Spec: dwsv1alpha2.DirectiveBreakdownSpec{
+				Directive: "#DW jobdw name=jobdw-lustre type=lustre capacity=1GiB",
+			},
+		}
+
+		Expect(k8sClient.Create(context.TODO(), directiveBreakdown)).To(Succeed())
+
+		Eventually(func(g Gomega) error {
+			g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(directiveBreakdown), directiveBreakdown)).To(Succeed())
+			return directiveBreakdown.Status.Error
+		}).ShouldNot(BeNil())
+	})
+
+	It("Creates a DirectiveBreakdown with an xfs jobdw and standaloneMgt", func() {
+		By("Setting standaloneMgt in the storage profile")
+		Eventually(func(g Gomega) error {
+			g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(storageProfile), storageProfile)).To(Succeed())
+			storageProfile.Data.LustreStorage.StandaloneMGT = true
+			return k8sClient.Update(context.TODO(), storageProfile)
+		}).Should(Succeed())
+
+		By("Creating a DirectiveBreakdown")
+		directiveBreakdown := &dwsv1alpha2.DirectiveBreakdown{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "standalone-xfs-jobdw-test",
+				Namespace: corev1.NamespaceDefault,
+			},
+			Spec: dwsv1alpha2.DirectiveBreakdownSpec{
+				Directive: "#DW jobdw name=jobdw-xfs type=xfs capacity=1GiB",
+			},
+		}
+
+		Expect(k8sClient.Create(context.TODO(), directiveBreakdown)).To(Succeed())
+
+		Eventually(func(g Gomega) bool {
+			g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(directiveBreakdown), directiveBreakdown)).To(Succeed())
+			return directiveBreakdown.Status.Ready
+		}).Should(BeTrue())
+	})
+
+	It("Creates a DirectiveBreakdown with a create_persistent and standaloneMgt", func() {
+		By("Setting standaloneMgt in the storage profile")
+		Eventually(func(g Gomega) error {
+			g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(storageProfile), storageProfile)).To(Succeed())
+			storageProfile.Data.LustreStorage.StandaloneMGT = true
+			return k8sClient.Update(context.TODO(), storageProfile)
+		}).Should(Succeed())
+
+		By("Creating a DirectiveBreakdown")
+		directiveBreakdown := &dwsv1alpha2.DirectiveBreakdown{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "standalone-lustre-persistent-test",
+				Namespace: corev1.NamespaceDefault,
+			},
+			Spec: dwsv1alpha2.DirectiveBreakdownSpec{
+				Directive: "#DW create_persistent name=persistent-lustre type=lustre capacity=1GiB",
+			},
+		}
+
+		Expect(k8sClient.Create(context.TODO(), directiveBreakdown)).To(Succeed())
+
+		Eventually(func(g Gomega) bool {
+			g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(directiveBreakdown), directiveBreakdown)).To(Succeed())
+			return directiveBreakdown.Status.Ready
+		}).Should(BeTrue())
+	})
 })

--- a/controllers/nnf_access_controller_test.go
+++ b/controllers/nnf_access_controller_test.go
@@ -165,8 +165,11 @@ var _ = Describe("Access Controller Test", func() {
 			}
 
 			By("Set NNF Access Desired State to unmounted")
-			access.Spec.DesiredState = "unmounted"
-			Expect(k8sClient.Update(context.TODO(), access)).To(Succeed())
+			Eventually(func(g Gomega) error {
+				g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(access), access)).To(Succeed())
+				access.Spec.DesiredState = "unmounted"
+				return k8sClient.Update(context.TODO(), access)
+			}).Should(Succeed())
 
 			By("Verify NNF Access goes Ready in unmounted state")
 			Eventually(func(g Gomega) bool {


### PR DESCRIPTION
Create an option in the Lustre section of the storage profile to only create an MGT. This option will be used by admins to create a pool of MGTs that can be used as external MGTs for other Lustre file systems.