### PR TITLE
Don't check status when deleting storage pools

### DIFF
--- a/internal/controller/nnf_node_block_storage_controller.go
+++ b/internal/controller/nnf_node_block_storage_controller.go
@@ -439,10 +439,6 @@ func (r *NnfNodeBlockStorageReconciler) deleteStorage(nodeBlockStorage *nnfv1alp
 	ss := nnf.NewDefaultStorageService()
 
 	allocationStatus := &nodeBlockStorage.Status.Allocations[index]
-	if allocationStatus.StoragePoolId == "" {
-		return nil, nil
-	}
-
 	log.Info("Deleting storage pool", "Id", allocationStatus.StoragePoolId)
 
 	err := r.deleteStoragePool(ss, allocationStatus.StoragePoolId)

--- a/internal/controller/nnf_storage_controller.go
+++ b/internal/controller/nnf_storage_controller.go
@@ -746,6 +746,11 @@ func (r *NnfStorageReconciler) setLustreOwnerGroup(ctx context.Context, nnfStora
 // that aren't in the cache and we may not have been able to add the object reference
 // to the NnfStorage.
 func (r *NnfStorageReconciler) teardownStorage(ctx context.Context, storage *nnfv1alpha1.NnfStorage) (nodeStoragesState, error) {
+	deleteStatus, err := dwsv1alpha2.DeleteChildren(ctx, r.Client, r.ChildObjects, storage)
+	if err != nil {
+		return nodeStoragesExist, err
+	}
+
 	// Collect status information from the NnfNodeStorage resources and aggregate it into the
 	// NnfStorage
 	for i := range storage.Status.AllocationSets {
@@ -753,11 +758,6 @@ func (r *NnfStorageReconciler) teardownStorage(ctx context.Context, storage *nnf
 		if err != nil {
 			return nodeStoragesExist, err
 		}
-	}
-
-	deleteStatus, err := dwsv1alpha2.DeleteChildren(ctx, r.Client, r.ChildObjects, storage)
-	if err != nil {
-		return nodeStoragesExist, err
 	}
 
 	if !deleteStatus.Complete() {


### PR DESCRIPTION
The allocation teardown code was checking whether a storage pool ID was listed in the status section of the NnfNodeBlockStorage before trying to delete it. If there was an issue saving the storage pool ID (e.g., conflict), then we can strand NVMe namespaces on the Rabbit. Always try to delete storage pools for every known index and treat "not found" errors as a success.

Also, fix an error with the NnfStorage deletion code where the child objects (NnfNodeStorage and NnfNodeBlockStorage) don't get deleted if they currently have an error.