### PR TITLE
Serialize the NLC reconcilers

### DIFF
--- a/mount-daemon/main.go
+++ b/mount-daemon/main.go
@@ -239,12 +239,14 @@ func startManager(config *managerConfig) {
 		os.Exit(1)
 	}
 
+	semReady := make(chan int, 1)
 	if err = (&controllers.NnfClientMountReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("ClientMount"),
 		//	Mock:    config.mock,
 		//	Timeout: config.timeout,
-		Scheme: mgr.GetScheme(),
+		Scheme:            mgr.GetScheme(),
+		SemaphoreForStart: semReady,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClientMount")
 		os.Exit(1)


### PR DESCRIPTION
Add a dummy channel semaphore to satisfy the reconciler's Start() so it can release the Reconcile() method. These semaphores are being used by the nnf-node-manager controller and aren't needed here in the clientmountd.