### PR TITLE
Allow empty FStype in NnfNodeStorageSpec

### DIFF
--- a/api/v1alpha1/nnfnodestorage_types.go
+++ b/api/v1alpha1/nnfnodestorage_types.go
@@ -54,7 +54,7 @@ type NnfNodeStorageSpec struct {
 	// block device.
 	// +kubebuilder:validation:Enum=raw;lvm;zfs;xfs;gfs2;lustre
 	// +kubebuilder:default:=raw
-	FileSystemType string `json:"fileSystemType"`
+	FileSystemType string `json:"fileSystemType,omitempty"`
 
 	// LustreStorageSpec describes the Lustre target created here, if
 	// FileSystemType specifies a Lustre target.

--- a/api/v1alpha1/nnfstorage_types.go
+++ b/api/v1alpha1/nnfstorage_types.go
@@ -88,7 +88,7 @@ type NnfStorageSpec struct {
 	// block device.
 	// +kubebuilder:validation:Enum=raw;lvm;zfs;xfs;gfs2;lustre
 	// +kubebuilder:default:=raw
-	FileSystemType string `json:"fileSystemType"`
+	FileSystemType string `json:"fileSystemType,omitempty"`
 
 	// User ID for file system
 	UserID uint32 `json:"userID"`

--- a/api/v1alpha1/nnfsystemstorage_types.go
+++ b/api/v1alpha1/nnfsystemstorage_types.go
@@ -60,7 +60,7 @@ type NnfSystemStorageSpec struct {
 	// ComputesTarget specifies which computes to make the storage accessible to
 	// +kubebuilder:validation:Enum=all;even;odd;pattern
 	// +kubebuilder:default:=all
-	ComputesTarget NnfSystemStorageComputesTarget `json:"computesTarget"`
+	ComputesTarget NnfSystemStorageComputesTarget `json:"computesTarget,omitempty"`
 
 	// ComputesPattern is a list of compute node indexes (0-15) to make the storage accessible to. This
 	// is only used if ComputesTarget is "pattern"
@@ -76,7 +76,7 @@ type NnfSystemStorageSpec struct {
 	// Type is the file system type to use for the storage allocation
 	// +kubebuilder:validation:Enum=raw;xfs;gfs2
 	// +kubebuilder:default:=raw
-	Type string `json:"type"`
+	Type string `json:"type,omitempty"`
 
 	// StorageProfile is an object reference to the storage profile to use
 	StorageProfile corev1.ObjectReference `json:"storageProfile"`

--- a/config/crd/bases/nnf.cray.hpe.com_nnfnodestorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfnodestorages.yaml
@@ -170,7 +170,6 @@ spec:
                 type: integer
             required:
             - count
-            - fileSystemType
             - groupID
             - sharedAllocation
             - userID

--- a/config/crd/bases/nnf.cray.hpe.com_nnfstorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfstorages.yaml
@@ -190,7 +190,6 @@ spec:
                 type: integer
             required:
             - allocationSets
-            - fileSystemType
             - groupID
             - userID
             type: object

--- a/config/crd/bases/nnf.cray.hpe.com_nnfsystemstorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfsystemstorages.yaml
@@ -200,10 +200,8 @@ spec:
                 type: string
             required:
             - capacity
-            - computesTarget
             - makeClientMounts
             - storageProfile
-            - type
             type: object
           status:
             description: NnfSystemStorageStatus defines the observed state of NnfSystemStorage


### PR DESCRIPTION
For the kubebuilder:default to work, you have to first allow the field to be empty.