### PR TITLE
Revert combinedMgtMdt in placeholder storage profile

### DIFF
--- a/config/examples/nnf_v1alpha1_nnfstorageprofile.yaml
+++ b/config/examples/nnf_v1alpha1_nnfstorageprofile.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   default: true
   lustreStorage:
-    combinedMgtMdt: false
+    combinedMgtMdt: true
     mgtCommandlines:
       zpoolCreate: -O canmount=off -o cachefile=none $POOL_NAME $DEVICE_LIST
       mkfs: --mgs --backfstype=$BACKFS $ZVOL_NAME


### PR DESCRIPTION
This was inadvertently changed from true to false in a recent change.
While the impact is low, this does change the established behavior when
deploying to simple systems like Kind.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
