### PR TITLE
Select strict allocation compliance to guarantee equally sized namespaces on each drive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/DataWorkflowServices/dws v0.0.1-0.20241029172011-d5898d0b8640
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20241209183639-2d8fdbd63dec
-	github.com/NearNodeFlash/nnf-ec v0.0.1-0.20241205165035-51a536434b0d
+	github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250113163425-2fd0825bc67c
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.4.1
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/HewlettPackard/structex v1.0.4 h1:RVTdN5FWhDWr1IkjllU8wxuLjISo4gr6u5r
 github.com/HewlettPackard/structex v1.0.4/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20241209183639-2d8fdbd63dec h1:LPeWeG5xeqixm1YfE26jY5mbhFS8jNkErrI+WmQLFgg=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20241209183639-2d8fdbd63dec/go.mod h1:3JGfBMIfipAZbbAAesSvKzGmKGAh2Wu6pPGQWMP2f8w=
-github.com/NearNodeFlash/nnf-ec v0.0.1-0.20241205165035-51a536434b0d h1:s+zaQp8959Z1KjAo/zRP05CRJUrHTKx2ItbR4C3ffQw=
-github.com/NearNodeFlash/nnf-ec v0.0.1-0.20241205165035-51a536434b0d/go.mod h1:oxdwMqfttOF9dabJhqrWlirCnMk8/8eyLMwl+hducjk=
+github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250113163425-2fd0825bc67c h1:zK1VlTmgsa+dhbLWOGaQ1GWyFeyv8jQmkiVq27VzGNc=
+github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250113163425-2fd0825bc67c/go.mod h1:oxdwMqfttOF9dabJhqrWlirCnMk8/8eyLMwl+hducjk=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=

--- a/internal/controller/nnf_node_block_storage_controller.go
+++ b/internal/controller/nnf_node_block_storage_controller.go
@@ -541,7 +541,7 @@ func (r *NnfNodeBlockStorageReconciler) createStoragePool(ss nnf.StorageServiceA
 		CapacityBytes: capacity,
 		Oem: openapi.MarshalOem(nnf.AllocationPolicyOem{
 			Policy:     nnf.SpareAllocationPolicyType,
-			Compliance: nnf.RelaxedAllocationComplianceType,
+			Compliance: nnf.StrictAllocationComplianceType,
 		}),
 	}
 

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nnf/manager.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nnf/manager.go
@@ -701,7 +701,7 @@ func (*StorageService) StorageServiceIdStoragePoolsPost(storageServiceId string,
 		return ec.NewErrInternalServerError().WithResourceType(StorageServiceOdataType).WithError(err).WithCause("Failed to initialize storage policy")
 	}
 
-	if err := policy.CheckCapacity(); err != nil {
+	if err := policy.CheckAndAdjustCapacity(); err != nil {
 		log.Error(err, "Storage policy cannot support capacity", "capacityInBytes", capacityInBytes)
 		return ec.NewErrNotAcceptable().WithResourceType(StorageServiceOdataType).WithError(err).WithCause("Insufficient capacity available")
 	}

--- a/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nvme/manager.go
+++ b/vendor/github.com/NearNodeFlash/nnf-ec/pkg/manager-nvme/manager.go
@@ -110,7 +110,7 @@ type Storage struct {
 	// the life of the object.
 	capacityBytes uint64
 
-	// Unallocated capacity in bytes. This value is updated for any namespaces create or
+	// Unallocated capacity in bytes. This value is updated for any namespace create or
 	// delete operation that might shrink or grow the byte count as expected.
 	unallocatedBytes uint64
 
@@ -217,8 +217,9 @@ func findStoragePool(storageId, storagePoolId string) (*Storage, *interface{}) {
 	return nil, nil
 }
 
+// CleanupVolumes - remove all volumes other than the list of providingVolumes
 func CleanupVolumes(providingVolumes []ProvidingVolume) {
-	for _, storage := range mgr.storage {
+	for _, storage := range GetStorage() {
 		if !storage.IsEnabled() {
 			continue
 		}
@@ -456,7 +457,7 @@ func (s *Storage) purge() error {
 	return nil
 }
 
-// Delete all the volumes on this storage device except for the volumes that we want to keep
+// Delete all the volumes on this storage device other than the ones specified
 func (s *Storage) purgeVolumes(volIdsToKeep []string) error {
 	if s.device == nil {
 		return fmt.Errorf("Storage %s has no device", s.id)
@@ -551,7 +552,7 @@ func (s *Storage) deleteVolume(volumeId string) error {
 				log.Error(err, "Delete namespace failed")
 				return err
 			}
-			log.V(1).Info("Deleted namespace")
+			log.V(1).Info("Deleted namespace", "capacity", volume.capacityBytes)
 
 			s.unallocatedBytes += volume.capacityBytes
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -16,7 +16,7 @@ github.com/HewlettPackard/structex
 github.com/NearNodeFlash/lustre-fs-operator/api/v1beta1
 github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
 github.com/NearNodeFlash/lustre-fs-operator/config/webhook
-# github.com/NearNodeFlash/nnf-ec v0.0.1-0.20241205165035-51a536434b0d
+# github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250113163425-2fd0825bc67c
 ## explicit; go 1.19
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme
 github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/switchtec


### PR DESCRIPTION
Vendor in nnf-ec changes to implement the `strict` allocation compliance policy, and then select that compliance policy for use with nnf-node-block-storage devices.