### PR TITLE
Fix error reporting from NnfNodeStorage and NnfNodeBlockStorage

### DIFF
--- a/config/crd/bases/nnf.cray.hpe.com_nnfaccesses.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfaccesses.yaml
@@ -229,6 +229,7 @@ spec:
                     enum:
                     - Internal
                     - User
+                    - WLM
                     type: string
                   userMessage:
                     description: Optional user facing message if the error is relevant

--- a/config/crd/bases/nnf.cray.hpe.com_nnfdatamovements.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfdatamovements.yaml
@@ -291,6 +291,7 @@ spec:
                     enum:
                     - Internal
                     - User
+                    - WLM
                     type: string
                   userMessage:
                     description: Optional user facing message if the error is relevant

--- a/config/crd/bases/nnf.cray.hpe.com_nnfnodeblockstorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfnodeblockstorages.yaml
@@ -143,6 +143,7 @@ spec:
                     enum:
                     - Internal
                     - User
+                    - WLM
                     type: string
                   userMessage:
                     description: Optional user facing message if the error is relevant

--- a/config/crd/bases/nnf.cray.hpe.com_nnfnodestorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfnodestorages.yaml
@@ -206,6 +206,7 @@ spec:
                     enum:
                     - Internal
                     - User
+                    - WLM
                     type: string
                   userMessage:
                     description: Optional user facing message if the error is relevant

--- a/config/crd/bases/nnf.cray.hpe.com_nnfstorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfstorages.yaml
@@ -235,6 +235,7 @@ spec:
                     enum:
                     - Internal
                     - User
