### PR TITLE
Add mpirunOptions to NnfDataMovementConfig

### DIFF
--- a/api/v1alpha1/nnf_datamovement_types.go
+++ b/api/v1alpha1/nnf_datamovement_types.go
@@ -91,8 +91,11 @@ type NnfDataMovementConfig struct {
 	// +kubebuilder:default:=false
 	Dryrun bool `json:"dryrun,omitempty"`
 
+	// Extra options to pass to the mpirun command (used to perform data movement).
+	MpirunOptions string `json:"mpirunOptions,omitempty"`
+
 	// Extra options to pass to the dcp command (used to perform data movement).
-	DCPOptions string `json:"dcpOptions,omitempty"`
+	DcpOptions string `json:"dcpOptions,omitempty"`
 
 	// If true, enable the command's stdout to be saved in the log when the command completes
 	// successfully. On failure, the output is always logged.

--- a/api/v1alpha1/nnfdatamovementprofile_types.go
+++ b/api/v1alpha1/nnfdatamovementprofile_types.go
@@ -35,13 +35,13 @@ type NnfDataMovementProfileData struct {
 	Pinned bool `json:"pinned,omitempty"`
 
 	// Slots is the number of slots specified in the MPI hostfile. A value of 0 disables the use of
-	// slots in the hostfile.
+	// slots in the hostfile. The hostfile is used for both `statCommand` and `Command`.
 	// +kubebuilder:default:=8
 	// +kubebuilder:validation:Minimum:=0
 	Slots int `json:"slots"`
 
 	// MaxSlots is the number of max_slots specified in the MPI hostfile. A value of 0 disables the
-	// use of max_slots in the hostfile.
+	// use of max_slots in the hostfile. The hostfile is used for both `statCommand` and `Command`.
 	// +kubebuilder:default:=0
 	// +kubebuilder:validation:Minimum:=0
 	MaxSlots int `json:"maxSlots"`

--- a/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementprofiles.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementprofiles.yaml
@@ -75,7 +75,7 @@ spec:
                 default: 0
                 description: |-
                   MaxSlots is the number of max_slots specified in the MPI hostfile. A value of 0 disables the
-                  use of max_slots in the hostfile.
+                  use of max_slots in the hostfile. The hostfile is used for both `statCommand` and `Command`.
                 minimum: 0
                 type: integer
               pinned:
@@ -95,7 +95,7 @@ spec:
                 default: 8
                 description: |-
                   Slots is the number of slots specified in the MPI hostfile. A value of 0 disables the use of
-                  slots in the hostfile.
+                  slots in the hostfile. The hostfile is used for both `statCommand` and `Command`.
                 minimum: 0
                 type: integer
               statCommand:

--- a/config/crd/bases/nnf.cray.hpe.com_nnfdatamovements.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfdatamovements.yaml
@@ -249,6 +249,10 @@ spec:
                       The number of max_slots specified in the MPI hostfile. A value of 0 disables the use of slots
                       in the hostfile. Nil will defer to the value specified in the NnfDataMovementProfile.
                     type: integer
+                  mpirunOptions:
+                    description: Extra options to pass to the mpirun command (used
+                      to perform data movement).
+                    type: string
                   slots:
                     description: |-
                       The number of slots specified in the MPI hostfile. A value of 0 disables the use of slots in


### PR DESCRIPTION
This allows users to add extra parameters to mpirun (e.g. -N, -n) for an
individual data movement.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
