### PR TITLE
CRDBUMPER-unserve-api

### DIFF
--- a/api/v1alpha3/nnfaccess_types.go
+++ b/api/v1alpha3/nnfaccess_types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+ * Copyright 2021-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -87,6 +87,7 @@ type NnfAccessStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 //+kubebuilder:printcolumn:name="DESIREDSTATE",type="string",JSONPath=".spec.desiredState",description="The desired state"
 //+kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.state",description="The current state"
 //+kubebuilder:printcolumn:name="READY",type="boolean",JSONPath=".status.ready",description="Whether the state has been achieved"

--- a/api/v1alpha3/nnfcontainerprofile_types.go
+++ b/api/v1alpha3/nnfcontainerprofile_types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+ * Copyright 2023-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -116,6 +116,7 @@ type NnfContainerProfileStorage struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 
 // NnfContainerProfile is the Schema for the nnfcontainerprofiles API
 type NnfContainerProfile struct {
@@ -126,6 +127,7 @@ type NnfContainerProfile struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 
 // NnfContainerProfileList contains a list of NnfContainerProfile
 type NnfContainerProfileList struct {

--- a/api/v1alpha3/nnfdatamovement_types.go
+++ b/api/v1alpha3/nnfdatamovement_types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+ * Copyright 2021-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -219,6 +219,7 @@ const (
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 //+kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.state",description="Current state"
 //+kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.status",description="Status of current state"
 //+kubebuilder:printcolumn:name="ERROR",type="string",JSONPath=".status.error.severity"

--- a/api/v1alpha3/nnfdatamovementmanager_types.go
+++ b/api/v1alpha3/nnfdatamovementmanager_types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+ * Copyright 2022-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -75,6 +75,7 @@ type NnfDataMovementManagerStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 //+kubebuilder:printcolumn:name="READY",type="boolean",JSONPath=".status.ready",description="True if manager readied all resoures"
 //+kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 

--- a/api/v1alpha3/nnfdatamovementprofile_types.go
+++ b/api/v1alpha3/nnfdatamovementprofile_types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Hewlett Packard Enterprise Development LP
+ * Copyright 2024-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -97,6 +97,7 @@ type NnfDataMovementProfileData struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 // +kubebuilder:printcolumn:name="DEFAULT",type="boolean",JSONPath=".data.default",description="True if this is the default instance"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 
@@ -109,6 +110,7 @@ type NnfDataMovementProfile struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 
 // NnfDataMovementProfileList contains a list of NnfDataMovementProfile
 type NnfDataMovementProfileList struct {

--- a/api/v1alpha3/nnflustremgt_types.go
+++ b/api/v1alpha3/nnflustremgt_types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Hewlett Packard Enterprise Development LP
+ * Copyright 2024-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -70,6 +70,7 @@ type NnfLustreMGTStatusClaim struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // NnfLustreMGT is the Schema for the nnfstorageprofiles API
 type NnfLustreMGT struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1alpha3/nnfnode_types.go
+++ b/api/v1alpha3/nnfnode_types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+ * Copyright 2021-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -98,6 +98,7 @@ type NnfDriveStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 //+kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".spec.state",description="Current desired state"
 //+kubebuilder:printcolumn:name="HEALTH",type="string",JSONPath=".status.health",description="Health of node"
 //+kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.status",description="Current status of node"

--- a/api/v1alpha3/nnfnodeblockstorage_types.go
+++ b/api/v1alpha3/nnfnodeblockstorage_types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+ * Copyright 2023-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -97,6 +97,7 @@ type NnfNodeBlockStorageAllocationStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.ready"
 // +kubebuilder:printcolumn:name="ERROR",type="string",JSONPath=".status.error.severity"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"

--- a/api/v1alpha3/nnfnodeecdata_types.go
+++ b/api/v1alpha3/nnfnodeecdata_types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+ * Copyright 2022-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -44,6 +44,7 @@ type NnfNodeECPrivateData map[string]string
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 
 // NnfNodeECData is the Schema for the nnfnodeecdata API
 type NnfNodeECData struct {

--- a/api/v1alpha3/nnfnodestorage_types.go
+++ b/api/v1alpha3/nnfnodestorage_types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+ * Copyright 2021-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -113,6 +113,7 @@ type NnfNodeStorageAllocationStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.ready"
 // +kubebuilder:printcolumn:name="ERROR",type="string",JSONPath=".status.error.severity"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"

--- a/api/v1alpha3/nnfportmanager_types.go
+++ b/api/v1alpha3/nnfportmanager_types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+ * Copyright 2023-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -113,6 +113,7 @@ type NnfPortManagerStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 
 // NnfPortManager is the Schema for the nnfportmanagers API
 type NnfPortManager struct {

--- a/api/v1alpha3/nnfstorage_types.go
+++ b/api/v1alpha3/nnfstorage_types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+ * Copyright 2021-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -141,6 +141,7 @@ type NnfStorageStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 //+kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.ready"
 //+kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 //+kubebuilder:printcolumn:name="ERROR",type="string",JSONPath=".status.error.severity"

--- a/api/v1alpha3/nnfstorageprofile_types.go
+++ b/api/v1alpha3/nnfstorageprofile_types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+ * Copyright 2022-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -275,6 +275,7 @@ type NnfStorageProfileData struct {
 }
 
 //+kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 //+kubebuilder:printcolumn:name="DEFAULT",type="boolean",JSONPath=".data.default",description="True if this is the default instance"
 //+kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 
@@ -287,6 +288,7 @@ type NnfStorageProfile struct {
 }
 
 //+kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 
 // NnfStorageProfileList contains a list of NnfStorageProfile
 type NnfStorageProfileList struct {

--- a/api/v1alpha3/nnfsystemstorage_types.go
+++ b/api/v1alpha3/nnfsystemstorage_types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Hewlett Packard Enterprise Development LP
+ * Copyright 2024-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -105,6 +105,7 @@ type NnfSystemStorageStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // NnfSystemStorage is the Schema for the nnfsystemstorages API
 type NnfSystemStorage struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crd/bases/nnf.cray.hpe.com_nnfaccesses.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfaccesses.yaml
@@ -510,7 +510,7 @@ spec:
             - state
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementmanagers.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementmanagers.yaml
@@ -14766,7 +14766,7 @@ spec:
             - ready
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementprofiles.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementprofiles.yaml
@@ -263,7 +263,7 @@ spec:
           metadata:
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources: {}
   - additionalPrinterColumns:

--- a/config/crd/bases/nnf.cray.hpe.com_nnfdatamovements.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfdatamovements.yaml
@@ -822,7 +822,7 @@ spec:
                 type: string
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/nnf.cray.hpe.com_nnflustremgts.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnflustremgts.yaml
@@ -552,7 +552,7 @@ spec:
                 type: string
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/nnf.cray.hpe.com_nnfnodeblockstorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfnodeblockstorages.yaml
@@ -336,7 +336,7 @@ spec:
             - ready
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/nnf.cray.hpe.com_nnfnodeecdata.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfnodeecdata.yaml
@@ -90,7 +90,7 @@ spec:
                 type: object
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/nnf.cray.hpe.com_nnfnodes.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfnodes.yaml
@@ -330,7 +330,7 @@ spec:
                 type: string
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/nnf.cray.hpe.com_nnfnodestorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfnodestorages.yaml
@@ -448,7 +448,7 @@ spec:
                 type: boolean
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/nnf.cray.hpe.com_nnfportmanagers.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfportmanagers.yaml
@@ -484,7 +484,7 @@ spec:
             - status
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/nnf.cray.hpe.com_nnfstorageprofiles.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfstorageprofiles.yaml
@@ -1266,7 +1266,7 @@ spec:
           metadata:
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources: {}
   - additionalPrinterColumns:

--- a/config/crd/bases/nnf.cray.hpe.com_nnfstorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfstorages.yaml
@@ -600,7 +600,7 @@ spec:
                 type: boolean
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/nnf.cray.hpe.com_nnfsystemstorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfsystemstorages.yaml
@@ -490,7 +490,7 @@ spec:
             - ready
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/internal/controller/conversion_test.go
+++ b/internal/controller/conversion_test.go
@@ -104,7 +104,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		It("reads NnfAccess resource via hub and via spoke v1alpha3", func() {
+		It("is unable to read NnfAccess resource via spoke v1alpha3", func() {
+			resSpoke := &nnfv1alpha3.NnfAccess{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfAccess resource via hub and via spoke v1alpha3", func() {
+			// ACTION: v1alpha3 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha3.NnfAccess{}
 			Eventually(func(g Gomega) {
@@ -199,7 +206,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		It("reads NnfContainerProfile resource via hub and via spoke v1alpha3", func() {
+		It("is unable to read NnfContainerProfile resource via spoke v1alpha3", func() {
+			resSpoke := &nnfv1alpha3.NnfContainerProfile{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfContainerProfile resource via hub and via spoke v1alpha3", func() {
+			// ACTION: v1alpha3 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha3.NnfContainerProfile{}
 			Eventually(func(g Gomega) {
@@ -289,7 +303,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		It("reads NnfDataMovement resource via hub and via spoke v1alpha3", func() {
+		It("is unable to read NnfDataMovement resource via spoke v1alpha3", func() {
+			resSpoke := &nnfv1alpha3.NnfDataMovement{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfDataMovement resource via hub and via spoke v1alpha3", func() {
+			// ACTION: v1alpha3 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha3.NnfDataMovement{}
 			Eventually(func(g Gomega) {
@@ -388,7 +409,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		It("reads NnfDataMovementManager resource via hub and via spoke v1alpha3", func() {
+		It("is unable to read NnfDataMovementManager resource via spoke v1alpha3", func() {
+			resSpoke := &nnfv1alpha3.NnfDataMovementManager{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfDataMovementManager resource via hub and via spoke v1alpha3", func() {
+			// ACTION: v1alpha3 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha3.NnfDataMovementManager{}
 			Eventually(func(g Gomega) {
@@ -478,7 +506,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		It("reads NnfDataMovementProfile resource via hub and via spoke v1alpha3", func() {
+		It("is unable to read NnfDataMovementProfile resource via spoke v1alpha3", func() {
+			resSpoke := &nnfv1alpha3.NnfDataMovementProfile{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfDataMovementProfile resource via hub and via spoke v1alpha3", func() {
+			// ACTION: v1alpha3 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha3.NnfDataMovementProfile{}
 			Eventually(func(g Gomega) {
@@ -570,7 +605,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		It("reads NnfLustreMGT resource via hub and via spoke v1alpha3", func() {
+		It("is unable to read NnfLustreMGT resource via spoke v1alpha3", func() {
+			resSpoke := &nnfv1alpha3.NnfLustreMGT{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfLustreMGT resource via hub and via spoke v1alpha3", func() {
+			// ACTION: v1alpha3 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha3.NnfLustreMGT{}
 			Eventually(func(g Gomega) {
@@ -662,7 +704,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		It("reads NnfNode resource via hub and via spoke v1alpha3", func() {
+		It("is unable to read NnfNode resource via spoke v1alpha3", func() {
+			resSpoke := &nnfv1alpha3.NnfNode{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfNode resource via hub and via spoke v1alpha3", func() {
+			// ACTION: v1alpha3 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha3.NnfNode{}
 			Eventually(func(g Gomega) {
@@ -752,7 +801,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		It("reads NnfNodeBlockStorage resource via hub and via spoke v1alpha3", func() {
+		It("is unable to read NnfNodeBlockStorage resource via spoke v1alpha3", func() {
+			resSpoke := &nnfv1alpha3.NnfNodeBlockStorage{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfNodeBlockStorage resource via hub and via spoke v1alpha3", func() {
+			// ACTION: v1alpha3 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha3.NnfNodeBlockStorage{}
 			Eventually(func(g Gomega) {
@@ -842,7 +898,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		It("reads NnfNodeECData resource via hub and via spoke v1alpha3", func() {
+		It("is unable to read NnfNodeECData resource via spoke v1alpha3", func() {
+			resSpoke := &nnfv1alpha3.NnfNodeECData{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfNodeECData resource via hub and via spoke v1alpha3", func() {
+			// ACTION: v1alpha3 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha3.NnfNodeECData{}
 			Eventually(func(g Gomega) {
@@ -932,7 +995,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		It("reads NnfNodeStorage resource via hub and via spoke v1alpha3", func() {
+		It("is unable to read NnfNodeStorage resource via spoke v1alpha3", func() {
+			resSpoke := &nnfv1alpha3.NnfNodeStorage{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfNodeStorage resource via hub and via spoke v1alpha3", func() {
+			// ACTION: v1alpha3 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha3.NnfNodeStorage{}
 			Eventually(func(g Gomega) {
@@ -1024,7 +1094,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		It("reads NnfPortManager resource via hub and via spoke v1alpha3", func() {
+		It("is unable to read NnfPortManager resource via spoke v1alpha3", func() {
+			resSpoke := &nnfv1alpha3.NnfPortManager{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfPortManager resource via hub and via spoke v1alpha3", func() {
+			// ACTION: v1alpha3 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha3.NnfPortManager{}
 			Eventually(func(g Gomega) {
@@ -1116,7 +1193,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		It("reads NnfStorage resource via hub and via spoke v1alpha3", func() {
+		It("is unable to read NnfStorage resource via spoke v1alpha3", func() {
+			resSpoke := &nnfv1alpha3.NnfStorage{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfStorage resource via hub and via spoke v1alpha3", func() {
+			// ACTION: v1alpha3 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha3.NnfStorage{}
 			Eventually(func(g Gomega) {
@@ -1206,7 +1290,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		It("reads NnfStorageProfile resource via hub and via spoke v1alpha3", func() {
+		It("is unable to read NnfStorageProfile resource via spoke v1alpha3", func() {
+			resSpoke := &nnfv1alpha3.NnfStorageProfile{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfStorageProfile resource via hub and via spoke v1alpha3", func() {
+			// ACTION: v1alpha3 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha3.NnfStorageProfile{}
 			Eventually(func(g Gomega) {
@@ -1296,7 +1387,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		It("reads NnfSystemStorage resource via hub and via spoke v1alpha3", func() {
+		It("is unable to read NnfSystemStorage resource via spoke v1alpha3", func() {
+			resSpoke := &nnfv1alpha3.NnfSystemStorage{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfSystemStorage resource via hub and via spoke v1alpha3", func() {
+			// ACTION: v1alpha3 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha3.NnfSystemStorage{}
 			Eventually(func(g Gomega) {


### PR DESCRIPTION
Mark the v1alpha3 API as unserved.

ACTION: Address the ACTION comments in internal/controller/conversion_test.go.

ACTION: Begin by running "make vet". Repair any issues that it finds.
  Then run "make test" and continue repairing issues until the tests
  pass.