### PR TITLE
Preserve the service namespace during undeploy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,
@@ -70,5 +70,6 @@ if [[ $CMD == 'undeploy' ]]; then
     fi
     $KUSTOMIZE build config/ports | kubectl delete --ignore-not-found -f -
     $KUSTOMIZE build $OVERLAY_EXAMPLES_DIR | kubectl delete --ignore-not-found -f -
-    $KUSTOMIZE build $OVERLAY_DIR | kubectl delete --ignore-not-found -f -
+    # Do not touch the namespace resource when deleting this service.
+    $KUSTOMIZE build $OVERLAY_DIR | yq eval 'select(.kind != "Namespace")' |  kubectl delete --ignore-not-found -f -
 fi


### PR DESCRIPTION
If a pod is on a host that cannot be reached, then any attempt to delete the namespace will hang.  So change this to preserve the namespace and leave that pod for k8s to cleanup when it can.