### PR TITLE
Add timeout when creating fan-out child resources

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -131,6 +131,8 @@ spec:
             value: nnf-port-manager
           - name: NNF_PORT_MANAGER_NAMESPACE
             value: nnf-system
+          - name: NNF_CHILD_RESOURCE_TIMEOUT_SECONDS
+            value: "300"
         ports:
           - containerPort: 50057
             name: nnf-ec

--- a/internal/controller/nnf_access_controller.go
+++ b/internal/controller/nnf_access_controller.go
@@ -1033,6 +1033,8 @@ func (r *NnfAccessReconciler) manageClientMounts(ctx context.Context, access *nn
 
 // getClientMountStatus aggregates the status from all the ClientMount resources
 func (r *NnfAccessReconciler) getClientMountStatus(ctx context.Context, access *nnfv1alpha2.NnfAccess, clientList []string) (bool, error) {
+	log := r.Log.WithValues("NnfAccess", client.ObjectKeyFromObject(access))
+
 	if !access.Spec.MakeClientMounts {
 		return true, nil
 	}
@@ -1069,7 +1071,8 @@ func (r *NnfAccessReconciler) getClientMountStatus(ctx context.Context, access *
 	if len(childTimeoutString) > 0 {
 		childTimeout, err := strconv.Atoi(childTimeoutString)
 		if err != nil {
-			return false, dwsv1alpha2.NewResourceError("invalid NNF_CHILD_RESOURCE_TIMEOUT_SECONDS value: %s", childTimeoutString)
+			log.Info("Error: Invalid NNF_CHILD_RESOURCE_TIMEOUT_SECONDS. Defaulting to 300 seconds", "value", childTimeoutString)
+			childTimeout = 300
 		}
 
 		for _, clientMount := range clientMounts {

--- a/internal/controller/nnf_storage_controller.go
+++ b/internal/controller/nnf_storage_controller.go
@@ -436,7 +436,8 @@ func (r *NnfStorageReconciler) aggregateNodeBlockStorageStatus(ctx context.Conte
 	if len(childTimeoutString) > 0 {
 		childTimeout, err := strconv.Atoi(childTimeoutString)
 		if err != nil {
-			return &ctrl.Result{}, dwsv1alpha2.NewResourceError("invalid NNF_CHILD_RESOURCE_TIMEOUT_SECONDS value: %s", childTimeoutString)
+			log.Info("Error: Invalid NNF_CHILD_RESOURCE_TIMEOUT_SECONDS. Defaulting to 300 seconds", "value", childTimeoutString)
+			childTimeout = 300
 		}
 
 		for _, nnfNodeBlockStorage := range nnfNodeBlockStorageList.Items {
@@ -656,7 +657,8 @@ func (r *NnfStorageReconciler) aggregateNodeStorageStatus(ctx context.Context, s
 	if len(childTimeoutString) > 0 {
 		childTimeout, err := strconv.Atoi(childTimeoutString)
 		if err != nil {
-			return &ctrl.Result{}, dwsv1alpha2.NewResourceError("invalid NNF_CHILD_RESOURCE_TIMEOUT_SECONDS value: %s", childTimeoutString)
+			log.Info("Error: Invalid NNF_CHILD_RESOURCE_TIMEOUT_SECONDS. Defaulting to 300 seconds", "value", childTimeoutString)
+			childTimeout = 300
 		}
 
 		for _, nnfNodeStorage := range nnfNodeStorageList.Items {


### PR DESCRIPTION
The ClientMount, NnfNodeStorage, and NnfNodeBlockStorage resources are fanned out to the Rabbit and compute nodes. If the correct controllers aren't running on one or more of those nodes, then the workflow will not progress but won't give an error. Add an optional timeout that checks whether the controller on the Rabbit/compute node has added its finalizer within a configurable amount of time. If the finalizer hasn't been added, then return an error.