+                    - WLM
                     type: string
                   userMessage:
                     description: Optional user facing message if the error is relevant

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/NearNodeFlash/nnf-sos
 go 1.19
 
 require (
-	github.com/DataWorkflowServices/dws v0.0.1-0.20240423152131-d92c9aadede8
+	github.com/DataWorkflowServices/dws v0.0.1-0.20240612193922-d17ead037c7b
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240326175906-15cfe803227d
 	github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240607170045-9d0ccb5f133a
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataWorkflowServices/dws v0.0.1-0.20240423152131-d92c9aadede8 h1:Ic1rErr2VFbIfGYx8loePH7HRqPMQEW5ZIDiOP2CMLk=
-github.com/DataWorkflowServices/dws v0.0.1-0.20240423152131-d92c9aadede8/go.mod h1:vSTBLWbsFjMYxx+sjMDyZpMXLY9m5Bp73cjnmAL30WU=
+github.com/DataWorkflowServices/dws v0.0.1-0.20240612193922-d17ead037c7b h1:YtGzquSqw06TZR4uUGDCJx7l4MzBQzlbww3mnPlN7QY=
+github.com/DataWorkflowServices/dws v0.0.1-0.20240612193922-d17ead037c7b/go.mod h1:vSTBLWbsFjMYxx+sjMDyZpMXLY9m5Bp73cjnmAL30WU=
 github.com/HewlettPackard/structex v1.0.4 h1:RVTdN5FWhDWr1IkjllU8wxuLjISo4gr6u5ryZpzyHcA=
 github.com/HewlettPackard/structex v1.0.4/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240326175906-15cfe803227d h1:gqAZOwvFrsgsAQYLqSnMBU4aALOH7+QpqYruhhI6MZU=

--- a/internal/controller/nnf_access_controller.go
+++ b/internal/controller/nnf_access_controller.go
@@ -92,11 +92,7 @@ func (r *NnfAccessReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	statusUpdater := updater.NewStatusUpdater[*nnfv1alpha1.NnfAccessStatus](access)
 	defer func() { err = statusUpdater.CloseWithStatusUpdate(ctx, r.Client.Status(), err) }()
-	defer func() {
-		if err != nil || (!res.Requeue && res.RequeueAfter == 0) {
-			access.Status.SetResourceErrorAndLog(err, log)
-		}
-	}()
+	defer func() { access.Status.SetResourceErrorAndLog(err, log) }()
 
 	// Create a list of names of the client nodes. This is pulled from either
 	// the Computes resource specified in the ClientReference or the NnfStorage
@@ -242,7 +238,7 @@ func (r *NnfAccessReconciler) mount(ctx context.Context, access *nnfv1alpha1.Nnf
 	}
 
 	if ready == false {
-		return &ctrl.Result{RequeueAfter: time.Second}, nil
+		return &ctrl.Result{}, nil
 	}
 
 	// Aggregate the status from all the ClientMount resources
@@ -253,7 +249,7 @@ func (r *NnfAccessReconciler) mount(ctx context.Context, access *nnfv1alpha1.Nnf
 
 	// Wait for all of the ClientMounts to be ready
 	if ready == false {
-		return &ctrl.Result{RequeueAfter: time.Second}, nil
+		return &ctrl.Result{}, nil
 	}
 
 	return nil, nil
@@ -824,8 +820,7 @@ func (r *NnfAccessReconciler) getBlockStorageAccessStatus(ctx context.Context, a
 		}
 
 		if nnfNodeStorage.Status.Error != nil {
-			access.Status.SetResourceError(nnfNodeStorage.Status.Error)
-			return false, nil
+			return false, nnfNodeStorage.Status.Error
 		}
 	}
 
@@ -996,8 +991,7 @@ func (r *NnfAccessReconciler) getClientMountStatus(ctx context.Context, access *
 		}
 
 		if clientMount.Status.Error != nil {
-			access.Status.SetResourceError(clientMount.Status.Error)
-			return false, nil
+			return false, clientMount.Status.Error
 		}
 
 		for _, mount := range clientMount.Status.Mounts {

--- a/internal/controller/nnf_clientmount_controller.go
+++ b/internal/controller/nnf_clientmount_controller.go
@@ -174,8 +174,7 @@ func (r *NnfClientMountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		resourceError := dwsv1alpha2.NewResourceError("mount/unmount failed").WithError(err)
 		log.Info(resourceError.Error())
 
-		clientMount.Status.Error = resourceError
-		return ctrl.Result{RequeueAfter: time.Second * time.Duration(10)}, nil
+		return ctrl.Result{}, resourceError
 	}
 
 	clientMount.Status.AllReady = true

--- a/internal/controller/nnf_storage_controller.go
+++ b/internal/controller/nnf_storage_controller.go
@@ -109,11 +109,7 @@ func (r *NnfStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// occuring on the on function exit.
 	statusUpdater := updater.NewStatusUpdater[*nnfv1alpha1.NnfStorageStatus](storage)
 	defer func() { err = statusUpdater.CloseWithStatusUpdate(ctx, r.Client.Status(), err) }()
-	defer func() {
-		if err != nil || (!res.Requeue && res.RequeueAfter == 0) {
-			storage.Status.SetResourceErrorAndLog(err, log)
-		}
-	}()
+	defer func() { storage.Status.SetResourceErrorAndLog(err, log) }()
 
 	// Check if the object is being deleted
 	if !storage.GetDeletionTimestamp().IsZero() {
@@ -419,7 +415,7 @@ func (r *NnfStorageReconciler) aggregateNodeBlockStorageStatus(ctx context.Conte
 		}
 
 		if nnfNodeBlockStorage.Status.Error != nil {
-			nnfStorage.Status.SetResourceError(nnfNodeBlockStorage.Status.Error)
+			return &ctrl.Result{}, nnfNodeBlockStorage.Status.Error
 		}
 
 		if nnfNodeBlockStorage.Status.Ready == false {
@@ -556,7 +552,7 @@ func (r *NnfStorageReconciler) aggregateNodeStorageStatus(ctx context.Context, s
 
 	for _, nnfNodeStorage := range nnfNodeStorageList.Items {
 		if nnfNodeStorage.Status.Error != nil {
-			storage.Status.SetResourceError(nnfNodeStorage.Status.Error)
+			return &ctrl.Result{}, nnfNodeStorage.Status.Error
 		}
 
 		if nnfNodeStorage.Status.Ready == false {

--- a/internal/controller/nnfstorageprofile_helpers.go
+++ b/internal/controller/nnfstorageprofile_helpers.go
@@ -71,8 +71,9 @@ func findProfileToUse(ctx context.Context, clnt client.Client, args map[string]s
 	}
 	err := clnt.Get(ctx, types.NamespacedName{Namespace: profileNamespace, Name: profileName}, nnfStorageProfile)
 	if err != nil {
-		return nil, err
+		return nil, dwsv1alpha2.NewResourceError("").WithUserMessage("Unable to find NnfStorageProfile: %s", profileName).WithUser().WithFatal()
 	}
+
 	return nnfStorageProfile, nil
 }
 

--- a/vendor/github.com/DataWorkflowServices/dws/api/v1alpha2/resource_error.go
+++ b/vendor/github.com/DataWorkflowServices/dws/api/v1alpha2/resource_error.go
@@ -63,7 +63,7 @@ type ResourceErrorInfo struct {
 	DebugMessage string `json:"debugMessage"`
 
 	// Internal or user error
-	// +kubebuilder:validation:Enum=Internal;User
+	// +kubebuilder:validation:Enum=Internal;User;WLM
 	Type ResourceErrorType `json:"type"`
 
 	// Indication of how severe the error is. Minor will likely succeed, Major may

--- a/vendor/github.com/DataWorkflowServices/dws/config/crd/bases/dataworkflowservices.github.io_clientmounts.yaml
+++ b/vendor/github.com/DataWorkflowServices/dws/config/crd/bases/dataworkflowservices.github.io_clientmounts.yaml
@@ -532,6 +532,7 @@ spec:
                     enum:
                     - Internal
                     - User
+                    - WLM
                     type: string
                   userMessage:
                     description: Optional user facing message if the error is relevant

--- a/vendor/github.com/DataWorkflowServices/dws/config/crd/bases/dataworkflowservices.github.io_directivebreakdowns.yaml
+++ b/vendor/github.com/DataWorkflowServices/dws/config/crd/bases/dataworkflowservices.github.io_directivebreakdowns.yaml
@@ -486,6 +486,7 @@ spec:
                     enum:
                     - Internal
                     - User
+                    - WLM
                     type: string
                   userMessage:
                     description: Optional user facing message if the error is relevant

--- a/vendor/github.com/DataWorkflowServices/dws/config/crd/bases/dataworkflowservices.github.io_persistentstorageinstances.yaml
+++ b/vendor/github.com/DataWorkflowServices/dws/config/crd/bases/dataworkflowservices.github.io_persistentstorageinstances.yaml
@@ -373,6 +373,7 @@ spec:
                     enum:
                     - Internal
                     - User
+                    - WLM
                     type: string
                   userMessage:
                     description: Optional user facing message if the error is relevant

--- a/vendor/github.com/DataWorkflowServices/dws/config/crd/bases/dataworkflowservices.github.io_servers.yaml
+++ b/vendor/github.com/DataWorkflowServices/dws/config/crd/bases/dataworkflowservices.github.io_servers.yaml
@@ -268,6 +268,7 @@ spec:
                     enum:
                     - Internal
                     - User
+                    - WLM
                     type: string
                   userMessage:
                     description: Optional user facing message if the error is relevant

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/DataWorkflowServices/dws v0.0.1-0.20240423152131-d92c9aadede8
+# github.com/DataWorkflowServices/dws v0.0.1-0.20240612193922-d17ead037c7b
 ## explicit; go 1.19
 github.com/DataWorkflowServices/dws/api/v1alpha2
 github.com/DataWorkflowServices/dws/config/crd/bases


### PR DESCRIPTION
Errors weren't being properly set in the NnfNodeStorage, NnfNodeBlockStorage, and ClientMount resources in some instances. Make sure that the error is always returned from the main Reconcile() function so that it gets picked up by SetResourceErrorAndLog()

Also, add a fatal error if a user specified NnfStorageProfile isn't found.