### PR TITLE
Add profile argument to copy_in/copy_out directives

### DIFF
--- a/api/v1alpha1/nnf_datamovement_types.go
+++ b/api/v1alpha1/nnf_datamovement_types.go
@@ -31,6 +31,10 @@ const (
 	// data movement.  Individual nodes may also perform data movement in which case they use the
 	// NNF Node Name as the namespace.
 	DataMovementNamespace = "nnf-dm-system"
+
+	// The name of the default profile stored in the nnf-dm-config ConfigMap that is used to
+	// configure Data Movement.
+	DataMovementProfileDefault = "default"
 )
 
 // NnfDataMovementSpec defines the desired state of NnfDataMovement
@@ -57,6 +61,11 @@ type NnfDataMovementSpec struct {
 	// Set to true if the data movement operation should be canceled.
 	// +kubebuilder:default:=false
 	Cancel bool `json:"cancel,omitempty"`
+
+	// Profile specifies the name of profile in the nnf-dm-config ConfigMap to be used for
+	// configuring data movement. Defaults to the default profile.
+	// +kubebuilder:default:=default
+	Profile string `json:"profile,omitempty"`
 
 	// User defined configuration on how data movement should be performed. This overrides the
 	// configuration defined in the nnf-dm-config ConfigMap. These values are typically set by the

--- a/config/crd/bases/nnf.cray.hpe.com_nnfdatamovements.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfdatamovements.yaml
@@ -109,6 +109,12 @@ spec:
                   operation.
                 format: int32
                 type: integer
+              profile:
+                default: default
+                description: Profile specifies the name of profile in the nnf-dm-config
+                  ConfigMap to be used for configuring data movement. Defaults to
+                  the default profile.
+                type: string
               source:
                 description: Source describes the source of the data movement operation
                 properties:

--- a/config/dws/nnf-ruleset.yaml
+++ b/config/dws/nnf-ruleset.yaml
@@ -81,6 +81,11 @@ spec:
         type: "string"
         isRequired: true
         isValueRequired: true
+      - key: "^profile$"
+        type: "string"
+        pattern: "^[a-z][a-z0-9-]+$"
+        isRequired: false
+        isValueRequired: true
   - command: "copy_out"
     watchStates: Proposal,DataOut,Teardown
     ruleDefs:
@@ -91,6 +96,11 @@ spec:
       - key: "^destination$"
         type: "string"
         isRequired: true
+        isValueRequired: true
+      - key: "^profile$"
+        type: "string"
+        pattern: "^[a-z][a-z0-9-]+$"
+        isRequired: false
         isValueRequired: true
   - command: "container"
     watchStates: Proposal,Setup,PreRun,PostRun,Teardown

--- a/internal/controller/nnf_workflow_controller.go
+++ b/internal/controller/nnf_workflow_controller.go
@@ -660,6 +660,12 @@ func (r *NnfWorkflowReconciler) startDataInOutState(ctx context.Context, workflo
 		return path
 	}
 
+	// Use a non-default profile for data movement, if supplied
+	dmProfile, found := dwArgs["profile"]
+	if !found {
+		dmProfile = nnfv1alpha1.DataMovementProfileDefault
+	}
+
 	switch fsType {
 	case "xfs", "gfs2":
 
@@ -690,6 +696,7 @@ func (r *NnfWorkflowReconciler) startDataInOutState(ctx context.Context, workflo
 						},
 						UserId:  workflow.Spec.UserID,
 						GroupId: workflow.Spec.GroupID,
+						Profile: dmProfile,
 					},
 				}
 
@@ -726,6 +733,7 @@ func (r *NnfWorkflowReconciler) startDataInOutState(ctx context.Context, workflo
 				},
 				UserId:  workflow.Spec.UserID,
 				GroupId: workflow.Spec.GroupID,
+				Profile: dmProfile,
 			},
 		}
 

--- a/internal/controller/nnf_workflow_controller_test.go
+++ b/internal/controller/nnf_workflow_controller_test.go
@@ -514,6 +514,8 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 						"Name":      Equal(fmt.Sprintf("%s-%d", workflow.Name, 0)),
 						"Namespace": Equal(workflow.Namespace),
 					}))
+
+				Expect(dm.Spec.Profile).To(Equal(nnfv1alpha1.DataMovementProfileDefault))
 			})
 		})
 
@@ -521,7 +523,7 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 			BeforeEach(func() {
 				workflow.Spec.DWDirectives = []string{
 					fmt.Sprintf("#DW persistentdw name=%s", persistentStorageName),
-					fmt.Sprintf("#DW copy_in source=/lus/maui/my-file.in destination=$DW_PERSISTENT_%s/my-persistent-file.out", strings.ReplaceAll(persistentStorageName, "-", "_")),
+					fmt.Sprintf("#DW copy_in source=/lus/maui/my-file.in profile=test destination=$DW_PERSISTENT_%s/my-persistent-file.out", strings.ReplaceAll(persistentStorageName, "-", "_")),
 				}
 
 				createPersistentStorageInstance(persistentStorageName, "lustre")
@@ -581,6 +583,7 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 						"Name":      Equal(persistentStorageName),
 						"Namespace": Equal(workflow.Namespace),
 					}))
+				Expect(dm.Spec.Profile).To(Equal("test"))
 			})
 		})
 	}) // When("Using copy_in directives", func()


### PR DESCRIPTION
- copy_in/out directives now take a profile=foo argument
- Added profile to NnfDataMovement.Spec
- Uses 'default' profile when not supplied

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
