### PR TITLE
Use a file based database for nnf-ec

### DIFF
--- a/config/dp0/manager_volumes_patch.yaml
+++ b/config/dp0/manager_volumes_patch.yaml
@@ -102,5 +102,6 @@ spec:
             path: /run/mdadm
         - name: localdisk
           hostPath:
+            type: Directory
             path: /localdisk
 

--- a/config/dp0/manager_volumes_patch.yaml
+++ b/config/dp0/manager_volumes_patch.yaml
@@ -11,6 +11,7 @@ spec:
           args:
             - --controller=node
             - --deleteUnknownVolumes
+          workingDir: /localdisk
           volumeMounts:
             - mountPath: /mnt
               name: mnt-dir
@@ -45,6 +46,8 @@ spec:
               name: tmp-dir
             - mountPath: /etc
               name: etc-dir
+            - mountPath: /localdisk
+              name: localdisk
       volumes:
         - name: mnt-dir
           hostPath:
@@ -97,4 +100,7 @@ spec:
         - name: mdadm-dir
           hostPath:
             path: /run/mdadm
+        - name: localdisk
+          hostPath:
+            path: /localdisk
 

--- a/config/kind/manager_volumes_patch.yaml
+++ b/config/kind/manager_volumes_patch.yaml
@@ -20,6 +20,7 @@ spec:
           hostPath:
             path: /mnt
         - name: localdisk
+          type: DirectoryOrCreate
           hostPath:
             path: /localdisk
 

--- a/config/kind/manager_volumes_patch.yaml
+++ b/config/kind/manager_volumes_patch.yaml
@@ -8,12 +8,18 @@ spec:
     spec:
       containers:
         - name: manager
+          workingDir: /localdisk
           volumeMounts:
             - mountPath: /mnt
               name: mnt-dir
               mountPropagation: Bidirectional
+            - mountPath: /localdisk
+              name: localdisk
       volumes:
         - name: mnt-dir
           hostPath:
             path: /mnt
+        - name: localdisk
+          hostPath:
+            path: /localdisk
 

--- a/internal/controller/nnf_node_ec_data_controller.go
+++ b/internal/controller/nnf_node_ec_data_controller.go
@@ -89,9 +89,6 @@ func (r *NnfNodeECDataReconciler) Start(ctx context.Context) error {
 				return err
 			}
 		}
-
-		// This resource acts as the storage provider for the NNF Element Controller
-		persistent.StorageProvider = r
 	}
 
 	// NNF Element Controller logger provides 4 verbosity levels. By default, nnf-ec


### PR DESCRIPTION
Mount /localdisk (the M.2) into the nnf-node-manager pods. Use the default database in nnf-ec (badger) and change the working directory of the container to /localdisk so the database file is created in the correct spot.