### PR TITLE
Add namespace to index mount directories to avoid DM collision

### DIFF
--- a/internal/controller/nnf_access_controller.go
+++ b/internal/controller/nnf_access_controller.go
@@ -1021,7 +1021,7 @@ func clientMountName(access *nnfv1alpha1.NnfAccess) string {
 // For rabbit mounts, use unique index mount directories that consist of <namespace>-<index>.  These
 // unique directories guard against potential data loss when doing copy out data movement
 // operations. Having the namespace (rabbit name) included in the mount path ensures that these
-// individual compute mount points are always unique.
+// individual compute mount points are unique.
 //
 // Ex:
 //
@@ -1034,7 +1034,7 @@ func clientMountName(access *nnfv1alpha1.NnfAccess) string {
 //	/mnt/nnf/7b5dda61-9d91-4b50-a0d3-f863d0aac25b-0/0
 //
 // When data movement copies the MountPathPrefix to global lustre, then the contents of these
-// directories are merged together and potential data loss can occur if the contents do not have
+// directories are merged together and data loss can occur if the contents do not have
 // unique filenames.
 func getIndexMountDir(namespace string, index int) string {
 	return fmt.Sprintf("%s-%s", namespace, strconv.Itoa(index))

--- a/internal/controller/nnf_access_controller.go
+++ b/internal/controller/nnf_access_controller.go
@@ -625,8 +625,9 @@ func (r *NnfAccessReconciler) mapClientLocalStorage(ctx context.Context, access 
 				// If no ClientReference exists, then the mounts are for the Rabbit nodes. Use references
 				// to the NnfNodeStorage resource so the client mounter can access the swordfish objects
 				if access.Spec.ClientReference == (corev1.ObjectReference{}) {
+					indexMountDir := getIndexMountDir(nnfNodeStorage.Namespace, i)
+					mountInfo.MountPath = filepath.Join(access.Spec.MountPathPrefix, indexMountDir)
 					mountInfo.Device.Type = dwsv1alpha2.ClientMountDeviceTypeReference
-					mountInfo.MountPath = filepath.Join(access.Spec.MountPathPrefix, strconv.Itoa(i))
 				} else {
 					mountInfo.MountPath = access.Spec.MountPath
 					mountInfo.Device.Type = dwsv1alpha2.ClientMountDeviceTypeLVM
@@ -1015,6 +1016,28 @@ func (r *NnfAccessReconciler) getClientMountStatus(ctx context.Context, access *
 
 func clientMountName(access *nnfv1alpha1.NnfAccess) string {
 	return access.Namespace + "-" + access.Name
+}
+
+// For rabbit mounts, use unique index mount directories that consist of <namespace>-<index>.  These
+// unique directories guard against potential data loss when doing copy out data movement
+// operations. Having the namespace (rabbit name) included in the mount path ensures that these
+// individual compute mount points are always unique.
+//
+// Ex:
+//
+//	/mnt/nnf/7b5dda61-9d91-4b50-a0d3-f863d0aac25b-0/rabbit-node-1-0
+//	/mnt/nnf/7b5dda61-9d91-4b50-a0d3-f863d0aac25b-0/rabbit-node-2-0
+//
+// If you did not include the namespace, then the paths would be:
+//
+//	/mnt/nnf/7b5dda61-9d91-4b50-a0d3-f863d0aac25b-0/0
+//	/mnt/nnf/7b5dda61-9d91-4b50-a0d3-f863d0aac25b-0/0
+//
+// When data movement copies the MountPathPrefix to global lustre, then the contents of these
+// directories are merged together and potential data loss can occur if the contents do not have
+// unique filenames.
+func getIndexMountDir(namespace string, index int) string {
+	return fmt.Sprintf("%s-%s", namespace, strconv.Itoa(index))
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/nnf_workflow_controller.go
+++ b/internal/controller/nnf_workflow_controller.go
@@ -647,12 +647,13 @@ func (r *NnfWorkflowReconciler) startDataInOutState(ctx context.Context, workflo
 
 	fsType := targetStorage.Spec.FileSystemType
 
-	getRabbitRelativePath := func(storageRef *corev1.ObjectReference, access *nnfv1alpha1.NnfAccess, path string, index int) string {
+	getRabbitRelativePath := func(storageRef *corev1.ObjectReference, access *nnfv1alpha1.NnfAccess, path, namespace string, index int) string {
 
 		if storageRef.Kind == reflect.TypeOf(nnfv1alpha1.NnfStorage{}).Name() {
 			switch fsType {
 			case "xfs", "gfs2":
-				return filepath.Join(access.Spec.MountPathPrefix, strconv.Itoa(index), path)
+				idxMount := getIndexMountDir(namespace, index)
+				return filepath.Join(access.Spec.MountPathPrefix, idxMount, path)
 			case "lustre":
 				return access.Spec.MountPath + path
 			}
@@ -688,11 +689,11 @@ func (r *NnfWorkflowReconciler) startDataInOutState(ctx context.Context, workflo
 					},
 					Spec: nnfv1alpha1.NnfDataMovementSpec{
 						Source: &nnfv1alpha1.NnfDataMovementSpecSourceDestination{
-							Path:             getRabbitRelativePath(sourceStorage, sourceAccess, source, i),
+							Path:             getRabbitRelativePath(sourceStorage, sourceAccess, source, node.Name, i),
 							StorageReference: *sourceStorage,
 						},
 						Destination: &nnfv1alpha1.NnfDataMovementSpecSourceDestination{
-							Path:             getRabbitRelativePath(destStorage, destAccess, dest, i),
+							Path:             getRabbitRelativePath(destStorage, destAccess, dest, node.Name, i),
 							StorageReference: *destStorage,
 						},
 						UserId:  workflow.Spec.UserID,
@@ -725,11 +726,11 @@ func (r *NnfWorkflowReconciler) startDataInOutState(ctx context.Context, workflo
 			},
 			Spec: nnfv1alpha1.NnfDataMovementSpec{
 				Source: &nnfv1alpha1.NnfDataMovementSpecSourceDestination{
-					Path:             getRabbitRelativePath(sourceStorage, sourceAccess, source, 0),
+					Path:             getRabbitRelativePath(sourceStorage, sourceAccess, source, "", 0),
 					StorageReference: *sourceStorage,
 				},
 				Destination: &nnfv1alpha1.NnfDataMovementSpecSourceDestination{
-					Path:             getRabbitRelativePath(destStorage, destAccess, dest, 0),
+					Path:             getRabbitRelativePath(destStorage, destAccess, dest, "", 0),
 					StorageReference: *destStorage,
 				},
 				UserId:  workflow.Spec.UserID,


### PR DESCRIPTION
Use unique index mount directories that consist of
`<namespace>-<index>`. These unique directories guard against potential
data loss when doing data movement operations. Having the namespace
(i.e. rabbit name) included in the mount path ensures that these
individual compute mount points (index mount directories) are always
unique.

For example, on a 2 rabbit job with 1 compute node each, you would see
the following directories across the 2 rabbits:

     /mnt/nnf/7b5dda61-9d91-4b50-a0d3-f863d0aac25b-0/rabbit-node-1-0
     /mnt/nnf/7b5dda61-9d91-4b50-a0d3-f863d0aac25b-0/rabbit-node-2-0

If you did not include the namespace, then the paths would be:

     /mnt/nnf/7b5dda61-9d91-4b50-a0d3-f863d0aac25b-0/0
     /mnt/nnf/7b5dda61-9d91-4b50-a0d3-f863d0aac25b-0/0

On a copy_out directive, if the user specifies the entire directory as
the source (e.g. `source=$DW_JOB_MY_GFS2`), then data movement will pick
up each of those `0/` directories and drop them in the same spot in the
destination. This would lead to potential data loss.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
