### PR TITLE
Clientmount issues

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataWorkflowServices/dws v0.0.1-0.20240221183421-1a123a9274b6 h1:LYKIIoawsuo+1ByvQaIpgl8vZc2KrE0q7AE7t0YumrI=
-github.com/DataWorkflowServices/dws v0.0.1-0.20240221183421-1a123a9274b6/go.mod h1:vSTBLWbsFjMYxx+sjMDyZpMXLY9m5Bp73cjnmAL30WU=
 github.com/DataWorkflowServices/dws v0.0.1-0.20240223212516-e29a8a3306e1 h1:BSVqA7mYIzb867DGukYIPjL2lsagvlrZ6xHBwC2VzsU=
 github.com/DataWorkflowServices/dws v0.0.1-0.20240223212516-e29a8a3306e1/go.mod h1:vSTBLWbsFjMYxx+sjMDyZpMXLY9m5Bp73cjnmAL30WU=
 github.com/HewlettPackard/structex v1.0.4 h1:RVTdN5FWhDWr1IkjllU8wxuLjISo4gr6u5ryZpzyHcA=
@@ -386,7 +384,6 @@ k8s.io/klog/v2 v2.100.1 h1:7WCHKK6K8fNhTqfBhISHQ97KrnJNFZMcQvKp7gP/tmg=
 k8s.io/klog/v2 v2.100.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 h1:LyMgNKD2P8Wn1iAwQU5OhxCKlKJy0sHc+PcDwFB24dQ=
 k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9/go.mod h1:wZK2AVp1uHCp4VamDVgBP2COHZjqD1T68Rf0CM3YjSM=
-k8s.io/kubernetes v1.15.0-alpha.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/kubernetes v1.28.4 h1:aRNxs5jb8FVTtlnxeA4FSDBVKuFwA8Gw40/U2zReBYA=
 k8s.io/kubernetes v1.28.4/go.mod h1:BTzDCKYAlu6LL9ITbfjwgwIrJ30hlTgbv0eXDoA/WoA=
 k8s.io/mount-utils v0.27.1 h1:RSd0wslbIuwLRaGGNAGMZ3m9FLcvukxJ3FWlOm76W2A=

