### PR TITLE
After activate, wait for the vg to appear in /dev/mapper directory

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,7 +64,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: NNF_WIPEFS_MAPPER_WAIT_COMMAND_TIMEOUT
+          - name: NNF_MAPPER_WAIT_TIMEOUT
             value: "5"
         ports:
           - containerPort: 50057


### PR DESCRIPTION
It turns out that any actions after the vgactivate have to wait for the vg device to appear in the /dev/mapper directory. Insert a wait for the device to appear in mapper into the activate action.
This change has been trialed on a previously failing system with success.