### PR TITLE
Daemon RPM build rework

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,5 @@
 Dockerfile
 .git
 .vscode
+internal/controller/nnf.db
+

--- a/.github/workflows/rpm_build.yml
+++ b/.github/workflows/rpm_build.yml
@@ -1,73 +1,53 @@
+# Testing with nektos/act:
+#   $ act --rm -j rpm_build --container-architecture linux/amd64 --pull=false --bind push
+#
+
+
 name: RPM Build
 on:
   push:
     branches:
       - '*'
-    tags:
-      - 'v*'
 
 jobs:
-  repo_version:
-    runs-on: ubuntu-latest
-    outputs:
-      version_output: ${{ steps.step1.outputs.version }}
-    steps:
-      - name: Verify context
-        run: |
-          echo "ref is ${{ github.ref }}"
-          echo "ref_type is ${{ github.ref_type }}"
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Get Version
-        id: step1
-        run: echo "version=$(./git-version-gen)" >> $GITHUB_OUTPUT
-
   rpm_build:
     runs-on: ubuntu-latest
-    needs: repo_version
-    container:
-      image: centos:8
-      env:
-        NODE_ENV: development
-      ports:
-        - 80
-      options: --cpus 1
     steps:
-      - name: "Build context"
-        env:
-          VERSION_OUTPUT: ${{ needs.repo_version.outputs.version_output }}
-        run: |
-          echo "ref is ${{ github.ref }}"
-          echo "ref_type is ${{ github.ref_type }}"
-          echo "head.sha is ${{ github.event.pull_request.head.sha }}"
-          echo "git-version-gen is $VERSION_OUTPUT"
+    - name: checkout
+      if: ${{ !env.ACT }} # skip during local actions testing
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: environment setup
-        env:
-          VERSION_OUTPUT: ${{ needs.repo_version.outputs.version_output }}
-        run: |
-          dnf -y --disablerepo '*' --enablerepo=extras swap centos-linux-repos centos-stream-repos
-          dnf -y distro-sync
-          dnf -y makecache --refresh
-          dnf install -y rpm-build rpmdevtools git make
-          dnf module -y install go-toolset 
-          rpmdev-setuptree
-          echo $VERSION_OUTPUT > .rpmversion
-          cat .rpmversion
-          tar -czf /github/home/rpmbuild/SOURCES/nnf-clientmount-1.0.tar.gz --transform 's,^,nnf-clientmount-1.0/,' .
-      - name: build rpms
-        run: rpmbuild -ba clientmount.spec
-      - name: upload rpms
-        uses: actions/upload-artifact@v3
-        with:
-          name: nnf-clientmount-1.0-1.el8.x86_64.rpm
-          path: /github/home/rpmbuild/RPMS/x86_64/nnf-clientmount-1.0-1.el8.x86_64.rpm
-      - name: upload srpms
-        uses: actions/upload-artifact@v3
-        with:
-          name: nnf-clientmount-1.0-1.el8.src.rpm
-          path: /github/home/rpmbuild/SRPMS/nnf-clientmount-1.0-1.el8.src.rpm
+    - name: context
+      run: |
+        echo "ref is ${{ github.ref }}"
+        echo "ref_type is ${{ github.ref_type }}"
+        echo "head.sha is ${{ github.event.pull_request.head.sha }}"
+        echo "git-version-gen: $(./git-version-gen)"
+        echo "want go version: $(grep -E '^go ' go.mod)"
+
+    - name: setup go
+      # This is needed only because the 'make build-daemon' target will run
+      # the 'go fmt' and 'go vet' commands before it starts the docker build.
+      if: ${{ env.ACT }} # use during local actions testing
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+
+    - name: build rpms
+      run: |
+         go version
+         pwd
+         make build-daemon-rpm
+         /bin/ls -al rpms
+
+    - name: upload rpms
+      if: ${{ !env.ACT }} # skip during local actions testing
+      uses: actions/upload-artifact@v4
+      with:
+         name: nnf-clientmount.rpm
+         path: /home/runner/work/nnf-sos/nnf-sos/rpms/*
+         if-no-files-found: error
+

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ nnf-sos
 .version
 config/begin/*
 config/begin-examples/*
+rpms/
 
 # .vscode log files
 .vscode/*.log

--- a/Dockerfile.rpmbuild
+++ b/Dockerfile.rpmbuild
@@ -1,0 +1,77 @@
+# Copyright 2024 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM --platform=$BUILDPLATFORM golang:1.19 AS gobuilder
+
+ARG TARGETARCH
+ARG TARGETOS
+ARG RPMVERSION
+
+ARG PACKAGE_VERSION="github.com/NearNodeFlash/nnf-sos/mount-daemon/version"
+
+WORKDIR /workspace
+
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# Copy the go source
+COPY clientmount.spec clientmount.spec
+COPY mount-daemon/ mount-daemon/
+COPY api/ api/
+COPY internal/ internal/
+COPY pkg/ pkg/
+COPY vendor/ vendor/
+
+# Build
+# the GOARCH has a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+
+RUN mkdir /artifacts && \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags="-X '$PACKAGE_VERSION.version=$RPMVERSION'" -a -o /artifacts/clientmountd mount-daemon/main.go && \
+    tar -czf /artifacts/nnf-clientmount-$RPMVERSION.tar.gz --transform 's,^,nnf-clientmount-'$RPMVERSION'/,' .
+
+FROM --platform=$BUILDPLATFORM centos:8 AS rpmbuilder
+
+ARG RPMVERSION
+ARG RPMTARGET
+
+# The mkdirs in /root/rpmbuild would normally be done by rpmdev-setuptree.
+# However, we're trying to cut the run time and that drags in a lot of
+# dependencies.
+RUN dnf -y --disablerepo '*' --enablerepo=extras swap centos-linux-repos centos-stream-repos && \
+    dnf -y install rpm-build && \
+    mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES
+
+WORKDIR /workspace
+
+COPY --from=gobuilder /workspace/clientmount.spec clientmount.spec
+COPY --from=gobuilder /artifacts/* /workspace/
+
+RUN sed -i.bak -e 's/^Version: .*/Version: '$RPMVERSION'/' clientmount.spec && \
+    cp nnf-clientmount-$RPMVERSION.tar.gz /root/rpmbuild/SOURCES/ && \
+    rpmbuild --target=$RPMTARGET -bb clientmount.spec && \
+    mkdir /artifacts && \
+    find /root/rpmbuild/RPMS -name '*.rpm' -exec cp {} /artifacts \;
+
+CMD ["/bin/ls", "-al", "/artifacts"]
+
+FROM scratch AS artifacts
+COPY --from=rpmbuilder /artifacts/* /
+

--- a/clientmount.spec
+++ b/clientmount.spec
@@ -11,8 +11,6 @@ License: Apache-2.0
 URL: https://github.com/NearNodeFlash/nnf-sos
 Source0: %{name}-%{version}.tar.gz
 
-BuildRequires:	golang
-BuildRequires:	make
 
 %description
 This package provides clientmountd for performing mount operations for the
@@ -22,7 +20,8 @@ near node flash software
 %setup -q
 
 %build
-RPM_VERSION=$(cat .rpmversion) make build-daemon
+# The executable was already created by the Dockerfile.
+mkdir bin && cp /workspace/clientmountd bin
 
 %install
 mkdir -p %{buildroot}/usr/bin/


### PR DESCRIPTION
Build the daemon in an environment defined by a Dockerfile, and build it with the same environment whether it's built locally or within a workflow.

Using `make build-daemon` will build the daemon locally as always and continue to drop it into the local bin/ directory.

Using `make build-daemon-rpm` will build the daemon within the container environment and will drop the resulting rpm in a local rpm/ directory.

In tests so far, this tends to cut the build time within the workflow to about 1/3 of the time that we've seen in the past.