### PR TITLE
Get missing events from k8s Node resource

### DIFF
--- a/internal/controller/dws_storage_controller.go
+++ b/internal/controller/dws_storage_controller.go
@@ -112,7 +112,7 @@ func (r *DWSStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	storage.Status.Access.Protocol = dwsv1alpha2.PCIe
 
 	if len(node.Status.Servers) == 0 {
-		return ctrl.Result{}, nil // Wait until severs array has been filed in with Rabbit info
+		return ctrl.Result{}, nil // Wait until severs array has been filled in with Rabbit info
 	}
 
 	// Populate server status' - Server 0 is reserved as the Rabbit node.
@@ -195,7 +195,6 @@ func (r *DWSStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			storage.Status.RebootRequired = true
 			storage.Status.Message = "Storage node requires reboot to recover from STONITH event"
 		} else {
-
 			ready, err := r.isKubernetesNodeReady(ctx, storage)
 			if err != nil {
 				return ctrl.Result{}, err
@@ -252,7 +251,8 @@ func (r *DWSStorageReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Setup to watch the Kubernetes Node resource
 	nodeMapFunc := func(ctx context.Context, o client.Object) []reconcile.Request {
 		return []reconcile.Request{{NamespacedName: types.NamespacedName{
-			Name: o.GetName(),
+			Name:      o.GetName(),
+			Namespace: corev1.NamespaceDefault,
 		}}}
 	}
 

--- a/internal/controller/nnf_workflow_controller.go
+++ b/internal/controller/nnf_workflow_controller.go
@@ -129,13 +129,15 @@ func (r *NnfWorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		if err != nil {
 			return ctrl.Result{}, err
 		} else if containerRes != nil {
-			return containerRes.Result, nil
+			// Requeue=true doesn't always work in the delete path. Use RequeueAfter instead
+			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 		}
 		containerRes, err = r.releaseContainerPorts(ctx, workflow)
 		if err != nil {
 			return ctrl.Result{}, err
 		} else if containerRes != nil {
-			return containerRes.Result, nil
+			// Requeue=true doesn't always work in the delete path. Use RequeueAfter instead
+			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 		}
 
 		deleteStatus, err := dwsv1alpha2.DeleteChildren(ctx, r.Client, r.ChildObjects, workflow)

--- a/internal/controller/nnf_workflow_controller_helpers.go
+++ b/internal/controller/nnf_workflow_controller_helpers.go
@@ -60,7 +60,7 @@ type result struct {
 
 // When workflow stages cannot advance they return a Requeue result with a particular reason.
 func Requeue(reason string) *result {
-	return &result{Result: ctrl.Result{}, reason: reason}
+	return &result{Result: ctrl.Result{Requeue: true}, reason: reason}
 }
 
 func (r *result) complete() bool {
@@ -68,6 +68,7 @@ func (r *result) complete() bool {
 }
 
 func (r *result) after(duration time.Duration) *result {
+	r.Result.Requeue = false
 	r.Result.RequeueAfter = duration
 	return r
 }
@@ -106,9 +107,6 @@ func (r *result) info() []interface{} {
 
 // Validate the workflow and return any error found
 func (r *NnfWorkflowReconciler) validateWorkflow(ctx context.Context, wf *dwsv1alpha2.Workflow) error {
-
-	log := r.Log.WithValues("Workflow", types.NamespacedName{Name: wf.Name, Namespace: wf.Namespace})
-
 	var createPersistentCount, deletePersistentCount, directiveCount, containerCount int
 	for index, directive := range wf.Spec.DWDirectives {
 
@@ -145,7 +143,6 @@ func (r *NnfWorkflowReconciler) validateWorkflow(ctx context.Context, wf *dwsv1a
 		}
 	}
 
-	log.Info("counts", "directive", directiveCount, "create", createPersistentCount, "delete", deletePersistentCount)
 	if directiveCount > 1 {
 		// Ensure create_persistent or destroy_persistent are singletons in the workflow
 		if createPersistentCount+deletePersistentCount > 0 {

--- a/internal/controller/nnf_workflow_controller_helpers.go
+++ b/internal/controller/nnf_workflow_controller_helpers.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+ * Copyright 2022-2024 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,


### PR DESCRIPTION
The Storage reconciler wasn't running when the k8s node resource changed. This is because the enqueuing function wasn't specifying the namespace in the namespacedname struct.

Also, fix the Requeue() function so that it specifies a requeue in the result. In the delete path, the Requeue=true result doesn't always result in a requeue. Use RequeueAfter=1sec instead. This was only an issue when the workflow was deleted without waiting for teardown to complete first. Teardown normally removes the container and port resources that were causing the issue.