### PR TITLE
zpool destroy: return success if the pool doesn't exist

### DIFF
--- a/pkg/blockdevice/zpool.go
+++ b/pkg/blockdevice/zpool.go
@@ -93,11 +93,11 @@ func (z *Zpool) Create(ctx context.Context, complete bool) (bool, error) {
 
 func (z *Zpool) Destroy(ctx context.Context) (bool, error) {
 	_, err := command.Run(fmt.Sprintf("zpool destroy %s", z.Name), z.Log)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "no such pool") {
 		return false, fmt.Errorf("could not destroy zpool %s", z.Name)
 	}
 
-	return false, nil
+	return true, nil
 }
 
 func (z *Zpool) Activate(ctx context.Context) (bool, error) {


### PR DESCRIPTION
Tested by:
1. Update the `zpoolCreate` options for mdt in the nnfstorageprofile to include
   bad options
2. Without this change, setup will hang on the create. Transition to
   teardown and it will also hang since it can't remove the pool that
   doesn't exist.
3. With this change, teardown will complete since destroy has nothing to
   remove.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
