### PR TITLE
Rescan devices on ClientMount deletion

### DIFF
--- a/internal/controller/nnf_clientmount_controller.go
+++ b/internal/controller/nnf_clientmount_controller.go
@@ -141,6 +141,13 @@ func (r *NnfClientMountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			return ctrl.Result{}, err
 		}
 
+		// Rescan the NVMe devices now that the StorageGroup has been deleted on the Rabbit.
+		// This is a workaround for a problem on some compute nodes where the NVMe namespaces don't
+		// disappear by themselves.
+		if err := nvme.NvmeRescanDevices(log); err != nil {
+			return ctrl.Result{}, dwsv1alpha3.NewResourceError("could not rescan NVMe devices").WithError(err).WithMajor()
+		}
+
 		controllerutil.RemoveFinalizer(clientMount, finalizerNnfClientMount)
 		if err := r.Update(ctx, clientMount); err != nil {
 			if !apierrors.IsConflict(err) {

--- a/pkg/blockdevice/nvme/nvme.go
+++ b/pkg/blockdevice/nvme/nvme.go
@@ -77,20 +77,84 @@ func NvmeListDevices(log logr.Logger) ([]NvmeDevice, error) {
 	return devices, nil
 }
 
-func NvmeRescanDevices(log logr.Logger) error {
+func NvmeGetDevices() ([]string, error) {
 	devices, err := ioutil.ReadDir("/dev/")
 	if err != nil {
-		return fmt.Errorf("could not read /dev: %w", err)
+		return []string{}, fmt.Errorf("could not read /dev: %w", err)
 	}
 
+	nvmeDevices := []string{}
 	nvmeRegex, _ := regexp.Compile("nvme[0-9]+$")
 	for _, device := range devices {
 		if match := nvmeRegex.MatchString(device.Name()); match {
-			nvmeDevice := "/dev/" + device.Name()
-			if _, err := command.Run("nvme ns-rescan "+nvmeDevice, log); err != nil {
-				return fmt.Errorf("could not rescan NVMe device: %w", err)
+			nvmeDevices = append(nvmeDevices, "/dev/"+device.Name())
+		}
+	}
+
+	return nvmeDevices, nil
+}
+
+func NvmeGetNamespaceDevices() ([]string, error) {
+	devices, err := ioutil.ReadDir("/dev/")
+	if err != nil {
+		return []string{}, fmt.Errorf("could not read /dev: %w", err)
+	}
+
+	nvmeNamespaceDevices := []string{}
+	nvmeRegex, _ := regexp.Compile("nvme[0-9]+n[0-9]+$")
+	for _, device := range devices {
+		if match := nvmeRegex.MatchString(device.Name()); match {
+			nvmeNamespaceDevices = append(nvmeNamespaceDevices, "/dev/"+device.Name())
+		}
+	}
+
+	return nvmeNamespaceDevices, nil
+}
+
+func NvmeRescanDevices(log logr.Logger) error {
+	nvmeDevices, err := NvmeGetDevices()
+	if err != nil {
+		return err
+	}
+
+	startingNamespaces, err := NvmeGetNamespaceDevices()
+	if err != nil {
+		return err
+	}
+
+	for _, nvmeDevice := range nvmeDevices {
+		if _, err := command.Run("nvme ns-rescan "+nvmeDevice, log); err != nil {
+			return fmt.Errorf("could not rescan NVMe device: %w", err)
+		}
+	}
+
+	endingNamespaces, err := NvmeGetNamespaceDevices()
+	if err != nil {
+		return err
+	}
+
+	removedNamespaces := []string{}
+
+	for _, startingNamespace := range startingNamespaces {
+		found := false
+		for i, endingNamespace := range endingNamespaces {
+			if startingNamespace == endingNamespace {
+				found = true
+				endingNamespaces = append(endingNamespaces[:i], endingNamespaces[i+1:]...)
+				break
 			}
 		}
+		if !found {
+			removedNamespaces = append(removedNamespaces, startingNamespace)
+		}
+	}
+
+	if len(removedNamespaces) != 0 {
+		log.Info("nvme ns-rescan removed NVMe devices", "device paths", removedNamespaces)
+	}
+
+	if len(endingNamespaces) != 0 {
+		log.Info("nvme ns-rescan added NVMe devices", "device paths", endingNamespaces)
 	}
 
 	return nil


### PR DESCRIPTION
Rescan devices when the ClientMount resource is deleted to make sure we pick up the removal of the NVMe namespaces. Also, print a log message anytime the NVMe rescan results in a change to the number of NVMe namespaces in /dev.