### PR TITLE
Fix NnfAccess ClientMount count

### DIFF
--- a/internal/controller/nnf_access_controller.go
+++ b/internal/controller/nnf_access_controller.go
@@ -1121,14 +1121,12 @@ func (r *NnfAccessReconciler) getClientMountStatus(ctx context.Context, access *
 	}
 
 	// Check whether the clientmounts have finished mounting/unmounting
-	count := 0
 	for _, clientMount := range clientMounts {
 		if len(clientMount.Status.Mounts) != len(clientMount.Spec.Mounts) {
 			return false, nil
 		}
 
 		for _, mount := range clientMount.Status.Mounts {
-			count++
 			if string(mount.State) != access.Status.State {
 				return false, nil
 			}
@@ -1139,9 +1137,9 @@ func (r *NnfAccessReconciler) getClientMountStatus(ctx context.Context, access *
 		}
 	}
 
-	if count != len(clientList) {
+	if len(clientMounts) != len(clientList) {
 		if access.GetDeletionTimestamp().IsZero() {
-			log.Info("unexpected number of ClientMounts", "found", count, "expected", len(clientList))
+			log.Info("unexpected number of ClientMounts", "found", len(clientMounts), "expected", len(clientList))
 		}
 		return false, nil
 	}


### PR DESCRIPTION
This was a workaround to account for creating multiple OSTs in an
unorthodox manner in the Servers resource. Flux won't create multiple
allocation sets on a single rabbit, but rather use the count when there
are multiple allocations on a single rabbit.

This workaround causes a bug and is not needed.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
