### PR TITLE
Fix nnf-container-example image tag in container profile

### DIFF
--- a/config/examples/nnf_nnfcontainerprofiles.yaml
+++ b/config/examples/nnf_nnfcontainerprofiles.yaml
@@ -169,7 +169,7 @@ data:
           spec:
             containers:
             - name: example-mpi-webserver
-              image: ghcr.io/nearnodeflash/nnf-container-example:latest
+              image: ghcr.io/nearnodeflash/nnf-container-example:master
               command:
               - mpirun
               - python3
@@ -181,4 +181,4 @@ data:
           spec:
             containers:
             - name: example-mpi-webserver
-              image: ghcr.io/nearnodeflash/nnf-container-example:latest
+              image: ghcr.io/nearnodeflash/nnf-container-example:master


### PR DESCRIPTION
The `latest` tag no longer exists for this image. Use `master` instead.