### PR TITLE
Add option for a single shared VG per Rabbit per workflow

### DIFF
--- a/api/v1alpha1/nnf_node_block_storage_types.go
+++ b/api/v1alpha1/nnf_node_block_storage_types.go
@@ -37,6 +37,9 @@ type NnfNodeBlockStorageAllocationSpec struct {
 // NnfNodeBlockStorageSpec defines the desired storage attributes on a NNF Node.
 // Storage spec are created on request of the user and fullfilled by the NNF Node Controller.
 type NnfNodeBlockStorageSpec struct {
+	// SharedAllocation is used when a single NnfNodeBlockStorage allocation is used by multiple NnfNodeStorage allocations
+	SharedAllocation bool `json:"sharedAllocation"`
+
 	// Allocations is the list of storage allocations to make
 	Allocations []NnfNodeBlockStorageAllocationSpec `json:"allocations,omitempty"`
 }

--- a/api/v1alpha1/nnf_node_storage_types.go
+++ b/api/v1alpha1/nnf_node_storage_types.go
@@ -38,6 +38,12 @@ type NnfNodeStorageSpec struct {
 	// +kubebuilder:validation:Minimum:=0
 	Count int `json:"count"`
 
+	// SharedAllocation is used when a single NnfNodeBlockStorage allocation is used by multiple NnfNodeStorage allocations
+	SharedAllocation bool `json:"sharedAllocation"`
+
+	// Capacity of an individual allocation
+	Capacity int64 `json:"capacity,omitempty"`
+
 	// User ID for file system
 	UserID uint32 `json:"userID"`
 

--- a/api/v1alpha1/nnf_storage_types.go
+++ b/api/v1alpha1/nnf_storage_types.go
@@ -75,6 +75,10 @@ type NnfStorageAllocationSetSpec struct {
 	// Lustre specific configuration
 	NnfStorageLustreSpec `json:",inline"`
 
+	// SharedAllocation shares a single block storage allocation between multiple file system allocations
+	// (within the same workflow) on a Rabbit
+	SharedAllocation bool `json:"sharedAllocation"`
+
 	// Nodes is the list of Rabbit nodes to make allocations on
 	Nodes []NnfStorageAllocationNodes `json:"nodes"`
 }

--- a/api/v1alpha1/nnfstorageprofile_types.go
+++ b/api/v1alpha1/nnfstorageprofile_types.go
@@ -130,6 +130,11 @@ type NnfStorageProfileCmdLines struct {
 	// Mkfs specifies the mkfs commandline, minus the "mkfs".
 	Mkfs string `json:"mkfs,omitempty"`
 
+	// SharedVg specifies that allocations from a workflow on the same Rabbit should share an
+	// LVM VolumeGroup
+	// +kubebuilder:default:=false
+	SharedVg bool `json:"sharedVg,omitempty"`
+
 	// PvCreate specifies the pvcreate commandline, minus the "pvcreate".
 	PvCreate string `json:"pvCreate,omitempty"`
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -233,6 +233,7 @@ func (c *nodeLocalController) SetupReconcilers(mgr manager.Manager, opts *nnf.Op
 		Log:               ctrl.Log.WithName("controllers").WithName("NnfClientMount"),
 		Scheme:            mgr.GetScheme(),
 		SemaphoreForStart: semNnfNodeStorageDone,
+		ClientType:        controllers.ClientRabbit,
 	}).SetupWithManager(mgr); err != nil {
 		return err
 	}

--- a/config/crd/bases/nnf.cray.hpe.com_nnfnodeblockstorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfnodeblockstorages.yaml
@@ -66,6 +66,12 @@ spec:
                       type: integer
                   type: object
                 type: array
+              sharedAllocation:
+                description: SharedAllocation is used when a single NnfNodeBlockStorage
+                  allocation is used by multiple NnfNodeStorage allocations
+                type: boolean
+            required:
+            - sharedAllocation
             type: object
           status:
             properties:

--- a/config/crd/bases/nnf.cray.hpe.com_nnfnodestorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfnodestorages.yaml
@@ -95,6 +95,10 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              capacity:
+                description: Capacity of an individual allocation
+                format: int64
+                type: integer
               count:
                 description: |-
                   Count is the number of allocations to make on this node. All of the allocations will
@@ -156,6 +160,10 @@ spec:
                     - ost
                     type: string
                 type: object
+              sharedAllocation:
+                description: SharedAllocation is used when a single NnfNodeBlockStorage
+                  allocation is used by multiple NnfNodeStorage allocations
+                type: boolean
               userID:
                 description: User ID for file system
                 format: int32
@@ -164,6 +172,7 @@ spec:
             - count
             - fileSystemType
             - groupID
+            - sharedAllocation
             - userID
             type: object
           status:

--- a/config/crd/bases/nnf.cray.hpe.com_nnfstorageprofiles.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfstorageprofiles.yaml
@@ -90,6 +90,12 @@ spec:
                         description: PvRemove specifies the pvremove commandline,
                           minus the "pvremove".
                         type: string
+                      sharedVg:
+                        default: false
+                        description: |-
+                          SharedVg specifies that allocations from a workflow on the same Rabbit should share an
+                          LVM VolumeGroup
+                        type: boolean
                       vgChange:
                         description: VgChange specifies the various vgchange commandlines,
                           minus the "vgchange"
@@ -394,6 +400,12 @@ spec:
                         description: PvRemove specifies the pvremove commandline,
                           minus the "pvremove".
                         type: string
+                      sharedVg:
+                        default: false
+                        description: |-
+                          SharedVg specifies that allocations from a workflow on the same Rabbit should share an
+                          LVM VolumeGroup
+                        type: boolean
                       vgChange:
                         description: VgChange specifies the various vgchange commandlines,
                           minus the "vgchange"
@@ -465,6 +477,12 @@ spec:
                         description: PvRemove specifies the pvremove commandline,
                           minus the "pvremove".
                         type: string
+                      sharedVg:
+                        default: false
+                        description: |-
+                          SharedVg specifies that allocations from a workflow on the same Rabbit should share an
+                          LVM VolumeGroup
+                        type: boolean
                       vgChange:
                         description: VgChange specifies the various vgchange commandlines,
                           minus the "vgchange"

--- a/config/crd/bases/nnf.cray.hpe.com_nnfstorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfstorages.yaml
@@ -152,6 +152,11 @@ spec:
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
+                    sharedAllocation:
+                      description: |-
+                        SharedAllocation shares a single block storage allocation between multiple file system allocations
+                        (within the same workflow) on a Rabbit
+                      type: boolean
                     targetType:
                       description: TargetType is the type of Lustre target to be created.
                       enum:
@@ -164,6 +169,7 @@ spec:
                   - capacity
                   - name
                   - nodes
+                  - sharedAllocation
                   type: object
                 type: array
               fileSystemType:

--- a/config/examples/nnf_v1alpha1_nnfstorageprofile.yaml
+++ b/config/examples/nnf_v1alpha1_nnfstorageprofile.yaml
@@ -36,6 +36,7 @@ data:
     mountCompute: $MGS_NID:/$FS_NAME $MOUNT_PATH
   gfs2Storage:
     commandlines:
+      sharedVg: true
       pvCreate: $DEVICE
       pvRemove: $DEVICE
       vgCreate: --shared $VG_NAME $DEVICE_LIST
@@ -43,7 +44,7 @@ data:
         lockStart: --lock-start $VG_NAME
         lockStop: --lock-stop $VG_NAME
       vgRemove: $VG_NAME
-      lvCreate: --zero n --activate n --extents 100%VG --stripes $DEVICE_NUM --stripesize=32KiB --name $LV_NAME $VG_NAME
+      lvCreate: --zero n --activate n --extents $PERCENT_VG --stripes $DEVICE_NUM --stripesize=32KiB --name $LV_NAME $VG_NAME
       lvChange:
         activate: --activate ys $VG_NAME/$LV_NAME
         deactivate: --activate n $VG_NAME/$LV_NAME
@@ -53,6 +54,7 @@ data:
       mountCompute: $DEVICE $MOUNT_PATH
   xfsStorage:
     commandlines:
+      sharedVg: true
       pvCreate: $DEVICE
       pvRemove: $DEVICE
       vgCreate: --shared $VG_NAME $DEVICE_LIST
@@ -60,7 +62,7 @@ data:
         lockStart: --lock-start $VG_NAME
         lockStop: --lock-stop $VG_NAME
       vgRemove: $VG_NAME
-      lvCreate: --zero n --activate n --extents 100%VG --stripes $DEVICE_NUM --stripesize=32KiB --name $LV_NAME $VG_NAME
+      lvCreate: --zero n --activate n --extents $PERCENT_VG --stripes $DEVICE_NUM --stripesize=32KiB --name $LV_NAME $VG_NAME
       lvChange:
         activate: --activate y $VG_NAME/$LV_NAME
         deactivate: --activate n $VG_NAME/$LV_NAME
@@ -70,6 +72,7 @@ data:
       mountCompute: $DEVICE $MOUNT_PATH
   rawStorage:
     commandlines:
+      sharedVg: true
       pvCreate: $DEVICE
       pvRemove: $DEVICE
       vgCreate: --shared $VG_NAME $DEVICE_LIST
@@ -77,7 +80,7 @@ data:
         lockStart: --lock-start $VG_NAME
         lockStop: --lock-stop $VG_NAME
       vgRemove: $VG_NAME
-      lvCreate: --zero n --activate n --extents 100%VG --stripes $DEVICE_NUM --stripesize=32KiB --name $LV_NAME $VG_NAME
+      lvCreate: --zero n --activate n --extents $PERCENT_VG --stripes $DEVICE_NUM --stripesize=32KiB --name $LV_NAME $VG_NAME
       lvChange:
         activate: --activate y $VG_NAME/$LV_NAME
         deactivate: --activate n $VG_NAME/$LV_NAME

--- a/internal/controller/filesystem_helpers.go
+++ b/internal/controller/filesystem_helpers.go
@@ -183,6 +183,11 @@ func newLvmBlockDevice(ctx context.Context, c client.Client, nnfNodeStorage *nnf
 	lvmDesc := blockdevice.Lvm{}
 	devices := []string{}
 
+	blockIndex := index
+	if nnfNodeStorage.Spec.SharedAllocation {
+		blockIndex = 0
+	}
+
 	if nnfNodeStorage.Spec.BlockReference.Kind == reflect.TypeOf(nnfv1alpha1.NnfNodeBlockStorage{}).Name() {
 		nnfNodeBlockStorage := &nnfv1alpha1.NnfNodeBlockStorage{
 			ObjectMeta: metav1.ObjectMeta{
@@ -196,8 +201,8 @@ func newLvmBlockDevice(ctx context.Context, c client.Client, nnfNodeStorage *nnf
 			return nil, dwsv1alpha2.NewResourceError("could not get NnfNodeBlockStorage: %v", client.ObjectKeyFromObject(nnfNodeBlockStorage)).WithError(err).WithUserMessage("could not find storage allocation").WithMajor()
 		}
 
-		if len(nnfNodeBlockStorage.Status.Allocations) > 0 && len(nnfNodeBlockStorage.Status.Allocations[index].Accesses) > 0 {
-			devices = nnfNodeBlockStorage.Status.Allocations[index].Accesses[os.Getenv("NNF_NODE_NAME")].DevicePaths
+		if len(nnfNodeBlockStorage.Status.Allocations) > 0 && len(nnfNodeBlockStorage.Status.Allocations[blockIndex].Accesses) > 0 {
+			devices = nnfNodeBlockStorage.Status.Allocations[blockIndex].Accesses[os.Getenv("NNF_NODE_NAME")].DevicePaths
 		} else {
 			// FIXME: This scenario has been encountered after rapid transitions from Setup to
 			// Teardown. The reason is not yet known, but we need a way to log and capture this
@@ -217,7 +222,7 @@ func newLvmBlockDevice(ctx context.Context, c client.Client, nnfNodeStorage *nnf
 		lvmDesc.PhysicalVolumes = append(lvmDesc.PhysicalVolumes, pv)
 	}
 
-	vgName, err := volumeGroupName(ctx, c, nnfNodeStorage, index)
+	vgName, err := volumeGroupName(ctx, c, nnfNodeStorage, blockIndex)
 	if err != nil {
 		return nil, dwsv1alpha2.NewResourceError("could not get volume group name").WithError(err).WithMajor()
 	}
@@ -227,9 +232,14 @@ func newLvmBlockDevice(ctx context.Context, c client.Client, nnfNodeStorage *nnf
 		return nil, dwsv1alpha2.NewResourceError("could not get logical volume name").WithError(err).WithMajor()
 	}
 
+	percentVG := 100
+	if nnfNodeStorage.Spec.SharedAllocation {
+		percentVG = 100 / nnfNodeStorage.Spec.Count
+	}
+
 	lvmDesc.Log = log
 	lvmDesc.VolumeGroup = lvm.NewVolumeGroup(ctx, vgName, lvmDesc.PhysicalVolumes, log)
-	lvmDesc.LogicalVolume = lvm.NewLogicalVolume(ctx, lvName, lvmDesc.VolumeGroup, log)
+	lvmDesc.LogicalVolume = lvm.NewLogicalVolume(ctx, lvName, lvmDesc.VolumeGroup, nnfNodeStorage.Spec.Capacity, percentVG, log)
 
 	lvmDesc.CommandArgs.PvArgs.Create = cmdLines.PvCreate
 	lvmDesc.CommandArgs.PvArgs.Remove = cmdLines.PvRemove
@@ -358,11 +368,18 @@ func volumeGroupName(ctx context.Context, c client.Client, nnfNodeStorage *nnfv1
 		return "", fmt.Errorf("missing directive index label on NnfNodeStorage")
 	}
 
+	if nnfNodeStorage.Spec.SharedAllocation {
+		return fmt.Sprintf("%s_%s", nnfStorageUid, directiveIndex), nil
+	}
+
 	return fmt.Sprintf("%s_%s_%d", nnfStorageUid, directiveIndex, index), nil
 }
 
 func logicalVolumeName(ctx context.Context, c client.Client, nnfNodeStorage *nnfv1alpha1.NnfNodeStorage, index int) (string, error) {
-	// For now just return "lv" as the lv name. If we end up sharing a volume group for multiple lvs, then
-	// this name needs to be something unique
+	if nnfNodeStorage.Spec.SharedAllocation {
+		// For a shared VG, the LV name must be unique in the VG
+		return fmt.Sprintf("lv-%d", index), nil
+	}
+
 	return "lv", nil
 }

--- a/internal/controller/nnf_access_controller.go
+++ b/internal/controller/nnf_access_controller.go
@@ -765,9 +765,13 @@ func (r *NnfAccessReconciler) addBlockStorageAccess(ctx context.Context, access 
 		// index found from the "storage" resource to account for the 0 index being the rabbit
 		// in swordfish.
 		for _, mountRef := range mountRefList {
+			allocationIndex := mountRef.allocationIndex
+			if nnfNodeBlockStorage.Spec.SharedAllocation {
+				allocationIndex = 0
+			}
 			// Add the client name to the access list if it's not already there
-			if slices.IndexFunc(nnfNodeBlockStorage.Spec.Allocations[mountRef.allocationIndex].Access, func(n string) bool { return n == mountRef.client }) < 0 {
-				nnfNodeBlockStorage.Spec.Allocations[mountRef.allocationIndex].Access = append(nnfNodeBlockStorage.Spec.Allocations[mountRef.allocationIndex].Access, mountRef.client)
+			if slices.IndexFunc(nnfNodeBlockStorage.Spec.Allocations[allocationIndex].Access, func(n string) bool { return n == mountRef.client }) < 0 {
+				nnfNodeBlockStorage.Spec.Allocations[allocationIndex].Access = append(nnfNodeBlockStorage.Spec.Allocations[allocationIndex].Access, mountRef.client)
 			}
 		}
 
@@ -852,7 +856,7 @@ func (r *NnfAccessReconciler) removeBlockStorageAccess(ctx context.Context, acce
 				continue
 			}
 
-			if mount.Device.DeviceReference.ObjectReference.Kind != reflect.TypeOf(nnfv1alpha1.NnfNodeBlockStorage{}).Name() {
+			if mount.Device.DeviceReference.ObjectReference.Kind != reflect.TypeOf(nnfv1alpha1.NnfNodeStorage{}).Name() {
 				continue
 			}
 

--- a/internal/controller/nnf_access_controller_test.go
+++ b/internal/controller/nnf_access_controller_test.go
@@ -130,8 +130,8 @@ var _ = Describe("Access Controller Test", func() {
 			Expect(k8sClient.Create(context.TODO(), storages[i])).To(Succeed())
 		}
 
-		// Create a default NnfStorageProfile for the unit tests.
-		storageProfile = createBasicDefaultNnfStorageProfile()
+		// Create a pinned NnfStorageProfile for the unit tests.
+		storageProfile = createBasicPinnedNnfStorageProfile()
 	})
 
 	AfterEach(func() {

--- a/internal/controller/nnf_node_block_storage_controller.go
+++ b/internal/controller/nnf_node_block_storage_controller.go
@@ -268,8 +268,6 @@ func (r *NnfNodeBlockStorageReconciler) allocateStorage(nodeBlockStorage *nnfv1a
 	if len(allocationStatus.StoragePoolId) == 0 {
 		log.Info("Created storage pool", "Id", sp.Id)
 		allocationStatus.StoragePoolId = sp.Id
-
-		return nil, nil
 	}
 
 	return nil, nil
@@ -343,7 +341,11 @@ func (r *NnfNodeBlockStorageReconciler) createBlockDevice(ctx context.Context, n
 				return nil, dwsv1alpha2.NewResourceError("could not delete storage group").WithError(err).WithMajor()
 			}
 
-			delete(allocationStatus.Accesses, nodeName)
+			for oldNodeName, accessStatus := range allocationStatus.Accesses {
+				if accessStatus.StorageGroupId == storageGroupId {
+					delete(allocationStatus.Accesses, oldNodeName)
+				}
+			}
 
 			log.Info("Deleted storage group", "storageGroupId", storageGroupId)
 		} else {
@@ -379,13 +381,13 @@ func (r *NnfNodeBlockStorageReconciler) createBlockDevice(ctx context.Context, n
 
 			// The device paths are discovered below. This is only relevant for the Rabbit node access
 			if nodeName != clients[0] {
-				return nil, nil
+				continue
 			}
 
 			// Bail out if this is kind
 			_, found := os.LookupEnv("NNF_TEST_ENVIRONMENT")
 			if found || os.Getenv("ENVIRONMENT") == "kind" {
-				return nil, nil
+				continue
 			}
 
 			// Initialize the path array if it doesn't exist yet

--- a/internal/controller/nnf_node_storage_controller.go
+++ b/internal/controller/nnf_node_storage_controller.go
@@ -34,6 +34,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/NearNodeFlash/nnf-sos/pkg/blockdevice"
+	"github.com/NearNodeFlash/nnf-sos/pkg/filesystem"
+
 	dwsv1alpha2 "github.com/DataWorkflowServices/dws/api/v1alpha2"
 	"github.com/DataWorkflowServices/dws/utils/updater"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
@@ -189,15 +192,26 @@ func (r *NnfNodeStorageReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	// Loop through each allocation and create the storage
+	blockDevices := []blockdevice.BlockDevice{}
+	fileSystems := []filesystem.FileSystem{}
+
+	// Create a list of all the block devices and file systems that need to be created
 	for i := 0; i < nnfNodeStorage.Spec.Count; i++ {
-		result, err := r.createAllocation(ctx, nnfNodeStorage, i)
+		blockDevice, fileSystem, err := getBlockDeviceAndFileSystem(ctx, r.Client, nnfNodeStorage, i, log)
 		if err != nil {
-			return ctrl.Result{}, dwsv1alpha2.NewResourceError("unable to format file system for allocation %v", i).WithError(err).WithMajor()
+			return ctrl.Result{}, err
 		}
-		if result != nil {
-			return *result, nil
-		}
+
+		blockDevices = append(blockDevices, blockDevice)
+		fileSystems = append(fileSystems, fileSystem)
+	}
+
+	result, err := r.createAllocations(ctx, nnfNodeStorage, blockDevices, fileSystems)
+	if err != nil {
+		return ctrl.Result{}, dwsv1alpha2.NewResourceError("unable to create storage allocation").WithError(err).WithMajor()
+	}
+	if result != nil {
+		return *result, nil
 	}
 
 	for _, allocation := range nnfNodeStorage.Status.Allocations {
@@ -237,7 +251,7 @@ func (r *NnfNodeStorageReconciler) deleteAllocation(ctx context.Context, nnfNode
 		log.Info("Destroyed file system", "allocation", index)
 	}
 
-	ran, err = blockDevice.Deactivate(ctx)
+	ran, err = blockDevice.Deactivate(ctx, false)
 	if err != nil {
 		return nil, dwsv1alpha2.NewResourceError("could not deactivate block devices").WithError(err).WithMajor()
 	}
@@ -256,50 +270,73 @@ func (r *NnfNodeStorageReconciler) deleteAllocation(ctx context.Context, nnfNode
 	return nil, nil
 }
 
-func (r *NnfNodeStorageReconciler) createAllocation(ctx context.Context, nnfNodeStorage *nnfv1alpha1.NnfNodeStorage, index int) (*ctrl.Result, error) {
-	log := r.Log.WithValues("NnfNodeStorage", client.ObjectKeyFromObject(nnfNodeStorage), "index", index)
+func (r *NnfNodeStorageReconciler) createAllocations(ctx context.Context, nnfNodeStorage *nnfv1alpha1.NnfNodeStorage, blockDevices []blockdevice.BlockDevice, fileSystems []filesystem.FileSystem) (*ctrl.Result, error) {
+	log := r.Log.WithValues("NnfNodeStorage", client.ObjectKeyFromObject(nnfNodeStorage))
 
-	blockDevice, fileSystem, err := getBlockDeviceAndFileSystem(ctx, r.Client, nnfNodeStorage, index, log)
-	if err != nil {
-		return nil, err
-	}
+	for index, blockDevice := range blockDevices {
+		allocationStatus := &nnfNodeStorage.Status.Allocations[index]
 
-	allocationStatus := &nnfNodeStorage.Status.Allocations[index]
-	ran, err := blockDevice.Create(ctx, allocationStatus.Ready)
-	if err != nil {
-		return nil, dwsv1alpha2.NewResourceError("could not create block devices").WithError(err).WithMajor()
-	}
-	if ran {
-		log.Info("Created block device", "allocation", index)
-	}
+		// Skip allocations that are already created
+		if allocationStatus.Ready {
+			continue
+		}
 
-	// We don't need to activate the block device here. It will be activated either when there is a mkfs, or when it's used
-	// by a ClientMount
-	ran, err = fileSystem.Create(ctx, allocationStatus.Ready)
-	if err != nil {
-		return nil, dwsv1alpha2.NewResourceError("could not create file system").WithError(err).WithMajor()
-	}
-	if ran {
-		log.Info("Created file system", "allocation", index)
-	}
+		ran, err := blockDevice.Create(ctx, allocationStatus.Ready)
+		if err != nil {
+			return nil, dwsv1alpha2.NewResourceError("could not create block devices").WithError(err).WithMajor()
+		}
+		if ran {
+			log.Info("Created block device", "allocation", index)
+		}
 
-	ran, err = fileSystem.Activate(ctx, allocationStatus.Ready)
-	if err != nil {
-		return nil, dwsv1alpha2.NewResourceError("could not activate file system").WithError(err).WithMajor()
-	}
-	if ran {
-		log.Info("Activated file system", "allocation", index)
+		_, err = blockDevice.Activate(ctx)
+		if err != nil {
+			return nil, dwsv1alpha2.NewResourceError("could not activate block devices").WithError(err).WithMajor()
+		}
+
+		deferIndex := index
+		defer func() {
+			_, err = blockDevices[deferIndex].Deactivate(ctx, false)
+			if err != nil {
+				allocationStatus.Ready = false
+			}
+		}()
 	}
 
-	ran, err = fileSystem.SetPermissions(ctx, nnfNodeStorage.Spec.UserID, nnfNodeStorage.Spec.GroupID, allocationStatus.Ready)
-	if err != nil {
-		return nil, dwsv1alpha2.NewResourceError("could not set file system permissions").WithError(err).WithMajor()
-	}
-	if ran {
-		log.Info("Set file system permission", "allocation", index)
-	}
+	for index, fileSystem := range fileSystems {
+		allocationStatus := &nnfNodeStorage.Status.Allocations[index]
 
-	allocationStatus.Ready = true
+		// Skip allocations that are already created
+		if allocationStatus.Ready {
+			continue
+		}
+
+		ran, err := fileSystem.Create(ctx, allocationStatus.Ready)
+		if err != nil {
+			return nil, dwsv1alpha2.NewResourceError("could not create file system").WithError(err).WithMajor()
+		}
+		if ran {
+			log.Info("Created file system", "allocation", index)
+		}
+
+		ran, err = fileSystem.Activate(ctx, allocationStatus.Ready)
+		if err != nil {
+			return nil, dwsv1alpha2.NewResourceError("could not activate file system").WithError(err).WithMajor()
+		}
+		if ran {
+			log.Info("Activated file system", "allocation", index)
+		}
+
+		ran, err = fileSystem.SetPermissions(ctx, nnfNodeStorage.Spec.UserID, nnfNodeStorage.Spec.GroupID, allocationStatus.Ready)
+		if err != nil {
+			return nil, dwsv1alpha2.NewResourceError("could not set file system permissions").WithError(err).WithMajor()
+		}
+		if ran {
+			log.Info("Set file system permission", "allocation", index)
+		}
+
+		allocationStatus.Ready = true
+	}
 
 	return nil, nil
 }

--- a/internal/controller/nnf_storage_controller.go
+++ b/internal/controller/nnf_storage_controller.go
@@ -344,12 +344,18 @@ func (r *NnfStorageReconciler) createNodeBlockStorage(ctx context.Context, nnfSt
 				labels[nnfv1alpha1.AllocationSetLabel] = allocationSet.Name
 				nnfNodeBlockStorage.SetLabels(labels)
 
+				expectedAllocations := node.Count
+				if allocationSet.SharedAllocation {
+					expectedAllocations = 1
+				}
+				nnfNodeBlockStorage.Spec.SharedAllocation = allocationSet.SharedAllocation
+
 				if len(nnfNodeBlockStorage.Spec.Allocations) == 0 {
-					nnfNodeBlockStorage.Spec.Allocations = make([]nnfv1alpha1.NnfNodeBlockStorageAllocationSpec, node.Count)
+					nnfNodeBlockStorage.Spec.Allocations = make([]nnfv1alpha1.NnfNodeBlockStorageAllocationSpec, expectedAllocations)
 				}
 
-				if len(nnfNodeBlockStorage.Spec.Allocations) != node.Count {
-					return dwsv1alpha2.NewResourceError("block storage allocation count incorrect. found %v, expected %v", len(nnfNodeBlockStorage.Spec.Allocations), node.Count).WithFatal()
+				if len(nnfNodeBlockStorage.Spec.Allocations) != expectedAllocations {
+					return dwsv1alpha2.NewResourceError("block storage allocation count incorrect. found %v, expected %v", len(nnfNodeBlockStorage.Spec.Allocations), expectedAllocations).WithFatal()
 				}
 
 				for i := range nnfNodeBlockStorage.Spec.Allocations {
@@ -360,7 +366,12 @@ func (r *NnfStorageReconciler) createNodeBlockStorage(ctx context.Context, nnfSt
 					if fsType == "lustre" && capacity < minimumLustreAllocationSizeInBytes {
 						capacity = minimumLustreAllocationSizeInBytes
 					}
-					nnfNodeBlockStorage.Spec.Allocations[i].Capacity = capacity
+					if allocationSet.SharedAllocation {
+						nnfNodeBlockStorage.Spec.Allocations[i].Capacity = capacity * int64(node.Count)
+					} else {
+						nnfNodeBlockStorage.Spec.Allocations[i].Capacity = capacity
+					}
+
 					if len(nnfNodeBlockStorage.Spec.Allocations[i].Access) == 0 {
 						nnfNodeBlockStorage.Spec.Allocations[i].Access = append(nnfNodeBlockStorage.Spec.Allocations[i].Access, node.Name)
 					}
@@ -496,9 +507,11 @@ func (r *NnfStorageReconciler) createNodeStorage(ctx context.Context, storage *n
 					Namespace: node.Name,
 					Kind:      reflect.TypeOf(nnfv1alpha1.NnfNodeBlockStorage{}).Name(),
 				}
+				nnfNodeStorage.Spec.Capacity = allocationSet.Capacity
 				nnfNodeStorage.Spec.UserID = storage.Spec.UserID
 				nnfNodeStorage.Spec.GroupID = storage.Spec.GroupID
 				nnfNodeStorage.Spec.Count = node.Count
+				nnfNodeStorage.Spec.SharedAllocation = allocationSet.SharedAllocation
 				nnfNodeStorage.Spec.FileSystemType = storage.Spec.FileSystemType
 				if storage.Spec.FileSystemType == "lustre" {
 					nnfNodeStorage.Spec.LustreStorage.StartIndex = startIndex

--- a/internal/controller/nnf_workflow_controller_helpers.go
+++ b/internal/controller/nnf_workflow_controller_helpers.go
@@ -623,6 +623,18 @@ func (r *NnfWorkflowReconciler) createNnfStorage(ctx context.Context, workflow *
 					mgsNid = nnfStorageProfile.Data.LustreStorage.ExternalMGS
 				}
 			}
+
+			sharedAllocation := false
+			if dwArgs["type"] == "gfs2" && nnfStorageProfile.Data.GFS2Storage.CmdLines.SharedVg {
+				sharedAllocation = true
+			}
+			if dwArgs["type"] == "xfs" && nnfStorageProfile.Data.XFSStorage.CmdLines.SharedVg {
+				sharedAllocation = true
+			}
+			if dwArgs["type"] == "raw" && nnfStorageProfile.Data.RawStorage.CmdLines.SharedVg {
+				sharedAllocation = true
+			}
+
 			// Need to remove all of the AllocationSets in the NnfStorage object before we begin
 			nnfStorage.Spec.AllocationSets = []nnfv1alpha1.NnfStorageAllocationSetSpec{}
 
@@ -632,6 +644,7 @@ func (r *NnfWorkflowReconciler) createNnfStorage(ctx context.Context, workflow *
 
 				nnfAllocSet.Name = s.Spec.AllocationSets[i].Label
 				nnfAllocSet.Capacity = s.Spec.AllocationSets[i].AllocationSize
+				nnfAllocSet.SharedAllocation = sharedAllocation
 				if dwArgs["type"] == "lustre" {
 					nnfAllocSet.NnfStorageLustreSpec.TargetType = s.Spec.AllocationSets[i].Label
 					nnfAllocSet.NnfStorageLustreSpec.BackFs = "zfs"

--- a/internal/controller/nnfstorageprofile_test.go
+++ b/internal/controller/nnfstorageprofile_test.go
@@ -77,6 +77,13 @@ func createBasicDefaultNnfStorageProfile() *nnfv1alpha1.NnfStorageProfile {
 	return createNnfStorageProfile(storageProfile, true)
 }
 
+// createBasicDefaultNnfStorageProfile creates a simple default storage profile.
+func createBasicPinnedNnfStorageProfile() *nnfv1alpha1.NnfStorageProfile {
+	storageProfile := basicNnfStorageProfile("durable-" + uuid.NewString()[:8])
+	storageProfile.Data.Pinned = true
+	return createNnfStorageProfile(storageProfile, true)
+}
+
 func verifyPinnedProfile(ctx context.Context, clnt client.Client, namespace string, profileName string) error {
 
 	nnfStorageProfile, err := findPinnedProfile(ctx, clnt, namespace, profileName)

--- a/mount-daemon/main.go
+++ b/mount-daemon/main.go
@@ -248,6 +248,7 @@ func startManager(config *managerConfig) {
 		//	Timeout: config.timeout,
 		Scheme:            mgr.GetScheme(),
 		SemaphoreForStart: semReady,
+		ClientType:        controllers.ClientCompute,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClientMount")
 		os.Exit(1)

--- a/pkg/blockdevice/blockdevice.go
+++ b/pkg/blockdevice/blockdevice.go
@@ -32,7 +32,7 @@ type BlockDevice interface {
 	Activate(ctx context.Context) (bool, error)
 
 	// Deactivate the block device (e.g., LVM lockstop and lvchange --activate n)
-	Deactivate(ctx context.Context) (bool, error)
+	Deactivate(ctx context.Context, full bool) (bool, error)
 
 	// Get device /dev path
 	GetDevice() string

--- a/pkg/blockdevice/lvm/logical_volumes.go
+++ b/pkg/blockdevice/lvm/logical_volumes.go
@@ -32,16 +32,20 @@ import (
 
 type LogicalVolume struct {
 	Name        string
+	Size        int64
+	PercentVG   int
 	VolumeGroup *VolumeGroup
 
 	Log logr.Logger
 }
 
-func NewLogicalVolume(ctx context.Context, name string, vg *VolumeGroup, log logr.Logger) *LogicalVolume {
+func NewLogicalVolume(ctx context.Context, name string, vg *VolumeGroup, size int64, percentVG int, log logr.Logger) *LogicalVolume {
 	return &LogicalVolume{
 		Name:        name,
 		VolumeGroup: vg,
+		Size:        size,
 		Log:         log,
+		PercentVG:   percentVG,
 	}
 }
 
@@ -57,6 +61,8 @@ func (lv *LogicalVolume) parseArgs(args string) (string, error) {
 		"$DEVICE_LIST": strings.Join(deviceNames, " "),
 		"$VG_NAME":     lv.VolumeGroup.Name,
 		"$LV_NAME":     lv.Name,
+		"$LV_SIZE":     fmt.Sprintf("%vK", (lv.Size / 1000)),
+		"$PERCENT_VG":  fmt.Sprintf("%v", lv.PercentVG) + "%VG",
 	})
 
 	if err := varHandler.ListToVars("$DEVICE_LIST", "$DEVICE"); err != nil {

--- a/pkg/blockdevice/lvm/vgs.go
+++ b/pkg/blockdevice/lvm/vgs.go
@@ -37,15 +37,16 @@ type vgsReport struct {
 }
 
 type vgsVolumeGroup struct {
-	Name    string `json:"vg_name"`
-	PVCount string `json:"pv_count"`
-	LVCount string `json:"lv_count"`
-	Attrs   string `json:"vg_attr"`
-	Size    string `json:"vg_size"`
+	Name       string `json:"vg_name"`
+	PVCount    string `json:"pv_count"`
+	LVCount    string `json:"lv_count"`
+	Attrs      string `json:"vg_attr"`
+	Size       string `json:"vg_size"`
+	ExtentSize string `json:"vg_extent_size"`
 }
 
 func vgsListVolumes(ctx context.Context, log logr.Logger) ([]vgsVolumeGroup, error) {
-	output, err := command.Run("vgs --nolock --reportformat json", log)
+	output, err := command.Run("vgs --nolock -v --reportformat json", log)
 	if err != nil {
 		return nil, fmt.Errorf("could not list volume groups: %w", err)
 	}

--- a/pkg/blockdevice/mock.go
+++ b/pkg/blockdevice/mock.go
@@ -54,7 +54,7 @@ func (m *MockBlockDevice) Activate(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func (m *MockBlockDevice) Deactivate(ctx context.Context) (bool, error) {
+func (m *MockBlockDevice) Deactivate(ctx context.Context, full bool) (bool, error) {
 	m.Log.Info("Deactivated mock block device")
 
 	return true, nil

--- a/pkg/blockdevice/zpool.go
+++ b/pkg/blockdevice/zpool.go
@@ -105,7 +105,7 @@ func (z *Zpool) Activate(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
-func (z *Zpool) Deactivate(ctx context.Context) (bool, error) {
+func (z *Zpool) Deactivate(ctx context.Context, full bool) (bool, error) {
 	return false, nil
 }
 

--- a/pkg/filesystem/lustre.go
+++ b/pkg/filesystem/lustre.go
@@ -142,7 +142,7 @@ func (l *LustreFileSystem) Activate(ctx context.Context, complete bool) (bool, e
 
 	// Run the mount command
 	if _, err := command.Run(mountCmd, l.Log); err != nil {
-		if _, err := l.BlockDevice.Deactivate(ctx); err != nil {
+		if _, err := l.BlockDevice.Deactivate(ctx, false); err != nil {
 			return false, fmt.Errorf("could not deactivate block device after failed mount %s: %w", path, err)
 		}
 
@@ -177,7 +177,7 @@ func (l *LustreFileSystem) Deactivate(ctx context.Context) (bool, error) {
 		// Remove the directory. If it fails don't worry about it.
 		_ = os.Remove(path)
 
-		if _, err := l.BlockDevice.Deactivate(ctx); err != nil {
+		if _, err := l.BlockDevice.Deactivate(ctx, false); err != nil {
 			return false, fmt.Errorf("could not deactivate block device after unmount %s: %w", path, err)
 		}
 
@@ -185,7 +185,7 @@ func (l *LustreFileSystem) Deactivate(ctx context.Context) (bool, error) {
 	}
 
 	// Try to deactivate the block device in case the deactivate failed after the unmount above
-	if _, err := l.BlockDevice.Deactivate(ctx); err != nil {
+	if _, err := l.BlockDevice.Deactivate(ctx, false); err != nil {
 		return false, fmt.Errorf("could not deactivate block device after unmount %s: %w", path, err)
 	}
 


### PR DESCRIPTION
This commit adds a new option, sharedVg, in the NnfStorageProfile for allocations backed by an LVM logical volume. This option allows allocations on a Rabbit node that are part of the same workflow to share a volume group. This reduces the overhead of creating allocations and greatly speeds up the Setup and Teardown phases of the workflow.

This commit also changes the way locking is done with lvmlockd. Previously, when the LV was not needed on a node, the LV was deactivated and the VG lockspace was stopped. Now, only the LV is deactivated in most situations. The VG lockspace is only stopped when a node is completely done with a VG and it won't be activated again.