--- a/internal/controller/nnf_access_controller.go
+++ b/internal/controller/nnf_access_controller.go
@@ -260,7 +260,7 @@ func (r *NnfAccessReconciler) mount(ctx context.Context, access *nnfv1alpha1.Nnf
 }
 
 func (r *NnfAccessReconciler) unmount(ctx context.Context, access *nnfv1alpha1.NnfAccess, clientList []string, storageMapping map[string][]dwsv1alpha2.ClientMountInfo) (*ctrl.Result, error) {
-	// Create the ClientMount resources. One ClientMount resource is created per client
+	// Update client mounts to trigger unmount operation
 	err := r.manageClientMounts(ctx, access, storageMapping)
 	if err != nil {
 		return nil, dwsv1alpha2.NewResourceError("unable to update ClientMount resources").WithError(err)

--- a/internal/controller/nnf_clientmount_controller.go
+++ b/internal/controller/nnf_clientmount_controller.go
@@ -234,7 +234,7 @@ func (r *NnfClientMountReconciler) changeMount(ctx context.Context, clientMount 
 			}
 		}
 	} else {
-		unmounted, err := fileSystem.Unmount(ctx, clientMountInfo.MountPath)
+		unmounted, err := fileSystem.Unmount(ctx, clientMountInfo.MountPath, clientMount.Status.Mounts[index].Ready)
 		if err != nil {
 			return dwsv1alpha2.NewResourceError("unable to unmount file system").WithError(err).WithMajor()
 		}

--- a/internal/controller/nnf_clientmount_controller.go
+++ b/internal/controller/nnf_clientmount_controller.go
@@ -246,7 +246,7 @@ func (r *NnfClientMountReconciler) changeMount(ctx context.Context, clientMount 
 	return nil
 }
 
-// fakeNnfNodeStorage creates an NnfNodeStorage resource with filled in with only the fields
+// fakeNnfNodeStorage creates an NnfNodeStorage resource filled in with only the fields
 // that are necessary to mount the file system. This is done to reduce the API server load
 // because the compute nodes don't need to Get() the actual NnfNodeStorage.
 func (r *NnfClientMountReconciler) fakeNnfNodeStorage(clientMount *dwsv1alpha2.ClientMount, index int) *nnfv1alpha1.NnfNodeStorage {

--- a/internal/controller/nnf_workflow_controller.go
+++ b/internal/controller/nnf_workflow_controller.go
@@ -844,7 +844,8 @@ func (r *NnfWorkflowReconciler) startPreRunState(ctx context.Context, workflow *
 			name, namespace := getStorageReferenceNameFromWorkflowActual(workflow, index)
 
 			access.Spec.StorageReference = corev1.ObjectReference{
-				// Directive Breakdowns share the same NamespacedName with the Servers it creates, which shares the same name with the NNFStorage.
+				// Directive Breakdowns share the same NamespacedName with the Servers it creates,
+				// which shares the same name with the NNFStorage.
 				Name:      name,
 				Namespace: namespace,
 				Kind:      reflect.TypeOf(nnfv1alpha1.NnfStorage{}).Name(),

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -38,7 +38,7 @@ type FileSystem interface {
 	Mount(ctx context.Context, path string, complete bool) (bool, error)
 
 	// Unmount the file system
-	Unmount(ctx context.Context, path string) (bool, error)
+	Unmount(ctx context.Context, path string, complete bool) (bool, error)
 
 	// Set the UID and GID for the file system
 	SetPermissions(ctx context.Context, uid uint32, gid uint32, complete bool) (bool, error)

--- a/pkg/filesystem/kind.go
+++ b/pkg/filesystem/kind.go
@@ -86,7 +86,7 @@ func (m *KindFileSystem) Mount(ctx context.Context, path string, complete bool) 
 	return true, nil
 }
 
-func (m *KindFileSystem) Unmount(ctx context.Context, path string) (bool, error) {
+func (m *KindFileSystem) Unmount(ctx context.Context, path string, complete bool) (bool, error) {
 	// Remove the directory. If it fails don't worry about it.
 	_ = os.Remove(path)
 

--- a/pkg/filesystem/lustre.go
+++ b/pkg/filesystem/lustre.go
@@ -235,7 +235,7 @@ func (l *LustreFileSystem) Mount(ctx context.Context, path string, complete bool
 	return true, nil
 }
 
-func (l *LustreFileSystem) Unmount(ctx context.Context, path string) (bool, error) {
+func (l *LustreFileSystem) Unmount(ctx context.Context, path string, complete bool) (bool, error) {
 	path = filepath.Clean(path)
 	mounter := mount.New("")
 	mounts, err := mounter.List()

--- a/pkg/filesystem/mock.go
+++ b/pkg/filesystem/mock.go
@@ -75,7 +75,7 @@ func (m *MockFileSystem) Mount(ctx context.Context, path string, complete bool) 
 	return true, nil
 }
 
-func (m *MockFileSystem) Unmount(ctx context.Context, path string) (bool, error) {
+func (m *MockFileSystem) Unmount(ctx context.Context, path string, complete bool) (bool, error) {
 	m.Log.Info("Unmounted mock file system")
 
 	return true, nil

--- a/pkg/filesystem/simple.go
+++ b/pkg/filesystem/simple.go
@@ -188,7 +188,11 @@ func (f *SimpleFileSystem) Mount(ctx context.Context, path string, complete bool
 	return true, nil
 }
 
-func (f *SimpleFileSystem) Unmount(ctx context.Context, path string) (bool, error) {
+func (f *SimpleFileSystem) Unmount(ctx context.Context, path string, complete bool) (bool, error) {
+	if complete {
+		return false, nil
+	}
+
 	path = filepath.Clean(path)
 	mounter := mount.New("")
 	mounts, err := mounter.List()
@@ -243,13 +247,13 @@ func (f *SimpleFileSystem) SetPermissions(ctx context.Context, userID uint32, gr
 	}
 
 	if err := os.Chown(f.TempDir, int(userID), int(groupID)); err != nil {
-		if _, unmountErr := f.Unmount(ctx, f.TempDir); unmountErr != nil {
+		if _, unmountErr := f.Unmount(ctx, f.TempDir, false); unmountErr != nil {
 			return false, fmt.Errorf("could not unmount after setting owner permissions failed '%s': %w", f.TempDir, unmountErr)
 		}
 		return false, fmt.Errorf("could not set owner permissions '%s': %w", f.TempDir, err)
 	}
 
-	if _, err := f.Unmount(ctx, f.TempDir); err != nil {
+	if _, err := f.Unmount(ctx, f.TempDir, false); err != nil {
 		return false, fmt.Errorf("could not unmount after setting owner permissions '%s': %w", f.TempDir, err)
 	}
 


### PR DESCRIPTION
In the SimpleFileSystem code when an unmount operation is successful, don't attempt unmount activities on subsequent Reconciles since the filesystem has already been unmounted. That is, trust the `Ready` status of the clientmount resource.