### PR TITLE
Address Transient Error issues

### DIFF
--- a/internal/controller/directivebreakdown_controller.go
+++ b/internal/controller/directivebreakdown_controller.go
@@ -456,7 +456,7 @@ func (r *DirectiveBreakdownReconciler) populateStorageBreakdown(ctx context.Cont
 	// The pinned profile will be named for the NnfStorage.
 	nnfStorageProfile, err := findPinnedProfile(ctx, r.Client, dbd.GetNamespace(), commonResourceName)
 	if err != nil {
-		return dwsv1alpha2.NewResourceError("unable to find pinned NnfStorageProfile: %s/%s", commonResourceName, dbd.GetNamespace()).WithError(err).WithUserMessage("Unable to find pinned NnfStorageProfile").WithFatal()
+		return dwsv1alpha2.NewResourceError("unable to find pinned NnfStorageProfile: %s/%s", commonResourceName, dbd.GetNamespace()).WithError(err).WithUserMessage("Unable to find pinned NnfStorageProfile").WithMajor()
 	}
 
 	// The directive has been validated by the webhook, so we can assume the pieces we need are in the map.

--- a/internal/controller/nnf_workflow_controller.go
+++ b/internal/controller/nnf_workflow_controller.go
@@ -800,9 +800,9 @@ func (r *NnfWorkflowReconciler) startPreRunState(ctx context.Context, workflow *
 		result, err := r.userContainerHandler(ctx, workflow, dwArgs, index, log)
 
 		if err != nil {
-			return nil, dwsv1alpha2.NewResourceError("").WithError(err).WithFatal().WithUserMessage("unable to create/update Container Jobs: " + err.Error())
+			return nil, dwsv1alpha2.NewResourceError("").WithError(err).WithUserMessage("unable to create/update Container Jobs: " + err.Error())
 		}
-		if result != nil {
+		if result != nil { // a requeue can be returned, so make sure that happens
 			return result, nil
 		}
 

--- a/internal/controller/nnf_workflow_controller_helpers.go
+++ b/internal/controller/nnf_workflow_controller_helpers.go
@@ -1272,15 +1272,15 @@ func (r *NnfWorkflowReconciler) userContainerHandler(ctx context.Context, workfl
 	// Get the targeted NNF nodes for the container jobs
 	nnfNodes, err := r.getNnfNodesFromComputes(ctx, workflow)
 	if err != nil || len(nnfNodes) <= 0 {
-		return nil, dwsv1alpha2.NewResourceError("error obtaining the target NNF nodes for containers").WithError(err).WithMajor()
+		return nil, dwsv1alpha2.NewResourceError("error obtaining the target NNF nodes for containers").WithError(err)
 	}
 
 	// Get the NNF volumes to mount into the containers
 	volumes, result, err := r.getContainerVolumes(ctx, workflow, dwArgs, profile)
 	if err != nil {
-		return nil, dwsv1alpha2.NewResourceError("could not determine the list of volumes needed to create container job for workflow: %s", workflow.Name).WithError(err).WithFatal()
+		return nil, dwsv1alpha2.NewResourceError("could not determine the list of volumes needed to create container job for workflow: %s", workflow.Name).WithError(err)
 	}
-	if result != nil {
+	if result != nil { // a requeue can be returned, so make sure that happens
 		return result, nil
 	}
 
@@ -1373,7 +1373,7 @@ func (r *NnfWorkflowReconciler) getNnfNodesFromComputes(ctx context.Context, wor
 
 	systemConfig := &dwsv1alpha2.SystemConfiguration{}
 	if err := r.Get(ctx, types.NamespacedName{Name: "default", Namespace: corev1.NamespaceDefault}, systemConfig); err != nil {
-		return ret, dwsv1alpha2.NewResourceError("could not get system configuration")
+		return ret, dwsv1alpha2.NewResourceError("could not get system configuration").WithFatal()
 	}
 
 	// The SystemConfiguration is organized by rabbit. Make a map of computes:rabbit for easy lookup.
@@ -1905,10 +1905,7 @@ func (r *NnfWorkflowReconciler) getContainerVolumes(ctx context.Context, workflo
 				},
 			}
 			if err := r.Get(ctx, client.ObjectKeyFromObject(nnfAccess), nnfAccess); err != nil {
-				if !apierrors.IsNotFound(err) {
-					return nil, nil, dwsv1alpha2.NewResourceError("could not retrieve the NnfAccess '%s'", nnfAccess.Name).WithMajor()
-				}
-				return nil, Requeue(fmt.Sprintf("wait for NnfAccess '%s'", nnfAccess.Name)).after(2 * time.Second), nil
+				return nil, nil, dwsv1alpha2.NewResourceError("could not retrieve the NnfAccess '%s'", nnfAccess.Name).WithMajor()
 			}
 
 			if !nnfAccess.Status.Ready {


### PR DESCRIPTION
- A missing pinned profile is now transient (major error)
- Fixed an issue with userContainerHandler() and its subroutines accidentally masking lower severity errors. Everything was being reported as Fatal at the top level.

Both issues were causing flux to see the fatal errors and immediately transition to Teardown.