### PR TITLE
Don't use a shared ChildObjects array

### DIFF
--- a/internal/controller/directivebreakdown_controller.go
+++ b/internal/controller/directivebreakdown_controller.go
@@ -64,9 +64,8 @@ const (
 // DirectiveBreakdownReconciler reconciles a DirectiveBreakdown object
 type DirectiveBreakdownReconciler struct {
 	client.Client
-	Log          logr.Logger
-	Scheme       *kruntime.Scheme
-	ChildObjects []dwsv1alpha2.ObjectList
+	Log    logr.Logger
+	Scheme *kruntime.Scheme
 }
 
 type lustreComponentType struct {
@@ -111,7 +110,7 @@ func (r *DirectiveBreakdownReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 
 		// Delete all children that are owned by this DirectiveBreakdown.
-		deleteStatus, err := dwsv1alpha2.DeleteChildren(ctx, r.Client, r.ChildObjects, dbd)
+		deleteStatus, err := dwsv1alpha2.DeleteChildren(ctx, r.Client, r.getChildObjects(), dbd)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -620,14 +619,16 @@ func populateStorageAllocationSet(a *dwsv1alpha2.StorageAllocationSet, strategy 
 	}
 }
 
-// SetupWithManager sets up the controller with the Manager.
-func (r *DirectiveBreakdownReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	r.ChildObjects = []dwsv1alpha2.ObjectList{
+func (r *DirectiveBreakdownReconciler) getChildObjects() []dwsv1alpha2.ObjectList {
+	return []dwsv1alpha2.ObjectList{
 		&dwsv1alpha2.ServersList{},
 		&nnfv1alpha4.NnfStorageProfileList{},
 		&dwsv1alpha2.PersistentStorageInstanceList{},
 	}
+}
 
+// SetupWithManager sets up the controller with the Manager.
+func (r *DirectiveBreakdownReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	maxReconciles := runtime.GOMAXPROCS(0)
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxReconciles}).

--- a/internal/controller/nnf_access_controller.go
+++ b/internal/controller/nnf_access_controller.go
@@ -54,9 +54,8 @@ import (
 // NnfAccessReconciler reconciles a NnfAccess object
 type NnfAccessReconciler struct {
 	client.Client
-	Log          logr.Logger
-	Scheme       *kruntime.Scheme
-	ChildObjects []dwsv1alpha2.ObjectList
+	Log    logr.Logger
+	Scheme *kruntime.Scheme
 }
 
 const (
@@ -118,7 +117,7 @@ func (r *NnfAccessReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, nil
 		}
 
-		deleteStatus, err := dwsv1alpha2.DeleteChildren(ctx, r.Client, r.ChildObjects, access)
+		deleteStatus, err := dwsv1alpha2.DeleteChildren(ctx, r.Client, r.getChildObjects(), access)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -1233,12 +1232,14 @@ func (r *NnfAccessReconciler) ComputesEnqueueRequests(ctx context.Context, o cli
 	return requests
 }
 
-// SetupWithManager sets up the controller with the Manager.
-func (r *NnfAccessReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	r.ChildObjects = []dwsv1alpha2.ObjectList{
+func (r *NnfAccessReconciler) getChildObjects() []dwsv1alpha2.ObjectList {
+	return []dwsv1alpha2.ObjectList{
 		&dwsv1alpha2.ClientMountList{},
 	}
+}
 
+// SetupWithManager sets up the controller with the Manager.
+func (r *NnfAccessReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// NOTE: NNF Access controller also depends on NNF Storage and NNF Node Storage status'
 	// as part of its reconcile sequence. But since there is not a very good way to translate
 	// from these resources to the associated NNF Access resource as one would typically do

--- a/internal/controller/nnfsystemstorage_controller.go
+++ b/internal/controller/nnfsystemstorage_controller.go
@@ -46,9 +46,8 @@ import (
 // NnfSystemStorageReconciler reconciles a NnfSystemStorage object
 type NnfSystemStorageReconciler struct {
 	client.Client
-	Log          logr.Logger
-	Scheme       *kruntime.Scheme
-	ChildObjects []dwsv1alpha2.ObjectList
+	Log    logr.Logger
+	Scheme *kruntime.Scheme
 }
 
 const (
@@ -88,7 +87,7 @@ func (r *NnfSystemStorageReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			return ctrl.Result{}, nil
 		}
 
-		deleteStatus, err := dwsv1alpha2.DeleteChildren(ctx, r.Client, r.ChildObjects, nnfSystemStorage)
+		deleteStatus, err := dwsv1alpha2.DeleteChildren(ctx, r.Client, r.getChildObjects(), nnfSystemStorage)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -689,16 +688,17 @@ func (r *NnfSystemStorageReconciler) NnfSystemStorageEnqueueAll(ctx context.Cont
 
 	return requests
 }
-
-// SetupWithManager sets up the controller with the Manager.
-func (r *NnfSystemStorageReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	r.ChildObjects = []dwsv1alpha2.ObjectList{
+func (r *NnfSystemStorageReconciler) getChildObjects() []dwsv1alpha2.ObjectList {
+	return []dwsv1alpha2.ObjectList{
 		&nnfv1alpha4.NnfAccessList{},
 		&nnfv1alpha4.NnfStorageList{},
 		&dwsv1alpha2.ComputesList{},
 		&dwsv1alpha2.ServersList{},
 	}
+}
 
+// SetupWithManager sets up the controller with the Manager.
+func (r *NnfSystemStorageReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&nnfv1alpha4.NnfSystemStorage{}).
 		Owns(&dwsv1alpha2.Computes{}).


### PR DESCRIPTION
Use a function to return a new ChildObjects array for each call to DeleteChildren()