### PR TITLE
Add a WLM ClusterRole that can also access some NNF resources

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
 - fencing_agent_role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- workload_manager_nnf_role.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/config/rbac/workload_manager_nnf_role.yaml
+++ b/config/rbac/workload_manager_nnf_role.yaml
@@ -1,0 +1,131 @@
+# Permissions for a WLM (workload manager) to interact with DWS and NNF resources.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: workload-manager
+rules:
+- apiGroups:
+  - dataworkflowservices.github.io
+  resources:
+  - clientmounts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dataworkflowservices.github.io
+  resources:
+  - clientmounts/status
+  verbs:
+  - get
+- apiGroups:
+  - dataworkflowservices.github.io
+  resources:
+  - computes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - dataworkflowservices.github.io
+  resources:
+  - directivebreakdowns
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dataworkflowservices.github.io
+  resources:
+  - directivebreakdowns/status
+  verbs:
+  - get
+- apiGroups:
+  - dataworkflowservices.github.io
+  resources:
+  - persistentstorageinstances
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dataworkflowservices.github.io
+  resources:
+  - persistentstorageinstances/status
+  verbs:
+  - get
+- apiGroups:
+  - dataworkflowservices.github.io
+  resources:
+  - servers
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - dataworkflowservices.github.io
+  resources:
+  - servers/status
+  verbs:
+  - get
+- apiGroups:
+  - dataworkflowservices.github.io
+  resources:
+  - storages
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dataworkflowservices.github.io
+  resources:
+  - storages/status
+  verbs:
+  - get
+- apiGroups:
+  - dataworkflowservices.github.io
+  resources:
+  - systemconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dataworkflowservices.github.io
+  resources:
+  - systemconfigurations/status
+  verbs:
+  - get
+- apiGroups:
+  - dataworkflowservices.github.io
+  resources:
+  - workflows
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+
+# Add some NNF pieces:
+
+- apiGroups:
+    - nnf.cray.hpe.com
+  resources:
+    - nnfdatamovements
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - nnf.cray.hpe.com
+  resources:
+    - nnfdatamovements/status
+  verbs:
+    - get


### PR DESCRIPTION
When access to NNF resources is desired, then the WLM would use this ClusterRole rather than the one provided by DWS.