### PR TITLE
Dynamically create an overlay for the image tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ kind-config.yaml
 standalone-playground
 nnf-sos
 .version
+config/begin/*
+config/begin-examples/*
 
 # .vscode log files
 .vscode/*.log

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2021, 2022 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,
@@ -262,11 +262,13 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 deploy: VERSION ?= $(shell cat .version)
 deploy: .version kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	./deploy.sh deploy $(KUSTOMIZE) $(IMAGE_TAG_BASE):$(VERSION) $(OVERLAY) $(NNFMFU_TAG_BASE):$(NNFMFU_VERSION)
+	$(KUSTOMIZE_IMAGE_TAG) config/begin $(OVERLAY) $(IMAGE_TAG_BASE) $(VERSION)
+	$(KUSTOMIZE_IMAGE_TAG) config/begin-examples examples $(NNFMFU_TAG_BASE) $(NNFMFU_VERSION)
+	./deploy.sh deploy $(KUSTOMIZE) config/begin config/begin-examples
 
 undeploy: VERSION ?= $(shell cat .version)
 undeploy: .version kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
-	./deploy.sh undeploy $(KUSTOMIZE) $(IMAGE_TAG_BASE):$(VERSION) $(OVERLAY)
+	./deploy.sh undeploy $(KUSTOMIZE) config/$(OVERLAY) config/examples
 
 # Let .version be phony so that a git update to the workarea can be reflected
 # in it each time it's needed.
@@ -289,6 +291,7 @@ clean-bin:
 	fi
 
 ## Tool Binaries
+KUSTOMIZE_IMAGE_TAG ?= ./hack/make-kustomization.sh
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -17,4 +17,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/nearnodeflash/nnf-sos
-  newTag: 53297ed0c2ce52ddc2113671b3dd3c79f5894dce
+  newTag: latest

--- a/hack/make-kustomization.sh
+++ b/hack/make-kustomization.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+OVERLAY_DIR=$1
+OVERLAY=$2
+IMAGE_TAG_BASE=$3
+TAG=$4
+
+if [[ ! -d $OVERLAY_DIR ]]
+then
+    mkdir "$OVERLAY_DIR"
+fi
+
+cat <<EOF > "$OVERLAY_DIR"/kustomization.yaml
+resources:
+- ../$OVERLAY
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: $IMAGE_TAG_BASE
+  newTag: $TAG
+EOF
+


### PR DESCRIPTION
Avoid editing config/manager/kustomization.yaml to set the image tag.  This causes git to consider the workarea to be dirty, so two consecutive deploys from a workarea that has no other changes will result in the second deploy looking for an image with a "-dirty" tag.

Instead, from the makefile we create a throw-away, and untracked, overlay that will be used to set the image tag.