### PR TITLE
Serialize the NLC reconcilers, take 2

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -182,8 +182,7 @@ func (c *nodeLocalController) SetupReconcilers(mgr manager.Manager, opts *nnf.Op
 
 	// Coordinate the startup of the NLC controllers that use EC.
 
-	semNnfNodeDone := make(chan int, 1)
-	semNnfNodeDone <- 1
+	semNnfNodeDone := make(chan struct{})
 	if err := (&controllers.NnfNodeReconciler{
 		Client:           mgr.GetClient(),
 		Log:              ctrl.Log.WithName("controllers").WithName("NnfNode"),
@@ -194,8 +193,7 @@ func (c *nodeLocalController) SetupReconcilers(mgr manager.Manager, opts *nnf.Op
 		return err
 	}
 
-	semNnfNodeECDone := make(chan int, 1)
-	semNnfNodeECDone <- 1
+	semNnfNodeECDone := make(chan struct{})
 	if err := (&controllers.NnfNodeECDataReconciler{
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
@@ -208,8 +206,7 @@ func (c *nodeLocalController) SetupReconcilers(mgr manager.Manager, opts *nnf.Op
 		return err
 	}
 
-	semNnfNodeBlockStorageDone := make(chan int, 1)
-	semNnfNodeBlockStorageDone <- 1
+	semNnfNodeBlockStorageDone := make(chan struct{})
 	if err := (&controllers.NnfNodeBlockStorageReconciler{
 		Client:            mgr.GetClient(),
 		Log:               ctrl.Log.WithName("controllers").WithName("NnfNodeBlockStorage"),
@@ -220,8 +217,7 @@ func (c *nodeLocalController) SetupReconcilers(mgr manager.Manager, opts *nnf.Op
 		return err
 	}
 
-	semNnfNodeStorageDone := make(chan int, 1)
-	semNnfNodeStorageDone <- 1
+	semNnfNodeStorageDone := make(chan struct{})
 	if err := (&controllers.NnfNodeStorageReconciler{
 		Client:            mgr.GetClient(),
 		Log:               ctrl.Log.WithName("controllers").WithName("NnfNodeStorage"),

--- a/internal/controller/nnf_clientmount_controller.go
+++ b/internal/controller/nnf_clientmount_controller.go
@@ -57,7 +57,7 @@ type NnfClientMountReconciler struct {
 	client.Client
 	Log               logr.Logger
 	Scheme            *kruntime.Scheme
-	SemaphoreForStart chan int
+	SemaphoreForStart chan struct{}
 
 	sync.Mutex
 	started         bool
@@ -67,7 +67,7 @@ type NnfClientMountReconciler struct {
 func (r *NnfClientMountReconciler) Start(ctx context.Context) error {
 	log := r.Log.WithValues("State", "Start")
 
-	r.SemaphoreForStart <- 1
+	<-r.SemaphoreForStart
 
 	log.Info("Ready to start")
 

--- a/internal/controller/nnf_node_block_storage_controller.go
+++ b/internal/controller/nnf_node_block_storage_controller.go
@@ -64,8 +64,8 @@ type NnfNodeBlockStorageReconciler struct {
 	client.Client
 	Log               logr.Logger
 	Scheme            *kruntime.Scheme
-	SemaphoreForStart chan int
-	SemaphoreForDone  chan int
+	SemaphoreForStart chan struct{}
+	SemaphoreForDone  chan struct{}
 
 	types.NamespacedName
 
@@ -77,7 +77,7 @@ type NnfNodeBlockStorageReconciler struct {
 func (r *NnfNodeBlockStorageReconciler) Start(ctx context.Context) error {
 	log := r.Log.WithValues("State", "Start")
 
-	r.SemaphoreForStart <- 1
+	<-r.SemaphoreForStart
 
 	log.Info("Ready to start")
 
@@ -85,7 +85,7 @@ func (r *NnfNodeBlockStorageReconciler) Start(ctx context.Context) error {
 	r.started = true
 	r.Unlock()
 
-	<-r.SemaphoreForDone
+	close(r.SemaphoreForDone)
 	return nil
 }
 

--- a/internal/controller/nnf_node_controller.go
+++ b/internal/controller/nnf_node_controller.go
@@ -67,7 +67,7 @@ type NnfNodeReconciler struct {
 	Scheme *kruntime.Scheme
 
 	Options          *nnfec.Options
-	SemaphoreForDone chan int
+	SemaphoreForDone chan struct{}
 	types.NamespacedName
 
 	sync.Mutex
@@ -201,7 +201,7 @@ func (r *NnfNodeReconciler) Start(ctx context.Context) error {
 	r.Unlock()
 
 	log.Info("Allow others to start")
-	<-r.SemaphoreForDone
+	close(r.SemaphoreForDone)
 	return nil
 }
 

--- a/internal/controller/nnf_node_ec_data_controller.go
+++ b/internal/controller/nnf_node_ec_data_controller.go
@@ -50,8 +50,8 @@ type NnfNodeECDataReconciler struct {
 	Scheme  *runtime.Scheme
 	Options *nnfec.Options
 	types.NamespacedName
-	SemaphoreForStart chan int
-	SemaphoreForDone  chan int
+	SemaphoreForStart chan struct{}
+	SemaphoreForDone  chan struct{}
 
 	RawLog logr.Logger // RawLog, as opposed to Log, is the un-edited controller logger
 }
@@ -60,7 +60,7 @@ type NnfNodeECDataReconciler struct {
 func (r *NnfNodeECDataReconciler) Start(ctx context.Context) error {
 	log := r.RawLog.WithName("NnfNodeECData").WithValues("State", "Start")
 
-	r.SemaphoreForStart <- 1
+	<-r.SemaphoreForStart
 
 	log.Info("Ready to start")
 
@@ -129,7 +129,7 @@ func (r *NnfNodeECDataReconciler) Start(ctx context.Context) error {
 	}
 
 	log.Info("Allow others to start")
-	<-r.SemaphoreForDone
+	close(r.SemaphoreForDone)
 
 	return nil
 }

--- a/internal/controller/nnf_node_storage_controller.go
+++ b/internal/controller/nnf_node_storage_controller.go
@@ -55,8 +55,8 @@ type NnfNodeStorageReconciler struct {
 	client.Client
 	Log               logr.Logger
 	Scheme            *kruntime.Scheme
-	SemaphoreForStart chan int
-	SemaphoreForDone  chan int
+	SemaphoreForStart chan struct{}
+	SemaphoreForDone  chan struct{}
 
 	types.NamespacedName
 	ChildObjects []dwsv1alpha2.ObjectList
@@ -69,7 +69,7 @@ type NnfNodeStorageReconciler struct {
 func (r *NnfNodeStorageReconciler) Start(ctx context.Context) error {
 	log := r.Log.WithValues("State", "Start")
 
-	r.SemaphoreForStart <- 1
+	<-r.SemaphoreForStart
 
 	log.Info("Ready to start")
 
@@ -77,7 +77,7 @@ func (r *NnfNodeStorageReconciler) Start(ctx context.Context) error {
 	r.started = true
 	r.Unlock()
 
-	<-r.SemaphoreForDone
+	close(r.SemaphoreForDone)
 	return nil
 }
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -275,8 +275,7 @@ var _ = BeforeSuite(func() {
 
 	// Coordinate the startup of the NLC controllers that use EC.
 
-	semNnfNodeDone := make(chan int, 1)
-	semNnfNodeDone <- 1
+	semNnfNodeDone := make(chan struct{})
 	err = (&NnfNodeReconciler{
 		Client:           k8sManager.GetClient(),
 		Log:              ctrl.Log.WithName("controllers").WithName("NnfNode"),
@@ -285,8 +284,7 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	semNnfNodeECDone := make(chan int, 1)
-	semNnfNodeECDone <- 1
+	semNnfNodeECDone := make(chan struct{})
 	err = (&NnfNodeECDataReconciler{
 		Client:            k8sManager.GetClient(),
 		Scheme:            testEnv.Scheme,
@@ -297,8 +295,7 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	semNnfNodeBlockStorageDone := make(chan int, 1)
-	semNnfNodeBlockStorageDone <- 1
+	semNnfNodeBlockStorageDone := make(chan struct{})
 	err = (&NnfNodeBlockStorageReconciler{
 		Client:            k8sManager.GetClient(),
 		Log:               ctrl.Log.WithName("controllers").WithName("NnfNodeBlockStorage"),
@@ -308,8 +305,7 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	semNnfNodeStorageDone := make(chan int, 1)
-	semNnfNodeStorageDone <- 1
+	semNnfNodeStorageDone := make(chan struct{})
 	err = (&NnfNodeStorageReconciler{
 		Client:            k8sManager.GetClient(),
 		Log:               ctrl.Log.WithName("controllers").WithName("NnfNodeStorage"),

--- a/mount-daemon/main.go
+++ b/mount-daemon/main.go
@@ -239,7 +239,8 @@ func startManager(config *managerConfig) {
 		os.Exit(1)
 	}
 
-	semReady := make(chan int, 1)
+	semReady := make(chan struct{})
+	close(semReady)
 	if err = (&controllers.NnfClientMountReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("ClientMount"),


### PR DESCRIPTION
Add channel semaphores to serialize the startup of the NLC reconcilers that are using EC.  Add locks to each reconciler to block its Reconcile() until it has completed its Start().

This is a rewrite of an earlier version, this time using close() on the channel rather than leaving the channels open.