### PR TITLE
Configure time for UTC.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,6 +27,7 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
@@ -38,7 +39,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	zapcr "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -91,15 +92,12 @@ func main() {
 
 	nnfopts := nnf.BindFlags(flag.CommandLine)
 
-	opts := zap.Options{
-		Development: true,
-		TimeEncoder: zapcore.ISO8601TimeEncoder,
-	}
-	opts.BindFlags(flag.CommandLine)
-
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	encoder := zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig())
+	zaplogger := zapcr.New(zapcr.Encoder(encoder), zapcr.UseDevMode(true))
+
+	ctrl.SetLogger(zaplogger)
 
 	setupLog.Info("GOMAXPROCS", "value", runtime.GOMAXPROCS(0))
 


### PR DESCRIPTION
Configure the time the same way we do for other services. This allows both the NLC and SLC controllers to agree on using UTC, rather than having one local and the other UTC.