### PR TITLE
Fix NnfAccess version in ./PROJECT

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -88,7 +88,7 @@ resources:
   domain: cray.hpe.com
   group: nnf
   kind: NnfAccess
-  version: ""
+  version: v1alpha1
 - api:
     crdVersion: v1
     namespaced: true

--- a/PROJECT
+++ b/PROJECT
@@ -88,6 +88,7 @@ resources:
   domain: cray.hpe.com
   group: nnf
   kind: NnfAccess
+  path: github.com/NearNodeFlash/nnf-sos/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1


### PR DESCRIPTION
This file is used by the crd bumper tool.
