### PR TITLE
Move kubebuilder:scaffold:builder for new webhooks

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -150,8 +150,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	//+kubebuilder:scaffold:builder
-
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
@@ -367,26 +365,30 @@ func (c *storageController) SetupReconcilers(mgr manager.Manager, opts *nnf.Opti
 		return err
 	}
 
+	var err error
+
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err := (&nnfv1alpha1.NnfStorageProfile{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&nnfv1alpha1.NnfStorageProfile{}).SetupWebhookWithManager(mgr); err != nil {
 			ctrl.Log.Error(err, "unable to create webhook", "webhook", "NnfStorageProfile")
 			return err
 		}
 	}
 
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err := (&nnfv1alpha1.NnfContainerProfile{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&nnfv1alpha1.NnfContainerProfile{}).SetupWebhookWithManager(mgr); err != nil {
 			ctrl.Log.Error(err, "unable to create webhook", "webhook", "NnfContainerProfile")
 			return err
 		}
 	}
 
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err := (&nnfv1alpha1.NnfDataMovementProfile{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&nnfv1alpha1.NnfDataMovementProfile{}).SetupWebhookWithManager(mgr); err != nil {
 			ctrl.Log.Error(err, "unable to create webhook", "webhook", "NnfDataMovementProfile")
 			return err
 		}
 	}
+
+	//+kubebuilder:scaffold:builder
 
 	return nil
 }


### PR DESCRIPTION
This is where kubebuilder should place new calls to SetupWebhookWithManager().