### PR TITLE
Move example resources to v1alpha2

### DIFF
--- a/config/examples-htx/nnfstorageprofile_patch.yaml
+++ b/config/examples-htx/nnfstorageprofile_patch.yaml
@@ -1,4 +1,4 @@
-apiVersion: nnf.cray.hpe.com/v1alpha1
+apiVersion: nnf.cray.hpe.com/v1alpha2
 kind: NnfStorageProfile
 metadata:
   name: template

--- a/config/examples/kustomization.yaml
+++ b/config/examples/kustomization.yaml
@@ -1,9 +1,9 @@
 namespace: nnf-system
 
 resources:
-- nnf_v1alpha1_nnfcontainerprofiles.yaml
-- nnf_v1alpha1_nnfdatamovementprofile.yaml
-- nnf_v1alpha1_nnfstorageprofile.yaml
+- nnf_nnfcontainerprofiles.yaml
+- nnf_nnfdatamovementprofile.yaml
+- nnf_nnfstorageprofile.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/config/examples/nnf_nnfcontainerprofiles.yaml
+++ b/config/examples/nnf_nnfcontainerprofiles.yaml
@@ -1,4 +1,4 @@
-apiVersion: nnf.cray.hpe.com/v1alpha1
+apiVersion: nnf.cray.hpe.com/v1alpha2
 kind: NnfContainerProfile
 metadata:
   name: example-success
@@ -20,7 +20,7 @@ data:
       - -c
       - "sleep 10 && exit 0"
 ---
-apiVersion: nnf.cray.hpe.com/v1alpha1
+apiVersion: nnf.cray.hpe.com/v1alpha2
 kind: NnfContainerProfile
 metadata:
   name: example-fail
@@ -34,7 +34,7 @@ data:
       - -c
       - "sleep 10 && exit 1"
 ---
-apiVersion: nnf.cray.hpe.com/v1alpha1
+apiVersion: nnf.cray.hpe.com/v1alpha2
 kind: NnfContainerProfile
 metadata:
   name: example-randomly-fail
@@ -59,7 +59,7 @@ data:
         echo "exiting: $x"
         exit $x
 ---
-apiVersion: nnf.cray.hpe.com/v1alpha1
+apiVersion: nnf.cray.hpe.com/v1alpha2
 kind: NnfContainerProfile
 metadata:
   name: example-forever
@@ -79,7 +79,7 @@ data:
       - -c
       - "while true; do date && sleep 5; done"
 ---
-apiVersion: nnf.cray.hpe.com/v1alpha1
+apiVersion: nnf.cray.hpe.com/v1alpha2
 kind: NnfContainerProfile
 metadata:
   name: example-mpi
@@ -117,7 +117,7 @@ data:
               image: nnf-mfu:latest
 
 ---
-apiVersion: nnf.cray.hpe.com/v1alpha1
+apiVersion: nnf.cray.hpe.com/v1alpha2
 kind: NnfContainerProfile
 metadata:
   name: example-mpi-fail
@@ -145,7 +145,7 @@ data:
             - name: example-mpi-fail
               image: nnf-mfu:latest
 ---
-apiVersion: nnf.cray.hpe.com/v1alpha1
+apiVersion: nnf.cray.hpe.com/v1alpha2
 kind: NnfContainerProfile
 metadata:
   name: example-mpi-webserver

--- a/config/examples/nnf_nnfdatamovementprofile.yaml
+++ b/config/examples/nnf_nnfdatamovementprofile.yaml
@@ -1,4 +1,4 @@
-apiVersion: nnf.cray.hpe.com/v1alpha1
+apiVersion: nnf.cray.hpe.com/v1alpha2
 kind: NnfDataMovementProfile
 metadata:
   name: template

--- a/config/examples/nnf_nnfstorageprofile.yaml
+++ b/config/examples/nnf_nnfstorageprofile.yaml
@@ -1,4 +1,4 @@
-apiVersion: nnf.cray.hpe.com/v1alpha1
+apiVersion: nnf.cray.hpe.com/v1alpha2
 kind: NnfStorageProfile
 metadata:
   name: template


### PR DESCRIPTION
Argocd is reporting them as OutOfSync because they are in the gitops repo as v1alpha1 but when argocd queries them it gets back v1alpha2.