### PR TITLE
Preserve trailing slash in data movement source/destinations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,7 +26,7 @@
                 "-ginkgo.v",
             ],
             "env": {
-                "KUBEBUILDER_ASSETS": "${workspaceFolder}/bin/k8s/1.26.0-darwin-amd64",
+                "KUBEBUILDER_ASSETS": "${workspaceFolder}/bin/k8s/1.28.0-darwin-arm64",
                 "GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT": "10m",
                 "GOMEGA_DEFAULT_EVENTUALLY_POLLING_INTERVAL": "100ms"
             },

--- a/internal/controller/nnf_workflow_controller.go
+++ b/internal/controller/nnf_workflow_controller.go
@@ -649,17 +649,24 @@ func (r *NnfWorkflowReconciler) startDataInOutState(ctx context.Context, workflo
 
 	getRabbitRelativePath := func(storageRef *corev1.ObjectReference, access *nnfv1alpha1.NnfAccess, path, namespace string, index int) string {
 
+		relPath := path
+
 		if storageRef.Kind == reflect.TypeOf(nnfv1alpha1.NnfStorage{}).Name() {
 			switch fsType {
 			case "xfs", "gfs2":
 				idxMount := getIndexMountDir(namespace, index)
-				return filepath.Join(access.Spec.MountPathPrefix, idxMount, path)
+				relPath = filepath.Join(access.Spec.MountPathPrefix, idxMount, path)
+
+				// Join does a Clean, which removes the trailing slash. Put it back.
+				if strings.HasSuffix(path, "/") {
+					relPath += "/"
+				}
 			case "lustre":
-				return access.Spec.MountPath + path
+				relPath = access.Spec.MountPath + path
 			}
 		}
 
-		return path
+		return relPath
 	}
 
 	// Use a non-default profile for data movement, if supplied


### PR DESCRIPTION
Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
