### PR TITLE
Nil err message after waiting for VG

### DIFF
--- a/pkg/blockdevice/lvm/volume_groups.go
+++ b/pkg/blockdevice/lvm/volume_groups.go
@@ -95,7 +95,7 @@ func (vg *VolumeGroup) WaitForAppearance(ctx context.Context) (bool, error) {
 		}
 	}
 
-	return false, fmt.Errorf("timeout waiting for VG %w", err)
+	return false, fmt.Errorf("timeout waiting for VG")
 }
 
 func (vg *VolumeGroup) parseArgs(args string) (string, error) {


### PR DESCRIPTION
Do not print the always-nil 'err' value when we timeout while waiting for a VG to appear.