### PR TITLE
Use "nnfv1alpha1" to refer to the api/v1alpha1 libs

### DIFF
--- a/internal/controller/integration_test.go
+++ b/internal/controller/integration_test.go
@@ -42,7 +42,6 @@ import (
 	dwsv1alpha2 "github.com/DataWorkflowServices/dws/api/v1alpha2"
 	dwparse "github.com/DataWorkflowServices/dws/utils/dwdparse"
 	lusv1beta1 "github.com/NearNodeFlash/lustre-fs-operator/api/v1beta1"
-	"github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
 )
 
@@ -346,7 +345,7 @@ var _ = Describe("Integration Test", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: nodeName,
 					Labels: map[string]string{
-						v1alpha1.RabbitNodeSelectorLabel: "true",
+						nnfv1alpha1.RabbitNodeSelectorLabel: "true",
 					},
 				},
 				Status: corev1.NodeStatus{

--- a/internal/controller/nnf_access_controller_test.go
+++ b/internal/controller/nnf_access_controller_test.go
@@ -34,7 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dwsv1alpha2 "github.com/DataWorkflowServices/dws/api/v1alpha2"
-	"github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
 )
 
@@ -66,7 +65,7 @@ var _ = Describe("Access Controller Test", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: nodeName,
 					Labels: map[string]string{
-						v1alpha1.RabbitNodeSelectorLabel: "true",
+						nnfv1alpha1.RabbitNodeSelectorLabel: "true",
 					},
 				},
 				Status: corev1.NodeStatus{

--- a/internal/controller/nnf_systemconfiguration_controller.go
+++ b/internal/controller/nnf_systemconfiguration_controller.go
@@ -38,7 +38,7 @@ import (
 
 	dwsv1alpha2 "github.com/DataWorkflowServices/dws/api/v1alpha2"
 	"github.com/DataWorkflowServices/dws/utils/updater"
-	"github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
+	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
 	"github.com/NearNodeFlash/nnf-sos/internal/controller/metrics"
 )
 
@@ -220,12 +220,12 @@ func (r *NnfSystemConfigurationReconciler) labelsAndTaints(ctx context.Context, 
 				labels = make(map[string]string)
 			}
 
-			if _, present := labels[v1alpha1.TaintsAndLabelsCompletedLabel]; present {
+			if _, present := labels[nnfv1alpha1.TaintsAndLabelsCompletedLabel]; present {
 				continue
 			}
 
 			taint := &corev1.Taint{
-				Key:    v1alpha1.RabbitNodeTaintKey,
+				Key:    nnfv1alpha1.RabbitNodeTaintKey,
 				Value:  "true",
 				Effect: effect,
 			}
@@ -239,7 +239,7 @@ func (r *NnfSystemConfigurationReconciler) labelsAndTaints(ctx context.Context, 
 					return false, err
 				}
 				// All passes completed on this node.
-				labels[v1alpha1.TaintsAndLabelsCompletedLabel] = "true"
+				labels[nnfv1alpha1.TaintsAndLabelsCompletedLabel] = "true"
 				doUpdate = true
 				node.SetLabels(labels)
 			} else {
@@ -252,8 +252,8 @@ func (r *NnfSystemConfigurationReconciler) labelsAndTaints(ctx context.Context, 
 			}
 
 			// Add the label.
-			if _, present := labels[v1alpha1.RabbitNodeSelectorLabel]; !present {
-				labels[v1alpha1.RabbitNodeSelectorLabel] = "true"
+			if _, present := labels[nnfv1alpha1.RabbitNodeSelectorLabel]; !present {
+				labels[nnfv1alpha1.RabbitNodeSelectorLabel] = "true"
 				doUpdate = true
 				node.SetLabels(labels)
 			}

--- a/internal/controller/nnf_systemconfiguration_controller_test.go
+++ b/internal/controller/nnf_systemconfiguration_controller_test.go
@@ -21,7 +21,6 @@ package controller
 import (
 	"context"
 
-	"github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -32,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dwsv1alpha2 "github.com/DataWorkflowServices/dws/api/v1alpha2"
+	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
 )
 
 var _ = Describe("NnfSystemconfigurationController", func() {
@@ -80,12 +80,12 @@ var _ = Describe("Adding taints and labels to nodes", func() {
 	var sysCfg *dwsv1alpha2.SystemConfiguration
 
 	taintNoSchedule := &corev1.Taint{
-		Key:    v1alpha1.RabbitNodeTaintKey,
+		Key:    nnfv1alpha1.RabbitNodeTaintKey,
 		Value:  "true",
 		Effect: corev1.TaintEffectNoSchedule,
 	}
 	taintNoExecute := &corev1.Taint{
-		Key:    v1alpha1.RabbitNodeTaintKey,
+		Key:    nnfv1alpha1.RabbitNodeTaintKey,
 		Value:  "true",
 		Effect: corev1.TaintEffectNoExecute,
 	}
@@ -147,8 +147,8 @@ var _ = Describe("Adding taints and labels to nodes", func() {
 		Eventually(func(g Gomega) {
 			g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(node), tnode))
 			labels := tnode.GetLabels()
-			g.Expect(labels).To(HaveKeyWithValue(v1alpha1.RabbitNodeSelectorLabel, "true"))
-			g.Expect(labels).To(HaveKeyWithValue(v1alpha1.TaintsAndLabelsCompletedLabel, "true"))
+			g.Expect(labels).To(HaveKeyWithValue(nnfv1alpha1.RabbitNodeSelectorLabel, "true"))
+			g.Expect(labels).To(HaveKeyWithValue(nnfv1alpha1.TaintsAndLabelsCompletedLabel, "true"))
 			g.Expect(taints.TaintExists(tnode.Spec.Taints, taintNoSchedule)).To(BeTrue())
 			g.Expect(taints.TaintExists(tnode.Spec.Taints, taintNoExecute)).To(BeFalse())
 		}).Should(Succeed(), "verify failed for node %s", node.Name)
@@ -165,7 +165,7 @@ var _ = Describe("Adding taints and labels to nodes", func() {
 			// Remove the "cleared" label from node1.
 			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(node1), node1))
 			labels := node1.GetLabels()
-			delete(labels, v1alpha1.TaintsAndLabelsCompletedLabel)
+			delete(labels, nnfv1alpha1.TaintsAndLabelsCompletedLabel)
 			node1.SetLabels(labels)
 			Expect(k8sClient.Update(context.TODO(), node1)).To(Succeed())
 			By("verifying node1 is repaired")
@@ -195,8 +195,8 @@ var _ = Describe("Adding taints and labels to nodes", func() {
 				tnode := &corev1.Node{}
 				g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(node4), tnode))
 				labels := tnode.GetLabels()
-				g.Expect(labels).ToNot(HaveKey(v1alpha1.RabbitNodeSelectorLabel))
-				g.Expect(labels).ToNot(HaveKey(v1alpha1.TaintsAndLabelsCompletedLabel))
+				g.Expect(labels).ToNot(HaveKey(nnfv1alpha1.RabbitNodeSelectorLabel))
+				g.Expect(labels).ToNot(HaveKey(nnfv1alpha1.TaintsAndLabelsCompletedLabel))
 				g.Expect(taints.TaintExists(tnode.Spec.Taints, taintNoSchedule)).To(BeFalse())
 				g.Expect(taints.TaintExists(tnode.Spec.Taints, taintNoExecute)).To(BeFalse())
 			}).Should(Succeed(), "verify failed for node %s", node4.Name)

--- a/internal/controller/nnf_workflow_controller_container_helpers.go
+++ b/internal/controller/nnf_workflow_controller_container_helpers.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	dwsv1alpha2 "github.com/DataWorkflowServices/dws/api/v1alpha2"
-	"github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
 	"github.com/go-logr/logr"
 	mpicommonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
@@ -267,7 +266,7 @@ func (c *nnfUserContainer) applyLabels(job metav1.Object) error {
 func (c *nnfUserContainer) applyTolerations(spec *corev1.PodSpec) {
 	spec.Tolerations = append(spec.Tolerations, corev1.Toleration{
 		Effect:   corev1.TaintEffectNoSchedule,
-		Key:      v1alpha1.RabbitNodeTaintKey,
+		Key:      nnfv1alpha1.RabbitNodeTaintKey,
 		Operator: corev1.TolerationOpEqual,
 		Value:    "true",
 	})

--- a/internal/controller/nnfsystemstorage_controller_test.go
+++ b/internal/controller/nnfsystemstorage_controller_test.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dwsv1alpha2 "github.com/DataWorkflowServices/dws/api/v1alpha2"
-	"github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
 )
 
@@ -65,7 +64,7 @@ var _ = Describe("NnfSystemStorage Controller Test", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: nodeName,
 					Labels: map[string]string{
-						v1alpha1.RabbitNodeSelectorLabel: "true",
+						nnfv1alpha1.RabbitNodeSelectorLabel: "true",
 					},
 				},
 				Status: corev1.NodeStatus{


### PR DESCRIPTION
So the crd-bumper tool can find these references.