### PR TITLE
Handle empty capacity when a drive cannot be found.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,10 @@ module github.com/NearNodeFlash/nnf-sos
 
 go 1.19
 
-replace github.com/NearNodeFlash/nnf-ec => ../../nnf-ec-1.git
-
 require (
 	github.com/DataWorkflowServices/dws v0.0.1-0.20240423152131-d92c9aadede8
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240326175906-15cfe803227d
-	github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240318141758-e8ded5e13eb8
+	github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240607170045-9d0ccb5f133a
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.4
 	github.com/google/uuid v1.3.1

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/NearNodeFlash/nnf-sos
 
 go 1.19
 
+replace github.com/NearNodeFlash/nnf-ec => ../../nnf-ec-1.git
+
 require (
 	github.com/DataWorkflowServices/dws v0.0.1-0.20240423152131-d92c9aadede8
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240326175906-15cfe803227d

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/HewlettPackard/structex v1.0.4 h1:RVTdN5FWhDWr1IkjllU8wxuLjISo4gr6u5r
 github.com/HewlettPackard/structex v1.0.4/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240326175906-15cfe803227d h1:gqAZOwvFrsgsAQYLqSnMBU4aALOH7+QpqYruhhI6MZU=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240326175906-15cfe803227d/go.mod h1:qBcz9p8sXm1qhDf8WUmhxTlD1NCMEjoAD7NoHbQvMiI=
+github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240607170045-9d0ccb5f133a h1:kPZLD7j4X0Cs+dNlhNRiY/1CrWugbEdWgY+orX2vYMw=
+github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240607170045-9d0ccb5f133a/go.mod h1:oxdwMqfttOF9dabJhqrWlirCnMk8/8eyLMwl+hducjk=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/HewlettPackard/structex v1.0.4 h1:RVTdN5FWhDWr1IkjllU8wxuLjISo4gr6u5r
 github.com/HewlettPackard/structex v1.0.4/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240326175906-15cfe803227d h1:gqAZOwvFrsgsAQYLqSnMBU4aALOH7+QpqYruhhI6MZU=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240326175906-15cfe803227d/go.mod h1:qBcz9p8sXm1qhDf8WUmhxTlD1NCMEjoAD7NoHbQvMiI=
-github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240318141758-e8ded5e13eb8 h1:Ja+ZQVGl/+buQXGqKFsM5mDwX4ReiI5UkputLsaiRSo=
-github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240318141758-e8ded5e13eb8/go.mod h1:oxdwMqfttOF9dabJhqrWlirCnMk8/8eyLMwl+hducjk=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nvme/manager.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nvme/manager.go
@@ -1137,7 +1137,12 @@ func (mgr *Manager) StorageIdStoragePoolsStoragePoolIdGet(storageId, storagePool
 		},
 	}
 
-	model.RemainingCapacityPercent = int64(float64(s.unallocatedBytes/s.capacityBytes) * 100.0)
+	if s.capacityBytes == 0 {
+		// If a drive could not be found, don't divide by zero.
+		model.RemainingCapacityPercent = 0
+	} else {
+		model.RemainingCapacityPercent = int64(float64(s.unallocatedBytes/s.capacityBytes) * 100.0)
+	}
 
 	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -15,7 +15,7 @@ github.com/HewlettPackard/structex
 ## explicit; go 1.19
 github.com/NearNodeFlash/lustre-fs-operator/api/v1beta1
 github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
-# github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240318141758-e8ded5e13eb8
+# github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240318141758-e8ded5e13eb8 => ../../nnf-ec-1.git
 ## explicit; go 1.19
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/switchtec
@@ -791,3 +791,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# github.com/NearNodeFlash/nnf-ec => ../../nnf-ec-1.git

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -15,7 +15,7 @@ github.com/HewlettPackard/structex
 ## explicit; go 1.19
 github.com/NearNodeFlash/lustre-fs-operator/api/v1beta1
 github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
-# github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240318141758-e8ded5e13eb8 => ../../nnf-ec-1.git
+# github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240607170045-9d0ccb5f133a
 ## explicit; go 1.19
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/switchtec
@@ -791,4 +791,3 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/NearNodeFlash/nnf-ec => ../../nnf-ec-1.git


### PR DESCRIPTION
Avoid doing a divide-by-zero and panicing the process.