### PR TITLE
Use GetUserMessage() for resource errors

### DIFF
--- a/controllers/nnf_workflow_controller_helpers.go
+++ b/controllers/nnf_workflow_controller_helpers.go
@@ -839,7 +839,7 @@ func handleWorkflowError(err error, driverStatus *dwsv1alpha2.WorkflowDriverStat
 			driverStatus.Error = err.Error()
 		} else {
 			driverStatus.Status = status
-			driverStatus.Message = e.UserMessage
+			driverStatus.Message = e.GetUserMessage()
 			driverStatus.Error = e.Error()
 		}
 	} else {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/NearNodeFlash/nnf-sos
 go 1.19
 
 require (
-	github.com/HewlettPackard/dws v0.0.1-0.20230907160421-5904baa06329
+	github.com/HewlettPackard/dws v0.0.1-0.20230907181649-2f6d9fca4249
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20230613180840-6178f2b04900
 	github.com/NearNodeFlash/nnf-ec v0.0.0-20230526161255-cfb2d89b35d7
 	github.com/ghodss/yaml v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/NearNodeFlash/nnf-sos
 go 1.19
 
 require (
-	github.com/HewlettPackard/dws v0.0.1-0.20230815174614-998c6ad6bd1d
+	github.com/HewlettPackard/dws v0.0.1-0.20230907160421-5904baa06329
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20230613180840-6178f2b04900
 	github.com/NearNodeFlash/nnf-ec v0.0.0-20230526161255-cfb2d89b35d7
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/HewlettPackard/dws v0.0.1-0.20230815174614-998c6ad6bd1d h1:QZKgq7r+4ZUOGV5IPT/HUYWxVMT7vLrYmOV5yvwB6IA=
-github.com/HewlettPackard/dws v0.0.1-0.20230815174614-998c6ad6bd1d/go.mod h1:YvNzcgAPmwhl/YQj6dMwsB9OpwbI5bp/41kINfFiXX8=
+github.com/HewlettPackard/dws v0.0.1-0.20230907160421-5904baa06329 h1:BigoG7b53CPEkdjH2VxM0iZrgVfuzOLtEVjwPIJx/bc=
+github.com/HewlettPackard/dws v0.0.1-0.20230907160421-5904baa06329/go.mod h1:YvNzcgAPmwhl/YQj6dMwsB9OpwbI5bp/41kINfFiXX8=
 github.com/HewlettPackard/structex v1.0.4 h1:RVTdN5FWhDWr1IkjllU8wxuLjISo4gr6u5ryZpzyHcA=
 github.com/HewlettPackard/structex v1.0.4/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20230613180840-6178f2b04900 h1:jOrP2H+D5amgHIONcucYS3/kJm6QfmqAG23Ke7elunI=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/HewlettPackard/dws v0.0.1-0.20230907160421-5904baa06329 h1:BigoG7b53CPEkdjH2VxM0iZrgVfuzOLtEVjwPIJx/bc=
-github.com/HewlettPackard/dws v0.0.1-0.20230907160421-5904baa06329/go.mod h1:YvNzcgAPmwhl/YQj6dMwsB9OpwbI5bp/41kINfFiXX8=
+github.com/HewlettPackard/dws v0.0.1-0.20230907181649-2f6d9fca4249 h1:t5ibQcHcEL374lxAVVXtHqXOZbPvDVSDSrrAVl7yzBA=
+github.com/HewlettPackard/dws v0.0.1-0.20230907181649-2f6d9fca4249/go.mod h1:YvNzcgAPmwhl/YQj6dMwsB9OpwbI5bp/41kINfFiXX8=
 github.com/HewlettPackard/structex v1.0.4 h1:RVTdN5FWhDWr1IkjllU8wxuLjISo4gr6u5ryZpzyHcA=
 github.com/HewlettPackard/structex v1.0.4/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20230613180840-6178f2b04900 h1:jOrP2H+D5amgHIONcucYS3/kJm6QfmqAG23Ke7elunI=

--- a/vendor/github.com/HewlettPackard/dws/api/v1alpha2/resource_error.go
+++ b/vendor/github.com/HewlettPackard/dws/api/v1alpha2/resource_error.go
@@ -174,6 +174,10 @@ func (e *ResourceErrorInfo) Error() string {
 	return fmt.Sprintf("%s error: %s", strings.ToLower(string(e.Type)), message)
 }
 
+func (e *ResourceErrorInfo) GetUserMessage() string {
+	return fmt.Sprintf("%s error: %s", string(e.Type), e.UserMessage)
+}
+
 func (e *ResourceError) SetResourceErrorAndLog(err error, log logr.Logger) {
 	e.SetResourceError(err)
 	if err == nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/HewlettPackard/dws v0.0.1-0.20230907160421-5904baa06329
+# github.com/HewlettPackard/dws v0.0.1-0.20230907181649-2f6d9fca4249
 ## explicit; go 1.19
 github.com/HewlettPackard/dws/api/v1alpha2
 github.com/HewlettPackard/dws/config/crd/bases

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/HewlettPackard/dws v0.0.1-0.20230815174614-998c6ad6bd1d
+# github.com/HewlettPackard/dws v0.0.1-0.20230907160421-5904baa06329
 ## explicit; go 1.19
 github.com/HewlettPackard/dws/api/v1alpha2
 github.com/HewlettPackard/dws/config/crd/bases


### PR DESCRIPTION
Use the GetUserMessage() receiver function when getting the user message for a resource error. This will properly prefix the message with the error type.