### PR TITLE
Check for empty list when choosing an MGS

### DIFF
--- a/internal/controller/nnf_workflow_controller_helpers.go
+++ b/internal/controller/nnf_workflow_controller_helpers.go
@@ -709,6 +709,10 @@ func (r *NnfWorkflowReconciler) getLustreMgsFromPool(ctx context.Context, pool s
 	}
 
 	// Choose an MGS at random from the list of persistent storages
+	if len(persistentStorageList.Items) == 0 {
+		return corev1.ObjectReference{}, "", dwsv1alpha2.NewResourceError("").WithUserMessage("no MGSs found for pool: %s", pool).WithFatal().WithUser()
+	}
+
 	persistentStorage := persistentStorageList.Items[rand.Intn(len(persistentStorageList.Items))]
 
 	// Find the NnfStorage for the PersistentStorage so we can get the LNid


### PR DESCRIPTION
When choosing an MGS from the persistent storages tagged with the pool label, it's possible to panic the nnf-controller-manager if the persistent storage list is empty.