### PR TITLE
Serialize the NLC reconcilers

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -232,7 +232,7 @@ func (c *nodeLocalController) SetupReconcilers(mgr manager.Manager, opts *nnf.Op
 		return err
 	}
 
-	// The NLC controllers that depend on EC to be ready.
+	// The NLC controllers relying on the readiness of EC.
 
 	if err := (&controllers.NnfClientMountReconciler{
 		Client:            mgr.GetClient(),

--- a/internal/controller/nnf_clientmount_controller.go
+++ b/internal/controller/nnf_clientmount_controller.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+ * Copyright 2021-2024 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -24,6 +24,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -54,8 +55,27 @@ const (
 // NnfClientMountReconciler contains the pieces used by the reconciler
 type NnfClientMountReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *kruntime.Scheme
+	Log               logr.Logger
+	Scheme            *kruntime.Scheme
+	SemaphoreForStart chan int
+
+	sync.Mutex
+	started         bool
+	reconcilerAwake bool
+}
+
+func (r *NnfClientMountReconciler) Start(ctx context.Context) error {
+	log := r.Log.WithValues("State", "Start")
+
+	r.SemaphoreForStart <- 1
+
+	log.Info("Ready to start")
+
+	r.Lock()
+	r.started = true
+	r.Unlock()
+
+	return nil
 }
 
 //+kubebuilder:rbac:groups=dataworkflowservices.github.io,resources=clientmounts,verbs=get;list;watch;create;update;patch;delete
@@ -67,6 +87,16 @@ type NnfClientMountReconciler struct {
 // move the current state of the cluster closer to the desired state.
 func (r *NnfClientMountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
 	log := r.Log.WithValues("ClientMount", req.NamespacedName)
+	r.Lock()
+	if !r.started {
+		r.Unlock()
+		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+	}
+	if !r.reconcilerAwake {
+		log.Info("Reconciler is awake")
+		r.reconcilerAwake = true
+	}
+	r.Unlock()
 
 	metrics.NnfClientMountReconcilesTotal.Inc()
 
@@ -267,7 +297,9 @@ func filterByRabbitNamespacePrefixForTest() predicate.Predicate {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NnfClientMountReconciler) SetupWithManager(mgr ctrl.Manager) error {
-
+	if err := mgr.Add(r); err != nil {
+		return err
+	}
 	maxReconciles := runtime.GOMAXPROCS(0)
 	builder := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxReconciles}).

--- a/internal/controller/nnf_node_block_storage_controller.go
+++ b/internal/controller/nnf_node_block_storage_controller.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Hewlett Packard Enterprise Development LP
+ * Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -26,6 +26,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -61,10 +62,31 @@ const (
 // NnfNodeBlockStorageReconciler contains the elements needed during reconciliation for NnfNodeBlockStorage
 type NnfNodeBlockStorageReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *kruntime.Scheme
+	Log               logr.Logger
+	Scheme            *kruntime.Scheme
+	SemaphoreForStart chan int
+	SemaphoreForDone  chan int
 
 	types.NamespacedName
+
+	sync.Mutex
+	started         bool
+	reconcilerAwake bool
+}
+
+func (r *NnfNodeBlockStorageReconciler) Start(ctx context.Context) error {
+	log := r.Log.WithValues("State", "Start")
+
+	r.SemaphoreForStart <- 1
+
+	log.Info("Ready to start")
+
+	r.Lock()
+	r.started = true
+	r.Unlock()
+
+	<-r.SemaphoreForDone
+	return nil
 }
 
 //+kubebuilder:rbac:groups=nnf.cray.hpe.com,resources=nnfnodeblockstorages,verbs=get;list;watch;create;update;patch;delete;deletecollection
@@ -78,6 +100,17 @@ type NnfNodeBlockStorageReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.7.2/pkg/reconcile
 func (r *NnfNodeBlockStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
 	log := r.Log.WithValues("NnfNodeBlockStorage", req.NamespacedName)
+	r.Lock()
+	if !r.started {
+		r.Unlock()
+		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+	}
+	if !r.reconcilerAwake {
+		log.Info("Reconciler is awake")
+		r.reconcilerAwake = true
+	}
+	r.Unlock()
+
 	metrics.NnfNodeBlockStorageReconcilesTotal.Inc()
 
 	nodeBlockStorage := &nnfv1alpha1.NnfNodeBlockStorage{}
@@ -525,6 +558,9 @@ func (r *NnfNodeBlockStorageReconciler) deleteStorageGroup(ss nnf.StorageService
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NnfNodeBlockStorageReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.Add(r); err != nil {
+		return err
+	}
 	// nnf-ec is not thread safe, so we are limited to a single reconcile thread.
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).

--- a/internal/controller/nnf_node_ec_data_controller.go
+++ b/internal/controller/nnf_node_ec_data_controller.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+ * Copyright 2022-2024 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -49,12 +49,19 @@ type NnfNodeECDataReconciler struct {
 	Scheme  *runtime.Scheme
 	Options *nnfec.Options
 	types.NamespacedName
+	SemaphoreForStart chan int
+	SemaphoreForDone  chan int
 
 	RawLog logr.Logger // RawLog, as opposed to Log, is the un-edited controller logger
 }
 
 // Start implements manager.Runnable
 func (r *NnfNodeECDataReconciler) Start(ctx context.Context) error {
+	log := r.RawLog.WithName("NnfNodeECData").WithValues("State", "Start")
+
+	r.SemaphoreForStart <- 1
+
+	log.Info("Ready to start")
 
 	_, testing := os.LookupEnv("NNF_TEST_ENVIRONMENT")
 
@@ -110,6 +117,8 @@ func (r *NnfNodeECDataReconciler) Start(ctx context.Context) error {
 		go c.Run()
 	}
 
+	log.Info("Allow others to start")
+	<-r.SemaphoreForDone
 	return nil
 }
 
@@ -128,6 +137,9 @@ func (r *NnfNodeECDataReconciler) Start(ctx context.Context) error {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.10.0/pkg/reconcile
 func (r *NnfNodeECDataReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
+
+	// This reconciler does nothing with EC. If it ever does, then it should
+	// have a lock to coordinate with the completion of Start() above.
 
 	metrics.NnfNodeECDataReconcilesTotal.Inc()
 

--- a/internal/controller/nnf_node_storage_controller.go
+++ b/internal/controller/nnf_node_storage_controller.go
@@ -56,6 +56,7 @@ type NnfNodeStorageReconciler struct {
 	Log               logr.Logger
 	Scheme            *kruntime.Scheme
 	SemaphoreForStart chan int
+	SemaphoreForDone  chan int
 
 	types.NamespacedName
 	ChildObjects []dwsv1alpha2.ObjectList
@@ -76,6 +77,7 @@ func (r *NnfNodeStorageReconciler) Start(ctx context.Context) error {
 	r.started = true
 	r.Unlock()
 
+	<-r.SemaphoreForDone
 	return nil
 }
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+ * Copyright 2021-2024 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -177,21 +177,39 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	/*
-		Start Everything
+		Start DWS pieces
 	*/
-
-	err = (&dwsv1alpha2.Workflow{}).SetupWebhookWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-
-	err = (&nnfv1alpha1.NnfStorageProfile{}).SetupWebhookWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-
-	err = (&nnfv1alpha1.NnfContainerProfile{}).SetupWebhookWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
 
 	err = (&dwsctrls.WorkflowReconciler{
 		Client: k8sManager.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("Workflow"),
+		Scheme: testEnv.Scheme,
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&dwsctrls.ClientMountReconciler{
+		Client: k8sManager.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("ClientMount"),
+		Scheme: testEnv.Scheme,
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&dwsv1alpha2.Workflow{}).SetupWebhookWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	/*
+		Start NNF-SOS SLC pieces
+	*/
+
+	err = (&NnfSystemConfigurationReconciler{
+		Client: k8sManager.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("NnfSystemConfiguration"),
+		Scheme: testEnv.Scheme,
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&NnfPortManagerReconciler{
+		Client: k8sManager.GetClient(),
 		Scheme: testEnv.Scheme,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
@@ -217,62 +235,6 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = (&NnfAccessReconciler{
-		Client: k8sManager.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("NnfAccess"),
-		Scheme: testEnv.Scheme,
-	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-
-	err = (&NnfNodeReconciler{
-		Client: k8sManager.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("NnfNode"),
-		Scheme: testEnv.Scheme,
-	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-
-	err = (&NnfNodeECDataReconciler{
-		Client:  k8sManager.GetClient(),
-		Scheme:  testEnv.Scheme,
-		Options: nnf.NewMockOptions(false),
-		RawLog:  ctrl.Log,
-	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-
-	err = (&NnfNodeStorageReconciler{
-		Client: k8sManager.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("NnfNodeStorage"),
-		Scheme: testEnv.Scheme,
-	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-
-	err = (&NnfNodeBlockStorageReconciler{
-		Client: k8sManager.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("NnfNodeBlockStorage"),
-		Scheme: testEnv.Scheme,
-	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-
-	err = (&NnfStorageReconciler{
-		Client: k8sManager.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("NnfStorage"),
-		Scheme: testEnv.Scheme,
-	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-
-	err = (&NnfSystemConfigurationReconciler{
-		Client: k8sManager.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("NnfSystemConfiguration"),
-		Scheme: testEnv.Scheme,
-	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-
-	err = (&NnfPortManagerReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: testEnv.Scheme,
-	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-
 	err = (&DWSStorageReconciler{
 		Client: k8sManager.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("Storage"),
@@ -287,16 +249,78 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = (&NnfClientMountReconciler{
+	err = (&NnfAccessReconciler{
 		Client: k8sManager.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("NnfClientMount"),
+		Log:    ctrl.Log.WithName("controllers").WithName("NnfAccess"),
 		Scheme: testEnv.Scheme,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = (&dwsctrls.ClientMountReconciler{
+	err = (&NnfStorageReconciler{
 		Client: k8sManager.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("ClientMount"),
+		Log:    ctrl.Log.WithName("controllers").WithName("NnfStorage"),
+		Scheme: testEnv.Scheme,
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&nnfv1alpha1.NnfStorageProfile{}).SetupWebhookWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&nnfv1alpha1.NnfContainerProfile{}).SetupWebhookWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	/*
+		Start NNF-SOS NLC pieces
+	*/
+
+	// Coordinate the startup of the NLC controllers that use EC.
+
+	semNnfNodeDone := make(chan int, 1)
+	semNnfNodeDone <- 1
+	err = (&NnfNodeReconciler{
+		Client:           k8sManager.GetClient(),
+		Log:              ctrl.Log.WithName("controllers").WithName("NnfNode"),
+		Scheme:           testEnv.Scheme,
+		SemaphoreForDone: semNnfNodeDone,
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	semNnfNodeECDone := make(chan int, 1)
+	semNnfNodeECDone <- 1
+	err = (&NnfNodeECDataReconciler{
+		Client:            k8sManager.GetClient(),
+		Scheme:            testEnv.Scheme,
+		Options:           nnf.NewMockOptions(false),
+		SemaphoreForStart: semNnfNodeDone,
+		SemaphoreForDone:  semNnfNodeECDone,
+		RawLog:            ctrl.Log,
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	semNnfNodeBlockStorageDone := make(chan int, 1)
+	semNnfNodeBlockStorageDone <- 1
+	err = (&NnfNodeBlockStorageReconciler{
+		Client:            k8sManager.GetClient(),
+		Log:               ctrl.Log.WithName("controllers").WithName("NnfNodeBlockStorage"),
+		Scheme:            testEnv.Scheme,
+		SemaphoreForStart: semNnfNodeECDone,
+		SemaphoreForDone:  semNnfNodeBlockStorageDone,
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&NnfNodeStorageReconciler{
+		Client:            k8sManager.GetClient(),
+		Log:               ctrl.Log.WithName("controllers").WithName("NnfNodeStorage"),
+		Scheme:            testEnv.Scheme,
+		SemaphoreForStart: semNnfNodeBlockStorageDone,
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	// The NLC controllers that do not use EC do not need startup coordination.
+
+	err = (&NnfClientMountReconciler{
+		Client: k8sManager.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("NnfClientMount"),
 		Scheme: testEnv.Scheme,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -319,7 +319,7 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	// The NLC controllers that depend on EC to be ready.
+	// The NLC controllers relying on the readiness of EC.
 
 	err = (&NnfClientMountReconciler{
 		Client:            k8sManager.GetClient(),


### PR DESCRIPTION
Add channel semaphores to serialize the startup of the NLC reconcilers that are using EC.  Add locks to each reconciler to block its Reconcile() until it has completed its Start().