### PR TITLE
Add examples-htx overlay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,9 @@ ENVTEST_K8S_VERSION = 1.28.0
 #   make deploy OVERLAY=dp0
 OVERLAY ?= kind
 
+# Tell Kustomize to deploy the default examples config, or an overlay
+OVERLAY_EXAMPLES ?= examples
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -263,7 +266,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 deploy: VERSION ?= $(shell cat .version)
 deploy: .version kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE_IMAGE_TAG) config/begin $(OVERLAY) $(IMAGE_TAG_BASE) $(VERSION)
-	$(KUSTOMIZE_IMAGE_TAG) config/begin-examples examples $(NNFMFU_TAG_BASE) $(NNFMFU_VERSION)
+	$(KUSTOMIZE_IMAGE_TAG) config/begin-examples $(OVERLAY_EXAMPLES) $(NNFMFU_TAG_BASE) $(NNFMFU_VERSION)
 	./deploy.sh deploy $(KUSTOMIZE) config/begin config/begin-examples
 
 undeploy: VERSION ?= $(shell cat .version)

--- a/Makefile
+++ b/Makefile
@@ -271,7 +271,7 @@ deploy: .version kustomize ## Deploy controller to the K8s cluster specified in 
 
 undeploy: VERSION ?= $(shell cat .version)
 undeploy: .version kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
-	./deploy.sh undeploy $(KUSTOMIZE) config/$(OVERLAY) config/examples
+	./deploy.sh undeploy $(KUSTOMIZE) config/$(OVERLAY) config/$(OVERLAY_EXAMPLES)
 
 # Let .version be phony so that a git update to the workarea can be reflected
 # in it each time it's needed.

--- a/config/examples-htx/kustomization.yaml
+++ b/config/examples-htx/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- ../examples
+
+patchesStrategicMerge:
+# configure lustre to use externalMgs
+- nnfstorageprofile_patch.yaml

--- a/config/examples-htx/nnfstorageprofile_patch.yaml
+++ b/config/examples-htx/nnfstorageprofile_patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: nnf.cray.hpe.com/v1alpha1
+kind: NnfStorageProfile
+metadata:
+  name: placeholder
+  namespace: nnf-system
+data:
+  lustreStorage:
+    combinedMgtMdt: false
+    # use compute-node-2 lustre server
+    externalMgs: 10.1.1.23@tcp


### PR DESCRIPTION
In order to support system-specific storage profiles, we need to add an
overlay based on top of the examples (storage + container profiles)
config.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
