### PR TITLE
Specify a repo-specific config for crd-bumper

### DIFF
--- a/crd-bumper.yaml
+++ b/crd-bumper.yaml
@@ -1,0 +1,5 @@
+# A comma-separated list of directories where more Go code can be found, beyond
+# the usual cmd/, api/, internal/ that kubebuilder would put in place. The Go
+# files in these dirs will be bumped to the new hub version.
+extra_go_dirs: mount-daemon
+


### PR DESCRIPTION
Tell crd-bumper about the Go code in the mount-daemon/ directory.