### PR TITLE
Verify user container TLS secret during Proposal

### DIFF
--- a/internal/controller/nnf_workflow_controller_helpers.go
+++ b/internal/controller/nnf_workflow_controller_helpers.go
@@ -2052,7 +2052,7 @@ func (r *NnfWorkflowReconciler) getContainerSecrets(workflow *dwsv1alpha3.Workfl
 			vol1 := nnfContainerSecret{
 				name:       "usercontainer-tls",
 				mountPath:  "/etc/usercontainer-tls",
-				secretName: "nnf-dm-usercontainer-server-tls",
+				secretName: userContainerTLSSecretName,
 				envVarsToFileNames: map[string]string{
 					"TLS_CERT_PATH": "tls.crt",
 					"TLS_KEY_PATH":  "tls.key",

--- a/internal/controller/nnf_workflow_controller_test.go
+++ b/internal/controller/nnf_workflow_controller_test.go
@@ -1565,8 +1565,11 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 				},
 				// The 'requiresList' content is constrained by config/dws/nnf-ruleset.yaml, while the
 				// 'wantList' content is not.
+				// In these first two cases, we don't care whether or not the
+				// TLS secret exists because we're not using it anyway. The workflow
+				// still has to get to Proposal-ready.
 				Entry("when requires list is empty", "", []string{}, true),
-				Entry("when requires list is empty", "", []string{}, false),
+				Entry("when requires list is empty and user-container TLS secret does not exist", "", []string{}, false),
 				Entry("when requires list has one", "user-container-auth", []string{requiresContainerAuth}, true),
 				// copy-offload adds two words: one for itself and one for container auth
 				Entry("when requires list has copy-offload", "copy-offload", []string{requiresContainerAuth, requiresCopyOffload}, true),


### PR DESCRIPTION
During Proposal state, if the Workflow directive specifies copy-offload or user-container-auth, check for the system "nnf-dm-usercontainer-client-tls" secret.