### PR TITLE
DM Profile: Add $VAR checks for commands in webhook

### DIFF
--- a/api/v1alpha7/nnfdatamovementprofile_types.go
+++ b/api/v1alpha7/nnfdatamovementprofile_types.go
@@ -56,6 +56,7 @@ type NnfDataMovementProfileData struct {
 	//   SRC: source for the data movement
 	//   DEST destination for the data movement
 	// +kubebuilder:default:="ulimit -n 2048 && mpirun --allow-run-as-root --hostfile $HOSTFILE dcp --progress 1 --uid $UID --gid $GID $SRC $DEST"
+	// +kubebuilder:validation:XValidation:rule=`!self.contains("dcp") || (self.contains("$HOSTFILE") && self.contains("$UID") && self.contains("$GID") && self.contains("$SRC") && self.contains("$DEST"))`
 	Command string `json:"command"`
 
 	// If true, enable the command's stdout to be saved in the log when the command completes
@@ -93,6 +94,7 @@ type NnfDataMovementProfileData struct {
 	//   		  inherited from the workflow.
 	//   PATH: Path to stat
 	// +kubebuilder:default:="mpirun --allow-run-as-root -np 1 --hostfile $HOSTFILE -- $SETPRIV stat --cached never -c '%F' $PATH"
+	// +kubebuilder:validation:XValidation:rule=`!self.contains("stat") || (self.contains("$HOSTFILE") && self.contains("$SETPRIV") && self.contains("$PATH"))`
 	StatCommand string `json:"statCommand"`
 
 	// If CreateDestDir is true, then use MkdirCommand to perform the mkdir commands.
@@ -105,6 +107,7 @@ type NnfDataMovementProfileData struct {
 	//   		  inherited from the workflow.
 	//   PATH: Path to stat
 	// +kubebuilder:default:="mpirun --allow-run-as-root -np 1 --hostfile $HOSTFILE -- $SETPRIV mkdir -p $PATH"
+	// +kubebuilder:validation:XValidation:rule=`!self.contains("mkdir") || (self.contains("$HOSTFILE") && self.contains("$SETPRIV") && self.contains("$PATH"))`
 	MkdirCommand string `json:"mkdirCommand"`
 
 	// The full setpriv command that is used to become the user and group specified in the workflow.
@@ -113,6 +116,7 @@ type NnfDataMovementProfileData struct {
 	//   UID: User ID that is inherited from the Workflow
 	//   GID: Group ID that is inherited from the Workflow
 	// +kubebuilder:default:="setpriv --euid $UID --egid $GID --clear-groups"
+	// +kubebuilder:validation:XValidation:rule=`!self.contains("setpriv") || (self.contains("$UID") && self.contains("$GID"))`
 	SetprivCommand string `json:"setprivCommand"`
 }
 

--- a/api/v1alpha7/nnfdatamovementprofile_webhook.go
+++ b/api/v1alpha7/nnfdatamovementprofile_webhook.go
@@ -41,6 +41,13 @@ func (r *NnfDataMovementProfile) SetupWebhookWithManager(mgr ctrl.Manager) error
 		Complete()
 }
 
+var (
+	defaultDMCommand        = "ulimit -n 2048 && mpirun --allow-run-as-root --hostfile $HOSTFILE dcp --progress 1 --uid $UID --gid $GID $SRC $DEST"
+	defaultDMStatCommand    = "mpirun --allow-run-as-root -np 1 --hostfile $HOSTFILE -- $SETPRIV stat --cached never -c '%F' $PATH"
+	defaultDMMkdirCommand   = "mpirun --allow-run-as-root -np 1 --hostfile $HOSTFILE -- $SETPRIV mkdir -p $PATH"
+	defaultDMSetprivCommand = "setpriv --euid $UID --egid $GID --clear-groups"
+)
+
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
 // +kubebuilder:webhook:path=/validate-nnf-cray-hpe-com-v1alpha7-nnfdatamovementprofile,mutating=false,failurePolicy=fail,sideEffects=None,groups=nnf.cray.hpe.com,resources=nnfdatamovementprofiles,verbs=create;update,versions=v1alpha7,name=vnnfdatamovementprofile.kb.io,admissionReviewVersions=v1

--- a/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementprofiles.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementprofiles.yaml
@@ -480,6 +480,9 @@ spec:
                     SRC: source for the data movement
                     DEST destination for the data movement
                 type: string
+                x-kubernetes-validations:
+                - rule: '!self.contains("dcp") || (self.contains("$HOSTFILE") && self.contains("$UID")
+                    && self.contains("$GID") && self.contains("$SRC") && self.contains("$DEST"))'
               createDestDir:
                 default: true
                 description: |-
@@ -518,6 +521,9 @@ spec:
                   Placeholder for where to inject the SETPRIV command to become the
                   UID/GID\n  \t\t  inherited from the workflow.\n  PATH: Path to stat"
                 type: string
+                x-kubernetes-validations:
+                - rule: '!self.contains("mkdir") || (self.contains("$HOSTFILE") &&
+                    self.contains("$SETPRIV") && self.contains("$PATH"))'
               pinned:
                 default: false
                 description: Pinned is true if this instance is an immutable copy
@@ -540,6 +546,8 @@ spec:
                     UID: User ID that is inherited from the Workflow
                     GID: Group ID that is inherited from the Workflow
                 type: string
+                x-kubernetes-validations:
+                - rule: '!self.contains("setpriv") || (self.contains("$UID") && self.contains("$GID"))'
               slots:
                 default: 8
                 description: |-
@@ -559,6 +567,9 @@ spec:
                   Placeholder for where to inject the SETPRIV command to become the
                   UID/GID\n  \t\t  inherited from the workflow.\n  PATH: Path to stat"
                 type: string
+                x-kubernetes-validations:
+                - rule: '!self.contains("stat") || (self.contains("$HOSTFILE") &&
+                    self.contains("$SETPRIV") && self.contains("$PATH"))'
               storeStdout:
                 default: false
                 description: |-


### PR DESCRIPTION
Make sure that the data movement commands contain the required $VAR in the command string.

Only do this when the expected command is found (e.g. dcp, mkdir) first. This allows for open configuration of the commands for testing/debugging purposes. For example, using `sleep 5` instead of an actual `dcp` command. Otherwise the validation would fail.