### PR TITLE
Use owner UID instead of workflow UID for VG name

### DIFF
--- a/api/v1alpha1/workflow_helpers.go
+++ b/api/v1alpha1/workflow_helpers.go
@@ -30,6 +30,10 @@ const (
 	// directive index of the storage they're targeting.
 	TargetDirectiveIndexLabel = "nnf.cray.hpe.com/target_directive_index"
 
+	// TargetOwnerUidLabel is used for ClientMount resources to indicate the UID of the
+	// parent NnfStorage it's targeting
+	TargetOwnerUidLabel = "nnf.cray.hpe.com/target_owner_uid"
+
 	// PinnedStorageProfileLabelName is a label applied to NnfStorage objects to show
 	// which pinned storage profile is being used.
 	PinnedStorageProfileLabelName = "nnf.cray.hpe.com/pinned_storage_profile_name"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/NearNodeFlash/nnf-sos
 go 1.19
 
 require (
-	github.com/DataWorkflowServices/dws v0.0.1-0.20231221163856-c438e3e7bc20
+	github.com/DataWorkflowServices/dws v0.0.1-0.20240102203131-bcb7760eda3e
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20231031201943-531116c1194e
 	github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f
 	github.com/ghodss/yaml v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/NearNodeFlash/nnf-sos
 go 1.19
 
 require (
-	github.com/DataWorkflowServices/dws v0.0.1-0.20240102203131-bcb7760eda3e
+	github.com/DataWorkflowServices/dws v0.0.1-0.20240102213032-8d38db39e6c6
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20231031201943-531116c1194e
 	github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataWorkflowServices/dws v0.0.1-0.20240102203131-bcb7760eda3e h1:+rnxpJ0g+yZuj+fRYdQaLsnU7NYNTdS6Y8RzrU4b6qQ=
-github.com/DataWorkflowServices/dws v0.0.1-0.20240102203131-bcb7760eda3e/go.mod h1:grHFCu0CoUK8exzS57r6cdf4qHpG1Pv5nl0n7evpaUM=
+github.com/DataWorkflowServices/dws v0.0.1-0.20240102213032-8d38db39e6c6 h1:xGf+OCDTBFJb2AlMd/zLlE57GWu9feYYYhf34mvg+Bg=
+github.com/DataWorkflowServices/dws v0.0.1-0.20240102213032-8d38db39e6c6/go.mod h1:grHFCu0CoUK8exzS57r6cdf4qHpG1Pv5nl0n7evpaUM=
 github.com/HewlettPackard/structex v1.0.4 h1:RVTdN5FWhDWr1IkjllU8wxuLjISo4gr6u5ryZpzyHcA=
 github.com/HewlettPackard/structex v1.0.4/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20231031201943-531116c1194e h1:j+MNZYrAcwtaUxqA2CcJFyPLWhfxpO6fsIUXhXljY2U=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataWorkflowServices/dws v0.0.1-0.20231221163856-c438e3e7bc20 h1:zI0wmMeo7N0bqd9PqBFEJTFoLNuVVfmSlktmZY+ZOXw=
-github.com/DataWorkflowServices/dws v0.0.1-0.20231221163856-c438e3e7bc20/go.mod h1:grHFCu0CoUK8exzS57r6cdf4qHpG1Pv5nl0n7evpaUM=
+github.com/DataWorkflowServices/dws v0.0.1-0.20240102203131-bcb7760eda3e h1:+rnxpJ0g+yZuj+fRYdQaLsnU7NYNTdS6Y8RzrU4b6qQ=
+github.com/DataWorkflowServices/dws v0.0.1-0.20240102203131-bcb7760eda3e/go.mod h1:grHFCu0CoUK8exzS57r6cdf4qHpG1Pv5nl0n7evpaUM=
 github.com/HewlettPackard/structex v1.0.4 h1:RVTdN5FWhDWr1IkjllU8wxuLjISo4gr6u5ryZpzyHcA=
 github.com/HewlettPackard/structex v1.0.4/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20231031201943-531116c1194e h1:j+MNZYrAcwtaUxqA2CcJFyPLWhfxpO6fsIUXhXljY2U=

--- a/internal/controller/filesystem_helpers.go
+++ b/internal/controller/filesystem_helpers.go
@@ -334,16 +334,18 @@ func newMockFileSystem(ctx context.Context, c client.Client, nnfNodeStorage *nnf
 func volumeGroupName(ctx context.Context, c client.Client, nnfNodeStorage *nnfv1alpha1.NnfNodeStorage, index int) (string, error) {
 	labels := nnfNodeStorage.GetLabels()
 
-	workflowUid, ok := labels[dwsv1alpha2.WorkflowUidLabel]
+	// Use the NnfStorage UID since the NnfStorage exists for as long as the storage allocation exists.
+	// This is important for persistent instances
+	nnfStorageUid, ok := labels[dwsv1alpha2.OwnerUidLabel]
 	if !ok {
-		return "", fmt.Errorf("missing Workflow UID label on NnfNodeStorage")
+		return "", fmt.Errorf("missing Owner UID label on NnfNodeStorage")
 	}
 	directiveIndex, ok := labels[nnfv1alpha1.DirectiveIndexLabel]
 	if !ok {
 		return "", fmt.Errorf("missing directive index label on NnfNodeStorage")
 	}
 
-	return fmt.Sprintf("%s_%s_%d", workflowUid, directiveIndex, index), nil
+	return fmt.Sprintf("%s_%s_%d", nnfStorageUid, directiveIndex, index), nil
 }
 
 func logicalVolumeName(ctx context.Context, c client.Client, nnfNodeStorage *nnfv1alpha1.NnfNodeStorage, index int) (string, error) {

--- a/internal/controller/nnf_access_controller.go
+++ b/internal/controller/nnf_access_controller.go
@@ -528,7 +528,6 @@ func (r *NnfAccessReconciler) mapClientNetworkStorage(ctx context.Context, acces
 		if os.Getenv("ENVIRONMENT") == "kind" {
 			mountInfo.UserID = access.Spec.UserID
 			mountInfo.GroupID = access.Spec.GroupID
-			mountInfo.SetPermissions = true
 		}
 
 		storageMapping[client] = append(storageMapping[client], mountInfo)
@@ -621,7 +620,6 @@ func (r *NnfAccessReconciler) mapClientLocalStorage(ctx context.Context, access 
 				if os.Getenv("ENVIRONMENT") == "kind" {
 					mountInfo.UserID = access.Spec.UserID
 					mountInfo.GroupID = access.Spec.GroupID
-					mountInfo.SetPermissions = true
 				}
 
 				// If no ClientReference exists, then the mounts are for the Rabbit nodes. Use references
@@ -941,6 +939,7 @@ func (r *NnfAccessReconciler) manageClientMounts(ctx context.Context, access *nn
 					dwsv1alpha2.InheritParentLabels(clientMount, access)
 					dwsv1alpha2.AddOwnerLabels(clientMount, access)
 					setTargetDirectiveIndexLabel(clientMount, targetIndex)
+					setTargetOwnerUIDLabel(clientMount, string(nnfStorage.GetUID()))
 
 					clientMount.Spec.Node = clientName
 					clientMount.Spec.DesiredState = dwsv1alpha2.ClientMountState(access.Spec.DesiredState)

--- a/internal/controller/nnf_clientmount_controller.go
+++ b/internal/controller/nnf_clientmount_controller.go
@@ -233,6 +233,7 @@ func (r *NnfClientMountReconciler) fakeNnfNodeStorage(clientMount *dwsv1alpha2.C
 	dwsv1alpha2.InheritParentLabels(nnfNodeStorage, clientMount)
 	labels := nnfNodeStorage.GetLabels()
 	labels[nnfv1alpha1.DirectiveIndexLabel] = getTargetDirectiveIndexLabel(clientMount)
+	labels[dwsv1alpha2.OwnerUidLabel] = getTargetOwnerUIDLabel(clientMount)
 	nnfNodeStorage.SetLabels(labels)
 
 	nnfNodeStorage.Spec.BlockReference = corev1.ObjectReference{

--- a/internal/controller/nnf_storage_controller.go
+++ b/internal/controller/nnf_storage_controller.go
@@ -571,6 +571,11 @@ func (r *NnfStorageReconciler) setLustreOwnerGroup(ctx context.Context, nnfStora
 		return nil, nil
 	}
 
+	// Don't create the clientmount in kind until the kind environment creates fake file systems.
+	if os.Getenv("ENVIRONMENT") == "kind" {
+		return nil, nil
+	}
+
 	if nnfStorage.Spec.FileSystemType != "lustre" {
 		return &ctrl.Result{}, dwsv1alpha2.NewResourceError("invalid file system type '%s' for setLustreOwnerGroup", nnfStorage.Spec.FileSystemType).WithFatal()
 	}

--- a/internal/controller/nnf_workflow_controller_helpers.go
+++ b/internal/controller/nnf_workflow_controller_helpers.go
@@ -1032,6 +1032,25 @@ func getDirectiveIndexLabel(object metav1.Object) string {
 	return labels[nnfv1alpha1.DirectiveIndexLabel]
 }
 
+func setTargetOwnerUIDLabel(object metav1.Object, value string) {
+	labels := object.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	labels[nnfv1alpha1.TargetOwnerUidLabel] = value
+	object.SetLabels(labels)
+}
+
+func getTargetOwnerUIDLabel(object metav1.Object) string {
+	labels := object.GetLabels()
+	if labels == nil {
+		return ""
+	}
+
+	return labels[nnfv1alpha1.TargetOwnerUidLabel]
+}
+
 func setTargetDirectiveIndexLabel(object metav1.Object, value string) {
 	labels := object.GetLabels()
 	if labels == nil {

--- a/pkg/filesystem/kind.go
+++ b/pkg/filesystem/kind.go
@@ -36,7 +36,7 @@ type KindFileSystem struct {
 }
 
 // Check that LustreFileSystem implements the FileSystem interface
-var _ FileSystem = &MockFileSystem{}
+var _ FileSystem = &KindFileSystem{}
 
 func (m *KindFileSystem) Create(ctx context.Context, complete bool) (bool, error) {
 	if complete == true {
@@ -73,7 +73,7 @@ func (m *KindFileSystem) Deactivate(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func (m *KindFileSystem) Mount(ctx context.Context, path string, options string, complete bool) (bool, error) {
+func (m *KindFileSystem) Mount(ctx context.Context, path string, complete bool) (bool, error) {
 	if complete == true {
 		return false, nil
 	}

--- a/vendor/github.com/DataWorkflowServices/dws/api/v1alpha2/owner_labels.go
+++ b/vendor/github.com/DataWorkflowServices/dws/api/v1alpha2/owner_labels.go
@@ -34,6 +34,7 @@ const (
 	OwnerKindLabel      = "dataworkflowservices.github.io/owner.kind"
 	OwnerNameLabel      = "dataworkflowservices.github.io/owner.name"
 	OwnerNamespaceLabel = "dataworkflowservices.github.io/owner.namespace"
+	OwnerUidLabel       = "dataworkflowservices.github.io/owner.uid"
 )
 
 // +kubebuilder:object:generate=false
@@ -51,6 +52,7 @@ func AddOwnerLabels(child metav1.Object, owner metav1.Object) {
 	labels[OwnerKindLabel] = reflect.Indirect(reflect.ValueOf(owner)).Type().Name()
 	labels[OwnerNameLabel] = owner.GetName()
 	labels[OwnerNamespaceLabel] = owner.GetNamespace()
+	labels[OwnerUidLabel] = string(owner.GetUID())
 
 	child.SetLabels(labels)
 }
@@ -73,6 +75,7 @@ func RemoveOwnerLabels(child metav1.Object) {
 	delete(labels, OwnerKindLabel)
 	delete(labels, OwnerNameLabel)
 	delete(labels, OwnerNamespaceLabel)
+	delete(labels, OwnerUidLabel)
 
 	child.SetLabels(labels)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/DataWorkflowServices/dws v0.0.1-0.20231221163856-c438e3e7bc20
+# github.com/DataWorkflowServices/dws v0.0.1-0.20240102203131-bcb7760eda3e
 ## explicit; go 1.19
 github.com/DataWorkflowServices/dws/api/v1alpha2
 github.com/DataWorkflowServices/dws/config/crd/bases

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/DataWorkflowServices/dws v0.0.1-0.20240102203131-bcb7760eda3e
+# github.com/DataWorkflowServices/dws v0.0.1-0.20240102213032-8d38db39e6c6
 ## explicit; go 1.19
 github.com/DataWorkflowServices/dws/api/v1alpha2
 github.com/DataWorkflowServices/dws/config/crd/bases


### PR DESCRIPTION
This is needed for persistent local file systems. The workflow mounting the persistent file system will have a different UID than the workflow that made the file system. Use the owner UID instead (NnfStorage) since that UID will be consistent for the lifetime of the persistent file system.

Also, don't set the file system permissions on ClientMounts in Kind. This will be enabled later when file systems are better mocked out in the kind environment.