### PR TITLE
Mark Storage resource as drained if its node is tainted

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/NearNodeFlash/nnf-sos
 
 go 1.21
 
+replace github.com/DataWorkflowServices/dws => ../dws
+
 require (
 	github.com/DataWorkflowServices/dws v0.0.1-0.20240726140248-bd9f85356c73
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240709160956-40dcbac0aadf

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,8 @@ module github.com/NearNodeFlash/nnf-sos
 
 go 1.21
 
-replace github.com/DataWorkflowServices/dws => ../dws
-
 require (
-	github.com/DataWorkflowServices/dws v0.0.1-0.20240726140248-bd9f85356c73
+	github.com/DataWorkflowServices/dws v0.0.1-0.20240801173757-1fb2188d84b9
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240709160956-40dcbac0aadf
 	github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240708183336-34d1295977f5
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DataWorkflowServices/dws v0.0.1-0.20240801173757-1fb2188d84b9 h1:Jf5AxKXNxNtDC4YBbnJfpKWr4DicrEJ0aCtIgarIIqU=
+github.com/DataWorkflowServices/dws v0.0.1-0.20240801173757-1fb2188d84b9/go.mod h1:6MrEEHISskyooSKcKU6R3mFqH6Yh6KzWgajhcw2s+nM=
 github.com/HewlettPackard/structex v1.0.4 h1:RVTdN5FWhDWr1IkjllU8wxuLjISo4gr6u5ryZpzyHcA=
 github.com/HewlettPackard/structex v1.0.4/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240709160956-40dcbac0aadf h1:ArBI1LR+BBZ9lF+Aohv49RhTpmRqIXLz4L/h45qQT4k=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataWorkflowServices/dws v0.0.1-0.20240726140248-bd9f85356c73 h1:bq1AaHhdaeuaq+ibNk/UIMExXuLicfQCir25xKHnEck=
-github.com/DataWorkflowServices/dws v0.0.1-0.20240726140248-bd9f85356c73/go.mod h1:6MrEEHISskyooSKcKU6R3mFqH6Yh6KzWgajhcw2s+nM=
 github.com/HewlettPackard/structex v1.0.4 h1:RVTdN5FWhDWr1IkjllU8wxuLjISo4gr6u5ryZpzyHcA=
 github.com/HewlettPackard/structex v1.0.4/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240709160956-40dcbac0aadf h1:ArBI1LR+BBZ9lF+Aohv49RhTpmRqIXLz4L/h45qQT4k=

--- a/internal/controller/dws_storage_controller.go
+++ b/internal/controller/dws_storage_controller.go
@@ -218,7 +218,7 @@ func (r *DWSStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				storage.Status.Message = "Kubernetes node is offline"
 			} else if len(nodeState.nnfTaint) > 0 {
 				log.Info(fmt.Sprintf("storage node is tainted with %s", nodeState.nnfTaint))
-				storage.Status.Status = dwsv1alpha2.DisabledStatus
+				storage.Status.Status = dwsv1alpha2.DrainedStatus
 				storage.Status.Message = fmt.Sprintf("Kubernetes node is tainted with %s", nodeState.nnfTaint)
 			} else {
 				storage.Status.Status = nnfNode.Status.Status.ConvertToDWSResourceStatus()

--- a/vendor/github.com/DataWorkflowServices/dws/api/v1alpha2/resource.go
+++ b/vendor/github.com/DataWorkflowServices/dws/api/v1alpha2/resource.go
@@ -34,7 +34,7 @@ const (
 )
 
 // ResourceStatus is the enumeration of the status of a DWS resource
-// +kubebuilder:validation:Enum:=Starting;Ready;Disabled;NotPresent;Offline;Failed;Degraded;Unknown
+// +kubebuilder:validation:Enum:=Starting;Ready;Disabled;NotPresent;Offline;Failed;Degraded;Drained;Unknown
 type ResourceStatus string
 
 const (
@@ -56,7 +56,7 @@ const (
 	NotPresentStatus ResourceStatus = "NotPresent"
 
 	// Offline means the resource is offline and cannot be communicated with. This differs
-	// fro the NotPresent state in that the resource is known to exist.
+	// from the NotPresent state in that the resource is known to exist.
 	OfflineStatus ResourceStatus = "Offline"
 
 	// Failed means the resource has failed during startup or execution.
@@ -65,6 +65,9 @@ const (
 	// Degraded means the resource is ready but operating in a degraded state. Certain
 	// recovery actions may alleviate a degraded status.
 	DegradedStatus ResourceStatus = "Degraded"
+
+	// Drained means the resource has had its pods drained from the node.
+	DrainedStatus ResourceStatus = "Drained"
 
 	// Unknown means the resource status is unknown.
 	UnknownStatus ResourceStatus = "Unknown"

--- a/vendor/github.com/DataWorkflowServices/dws/config/crd/bases/dataworkflowservices.github.io_storages.yaml
+++ b/vendor/github.com/DataWorkflowServices/dws/config/crd/bases/dataworkflowservices.github.io_storages.yaml
@@ -297,6 +297,7 @@ spec:
                           - Offline
                           - Failed
                           - Degraded
+                          - Drained
                           - Unknown
                           type: string
                       type: object
@@ -326,6 +327,7 @@ spec:
                           - Offline
                           - Failed
                           - Degraded
+                          - Drained
                           - Unknown
                           type: string
                       type: object
@@ -374,6 +376,7 @@ spec:
                       - Offline
                       - Failed
                       - Degraded
+                      - Drained
                       - Unknown
                       type: string
                     wearLevel:
@@ -403,6 +406,7 @@ spec:
                 - Offline
                 - Failed
                 - Degraded
+                - Drained
                 - Unknown
                 type: string
               type:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/DataWorkflowServices/dws v0.0.1-0.20240726140248-bd9f85356c73
+# github.com/DataWorkflowServices/dws v0.0.1-0.20240726140248-bd9f85356c73 => ../dws
 ## explicit; go 1.21
 github.com/DataWorkflowServices/dws/api/v1alpha2
 github.com/DataWorkflowServices/dws/config/crd/bases
@@ -793,3 +793,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# github.com/DataWorkflowServices/dws => ../dws

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/DataWorkflowServices/dws v0.0.1-0.20240726140248-bd9f85356c73 => ../dws
+# github.com/DataWorkflowServices/dws v0.0.1-0.20240801173757-1fb2188d84b9
 ## explicit; go 1.21
 github.com/DataWorkflowServices/dws/api/v1alpha2
 github.com/DataWorkflowServices/dws/config/crd/bases
@@ -793,4 +793,3 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/DataWorkflowServices/dws => ../dws


### PR DESCRIPTION
Specifically, if any cray.nnf.node.drain* taint is applied to the node then
mark the corresponding Storage resource as "Drained". The WLM will see this
and will stop scheduling work on this node.

Restore the Storage resource to "Ready" after the taint has been removed.