### PR TITLE
Copy Offload API: Support changes to using mpi-operator

### DIFF
--- a/internal/controller/nnf_workflow_controller.go
+++ b/internal/controller/nnf_workflow_controller.go
@@ -374,7 +374,10 @@ func intepretRequiresKeyword(workflow *dwsv1alpha3.Workflow, requiresList string
 
 	for _, value := range strings.Split(requiresList, ",") {
 		switch value {
-		case "copy-offload", "user-container-auth":
+		case "copy-offload":
+			addWord(requiresCopyOffload)
+			addWord(requiresContainerAuth)
+		case "user-container-auth":
 			addWord(requiresContainerAuth)
 		}
 	}
@@ -837,7 +840,6 @@ func (r *NnfWorkflowReconciler) finishDataInOutState(ctx context.Context, workfl
 	}
 
 	// Check results of data movement operations
-	// TODO: Detailed Fail Message?
 	for _, dm := range dataMovementList.Items {
 		if dm.Status.Status != nnfv1alpha6.DataMovementConditionReasonSuccess {
 			handleWorkflowErrorByIndex(dwsv1alpha3.NewResourceError("").WithUserMessage(
@@ -1107,7 +1109,6 @@ func (r *NnfWorkflowReconciler) finishPostRunState(ctx context.Context, workflow
 	}
 
 	// Any user created copy-offload data movement requests created during run must report any errors to the workflow.
-	// TODO: Customer asked if this could be optional
 	matchingLabels := dwsv1alpha3.MatchingOwner(workflow)
 	matchingLabels[nnfv1alpha6.DataMovementTeardownStateLabel] = string(dwsv1alpha3.StatePostRun)
 

--- a/internal/controller/nnf_workflow_controller_container_helpers.go
+++ b/internal/controller/nnf_workflow_controller_container_helpers.go
@@ -177,8 +177,8 @@ func (c *nnfUserContainer) createMPIJob() error {
 		return err
 	}
 
-	// Add the ports to the worker spec and add environment variable for both launcher/worker For
-	// copy offload we want the ports on the launcher so the copy offload server can be contacted
+	// Add the ports to the worker spec and add environment variable for both launcher/worker. For
+	// copy offload we want the ports on the launcher, so the copy offload server can be contacted
 	// from the computes.
 	// FIXME: For user-containers, we're opening the ports on the workers - but is that what we
 	// actually want?

--- a/internal/controller/nnf_workflow_controller_container_helpers.go
+++ b/internal/controller/nnf_workflow_controller_container_helpers.go
@@ -43,18 +43,19 @@ import (
 )
 
 type nnfUserContainer struct {
-	workflow *dwsv1alpha3.Workflow
-	profile  *nnfv1alpha6.NnfContainerProfile
-	nnfNodes []string
-	volumes  []nnfContainerVolume
-	secrets  []nnfContainerSecret
-	username string
-	uid, gid int64
-	client   client.Client
-	log      logr.Logger
-	scheme   *runtime.Scheme
-	ctx      context.Context
-	index    int
+	workflow    *dwsv1alpha3.Workflow
+	profile     *nnfv1alpha6.NnfContainerProfile
+	nnfNodes    []string
+	volumes     []nnfContainerVolume
+	secrets     []nnfContainerSecret
+	username    string
+	uid, gid    int64
+	client      client.Client
+	log         logr.Logger
+	scheme      *runtime.Scheme
+	ctx         context.Context
+	index       int
+	copyOffload bool
 }
 
 // This struct contains all the necessary information for mounting container storages
@@ -79,6 +80,7 @@ type nnfContainerSecret struct {
 
 const (
 	requiresContainerAuth = "container-auth"
+	requiresCopyOffload   = "copy-offload"
 )
 
 // MPI container workflow. In this model, we use mpi-operator to create an MPIJob, which creates
@@ -174,8 +176,17 @@ func (c *nnfUserContainer) createMPIJob() error {
 	if err != nil {
 		return err
 	}
-	// Add the ports to the worker spec and add environment variable for both launcher/worker
-	addHostPorts(workerSpec, ports)
+
+	// Add the ports to the worker spec and add environment variable for both launcher/worker For
+	// copy offload we want the ports on the launcher so the copy offload server can be contacted
+	// from the computes.
+	// FIXME: For user-containers, we're opening the ports on the workers - but is that what we
+	// actually want?
+	if c.copyOffload {
+		addHostPorts(launcherSpec, ports)
+	} else {
+		addHostPorts(workerSpec, ports)
+	}
 	addPortsEnvVars(launcherSpec, ports)
 	addPortsEnvVars(workerSpec, ports)
 
@@ -486,6 +497,8 @@ func addHostPorts(spec *corev1.PodSpec, ports []uint16) {
 	}
 
 	// Add the ports to the containers
+	// FIXME: this adds the same ports to all containers. Is that what we actually want? Doesn't
+	// each container need it's own port?
 	for idx := range spec.Containers {
 		container := &spec.Containers[idx]
 

--- a/internal/controller/nnf_workflow_controller_helpers.go
+++ b/internal/controller/nnf_workflow_controller_helpers.go
@@ -1540,7 +1540,7 @@ func (r *NnfWorkflowReconciler) waitForContainersToStart(ctx context.Context, wo
 			}
 		}
 
-		// If we're up and running and this is copy offload, then go and find which rabbit node the
+		// If we're up and running and this is copy offload, then determine which rabbit node the
 		// launcher pod landed on and set an env var for flux. This tells the compute how to contact
 		// the copy offload server.
 		if running && slices.Contains(workflow.Status.Requires, requiresCopyOffload) {

--- a/internal/controller/nnf_workflow_controller_test.go
+++ b/internal/controller/nnf_workflow_controller_test.go
@@ -1519,7 +1519,7 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 			)
 
 			DescribeTable("should go to Proposal Ready with interpreted Requires in the workflow",
-				func(requiresList string, wantList string) {
+				func(requiresList string, wantList []string) {
 					buildRestrictedContainerProfile(nil, nil)
 					buildWorkflowWithCorrectDirectives(requiresList)
 					Eventually(func(g Gomega) bool {
@@ -1529,16 +1529,17 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 					if len(wantList) == 0 {
 						Expect(workflow.Status.Requires).To(HaveLen(0))
 					} else {
-						words := strings.Split(wantList, ",")
-						Expect(workflow.Status.Requires).Should(ContainElements(words))
-						Expect(workflow.Status.Requires).To(HaveLen(len(words)))
+						Expect(workflow.Status.Requires).Should(ContainElements(wantList))
+						Expect(workflow.Status.Requires).To(HaveLen(len(wantList)))
 					}
 				},
-				// The 'requiresList' content is constrained by the nnf-ruleset,
-				// while the 'wantList' content is not.
-				Entry("when requires list is empty", "", ""),
-				Entry("when requires list has one", "copy-offload", requiresContainerAuth),
-				Entry("when requires list has multiple matches", "copy-offload,user-container-auth", requiresContainerAuth),
+				// The 'requiresList' content is constrained by the nnf-ruleset, while the
+				// 'wantList' content is not.
+				Entry("when requires list is empty", "", []string{}),
+				Entry("when requires list has one", "user-container-auth", []string{requiresContainerAuth}),
+				// copy-offload adds two words: one for itself and one for container auth
+				Entry("when requires list has copy-offload", "copy-offload", []string{requiresContainerAuth, requiresCopyOffload}),
+				Entry("when requires list has multiple matches", "copy-offload,user-container-auth", []string{requiresContainerAuth, requiresCopyOffload}),
 			)
 		})
 


### PR DESCRIPTION
This adds a few pieces to support using mpi-operator for the new Copy Offload API.

Most notably is adding the `NNF_COPY_OFFLOAD_SERVER` environment variable which tells the compute nodes how to contact the Copy Offload Server that is hosting the API on one of the rabbit nodes allocated to the workflow.