### PR TITLE
Use 5GiB as the default size for an MGT

### DIFF
--- a/api/v1alpha1/nnfstorageprofile_types.go
+++ b/api/v1alpha1/nnfstorageprofile_types.go
@@ -74,7 +74,7 @@ type NnfStorageProfileLustreData struct {
 
 	// CapacityMGT specifies the size of the MGT device.
 	// +kubebuilder:validation:Pattern:="^\\d+(KiB|KB|MiB|MB|GiB|GB|TiB|TB)$"
-	// +kubebuilder:default:="1GiB"
+	// +kubebuilder:default:="5GiB"
 	CapacityMGT string `json:"capacityMgt,omitempty"`
 
 	// CapacityMDT specifies the size of the MDT device.  This is also

--- a/api/v1alpha1/nnfstorageprofile_webhook_test.go
+++ b/api/v1alpha1/nnfstorageprofile_webhook_test.go
@@ -217,7 +217,7 @@ var _ = Describe("NnfStorageProfile Webhook", func() {
 
 		// The defaults are found in the kubebuilder validation
 		// statements in nnfstorageprofile_types.go.
-		Expect(newProfile.Data.LustreStorage.CapacityMGT).To(Equal("1GiB"))
+		Expect(newProfile.Data.LustreStorage.CapacityMGT).To(Equal("5GiB"))
 		Expect(newProfile.Data.LustreStorage.CapacityMDT).To(Equal("5GiB"))
 	})
 

--- a/config/crd/bases/nnf.cray.hpe.com_nnfstorageprofiles.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfstorageprofiles.yaml
@@ -118,7 +118,7 @@ spec:
                     pattern: ^\d+(KiB|KB|MiB|MB|GiB|GB|TiB|TB)$
                     type: string
                   capacityMgt:
-                    default: 1GiB
+                    default: 5GiB
                     description: CapacityMGT specifies the size of the MGT device.
                     pattern: ^\d+(KiB|KB|MiB|MB|GiB|GB|TiB|TB)$
                     type: string


### PR DESCRIPTION
1GiB is to small to create a zpool when it is divided across 16 drives.