### PR TITLE
Add DataMovementInitiatorLabel to copy_in/copy_out DMs

### DIFF
--- a/api/v1alpha1/nnf_datamovement_types.go
+++ b/api/v1alpha1/nnf_datamovement_types.go
@@ -227,6 +227,11 @@ const (
 	// DataMovementTeardownStateLabel is the label applied to Data Movement and related resources that describes
 	// the workflow state when the resource is no longer need and can be safely deleted.
 	DataMovementTeardownStateLabel = "nnf.cray.hpe.com/teardown_state"
+
+	// DataMovementInitiatorLabel is the label applied to Data Movement resources that describes the origin of
+	// data movement request. This would be from a copy_in/copy_out directive or from a compute node via the
+	// Copy Offload API (i.e. nnf-dm daemon).
+	DataMovementInitiatorLabel = "dm.cray.hpe.com/initiator"
 )
 
 func AddDataMovementTeardownStateLabel(object metav1.Object, state dwsv1alpha2.WorkflowState) {
@@ -236,6 +241,16 @@ func AddDataMovementTeardownStateLabel(object metav1.Object, state dwsv1alpha2.W
 	}
 
 	labels[DataMovementTeardownStateLabel] = string(state)
+	object.SetLabels(labels)
+}
+
+func AddDataMovementInitiatorLabel(object metav1.Object, initiator string) {
+	labels := object.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	labels[DataMovementInitiatorLabel] = initiator
 	object.SetLabels(labels)
 }
 

--- a/internal/controller/nnf_workflow_controller.go
+++ b/internal/controller/nnf_workflow_controller.go
@@ -691,6 +691,7 @@ func (r *NnfWorkflowReconciler) startDataInOutState(ctx context.Context, workflo
 				dwsv1alpha2.AddWorkflowLabels(dm, workflow)
 				dwsv1alpha2.AddOwnerLabels(dm, workflow)
 				nnfv1alpha1.AddDataMovementTeardownStateLabel(dm, workflow.Status.State)
+				nnfv1alpha1.AddDataMovementInitiatorLabel(dm, dwArgs["command"])
 				addDirectiveIndexLabel(dm, index)
 
 				log.Info("Creating NNF Data Movement", "name", client.ObjectKeyFromObject(dm).String())
@@ -728,6 +729,7 @@ func (r *NnfWorkflowReconciler) startDataInOutState(ctx context.Context, workflo
 		dwsv1alpha2.AddWorkflowLabels(dm, workflow)
 		dwsv1alpha2.AddOwnerLabels(dm, workflow)
 		nnfv1alpha1.AddDataMovementTeardownStateLabel(dm, workflow.Status.State)
+		nnfv1alpha1.AddDataMovementInitiatorLabel(dm, dwArgs["command"])
 		addDirectiveIndexLabel(dm, index)
 
 		log.Info("Creating NNF Data Movement", "name", client.ObjectKeyFromObject(dm).String())

--- a/internal/controller/nnf_workflow_controller_test.go
+++ b/internal/controller/nnf_workflow_controller_test.go
@@ -593,6 +593,7 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 					}))
 
 				Expect(dm.Spec.Profile).To(Equal(nnfv1alpha1.DataMovementProfileDefault))
+				Expect(dm.GetLabels()[nnfv1alpha1.DataMovementInitiatorLabel]).To(Equal("copy_in"))
 			})
 		})
 
@@ -661,6 +662,8 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 						"Namespace": Equal(workflow.Namespace),
 					}))
 				Expect(dm.Spec.Profile).To(Equal("test"))
+				Expect(dm.GetLabels()[nnfv1alpha1.DataMovementInitiatorLabel]).To(Equal("copy_in"))
+
 			})
 		})
 	}) // When("Using copy_in directives", func()


### PR DESCRIPTION
There currently is not a specific determination on where an
NnfDataMovement resource is created.

This label is used by the Copy Offload API to record the compute node,
but that's it. Add a function to add the label and use `copy_in` or
`copy_out` for the value.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
