### PR TITLE
Add `zpool import` on Node EC Data controller startup

### DIFF
--- a/internal/controller/nnf_node_ec_data_controller.go
+++ b/internal/controller/nnf_node_ec_data_controller.go
@@ -36,6 +36,7 @@ import (
 	"github.com/NearNodeFlash/nnf-ec/pkg/persistent"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
 	"github.com/NearNodeFlash/nnf-sos/internal/controller/metrics"
+	"github.com/NearNodeFlash/nnf-sos/pkg/blockdevice"
 	"github.com/go-logr/logr"
 )
 
@@ -117,8 +118,19 @@ func (r *NnfNodeECDataReconciler) Start(ctx context.Context) error {
 		go c.Run()
 	}
 
+	// import zpools
+	ran, err := blockdevice.ZpoolImportAll(log)
+	if err != nil {
+		log.Error(err, "failed to import zpools")
+		return err
+	}
+	if ran {
+		log.Info("Imported all available zpools")
+	}
+
 	log.Info("Allow others to start")
 	<-r.SemaphoreForDone
+
 	return nil
 }
 


### PR DESCRIPTION
This ensures that any existing pools are imported and present after a reboot of the rabbit node.

Tested by:
1. Create lustre workflow and transition to PostRun
2. Reboot the rabbit-node prior to Teardown
3. Once rebooted, verify that zool list includes pools
4. Verify log contains "Imported all available zpools"

Another test:
1. Do step 1 from above.
2. Transition to Teardown and then very quickly reboot the rabbit node (`ssh rabbit-node-2 reboot`).
3. Once rabbit node reboots, workflow will transition to Teardown complete.
4. Verify step 4 above.
5. Verify `zpool list` as no pools left.



moved import to NnfNodeECData.Start()