### PR TITLE
Remove the default flag from NnfStorageProfile/placeholder

### DIFF
--- a/config/examples/nnf_v1alpha1_nnfstorageprofile.yaml
+++ b/config/examples/nnf_v1alpha1_nnfstorageprofile.yaml
@@ -4,7 +4,7 @@ metadata:
   name: placeholder
   namespace: nnf-system
 data:
-  default: true
+  default: false
   lustreStorage:
     combinedMgtMdt: true
     mgtCommandlines:


### PR DESCRIPTION
The NnfStorageProfile/placeholder resource is meant to be an example resource and should not be marked as default.