### PR TITLE
Allow deletion to make more progress when Computes and Rabbits are un…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.5
 
 require (
-	github.com/DataWorkflowServices/dws v0.0.1-0.20250312162549-a682dcdf49b1
+	github.com/DataWorkflowServices/dws v0.0.1-0.20250409135707-54aec73a7da6
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20250219194350-45aad5cbbe17
 	github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250312170301-6f4fd32b0173
 	github.com/ghodss/yaml v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.5
 
 require (
-	github.com/DataWorkflowServices/dws v0.0.1-0.20250409135707-54aec73a7da6
+	github.com/DataWorkflowServices/dws v0.0.1-0.20250410182135-484719f8c390
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20250219194350-45aad5cbbe17
 	github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250312170301-6f4fd32b0173
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataWorkflowServices/dws v0.0.1-0.20250312162549-a682dcdf49b1 h1:HrW1btnw3MKoT8yjyx/eyLvuESuF6MWcPG7CUnuvzIQ=
-github.com/DataWorkflowServices/dws v0.0.1-0.20250312162549-a682dcdf49b1/go.mod h1:i9v4K2d64a9uyd9ZazOJ85RWzVQjIgHWXkLo895KDAE=
+github.com/DataWorkflowServices/dws v0.0.1-0.20250409135707-54aec73a7da6 h1:LSWgjUuqCGFAM1DmgARHYpP9yQvwQv6/dd0cpxwStq0=
+github.com/DataWorkflowServices/dws v0.0.1-0.20250409135707-54aec73a7da6/go.mod h1:i9v4K2d64a9uyd9ZazOJ85RWzVQjIgHWXkLo895KDAE=
 github.com/HewlettPackard/structex v1.0.4 h1:RVTdN5FWhDWr1IkjllU8wxuLjISo4gr6u5ryZpzyHcA=
 github.com/HewlettPackard/structex v1.0.4/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20250219194350-45aad5cbbe17 h1:xYLLW3fMEKauujqkmspeWoyWhEEu+capOKUPePo4IuU=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataWorkflowServices/dws v0.0.1-0.20250409135707-54aec73a7da6 h1:LSWgjUuqCGFAM1DmgARHYpP9yQvwQv6/dd0cpxwStq0=
-github.com/DataWorkflowServices/dws v0.0.1-0.20250409135707-54aec73a7da6/go.mod h1:i9v4K2d64a9uyd9ZazOJ85RWzVQjIgHWXkLo895KDAE=
+github.com/DataWorkflowServices/dws v0.0.1-0.20250410182135-484719f8c390 h1:YTQH0gyvzmi+ZevtAsbx0/rRIuEzc8HvyPt0fe8ttoc=
+github.com/DataWorkflowServices/dws v0.0.1-0.20250410182135-484719f8c390/go.mod h1:i9v4K2d64a9uyd9ZazOJ85RWzVQjIgHWXkLo895KDAE=
 github.com/HewlettPackard/structex v1.0.4 h1:RVTdN5FWhDWr1IkjllU8wxuLjISo4gr6u5ryZpzyHcA=
 github.com/HewlettPackard/structex v1.0.4/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20250219194350-45aad5cbbe17 h1:xYLLW3fMEKauujqkmspeWoyWhEEu+capOKUPePo4IuU=

--- a/internal/controller/dws_servers_controller.go
+++ b/internal/controller/dws_servers_controller.go
@@ -395,5 +395,6 @@ func (r *DWSServersReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxReconciles}).
 		For(&dwsv1alpha3.Servers{}).
 		Watches(&nnfv1alpha7.NnfStorage{}, handler.EnqueueRequestsFromMapFunc(nnfStorageServersMapFunc)).
+		Watches(&nnfv1alpha7.NnfNodeBlockStorage{}, handler.EnqueueRequestsFromMapFunc(dwsv1alpha3.OwnerLabelMapFunc)).
 		Complete(r)
 }

--- a/internal/controller/nnf_access_controller.go
+++ b/internal/controller/nnf_access_controller.go
@@ -123,6 +123,10 @@ func (r *NnfAccessReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 
 		if !deleteStatus.Complete() {
+			err := r.removeOfflineClientMounts(ctx, access)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
 			return ctrl.Result{RequeueAfter: time.Second}, nil
 		}
 
@@ -1126,11 +1130,19 @@ func (r *NnfAccessReconciler) getClientMountStatus(ctx context.Context, access *
 		}
 
 		for _, mount := range clientMount.Status.Mounts {
-			if string(mount.State) != access.Status.State {
-				return false, nil
-			}
+			if string(mount.State) != access.Status.State || !mount.Ready {
+				if string(mount.State) == "unmounted" {
+					offline, err := r.checkOfflineCompute(ctx, access, &clientMount)
+					if err != nil {
+						return false, err
+					}
+					// If the compute node is down, then ignore an unmount failure. If the compute node
+					// comes back up, the file system won't be mounted again since spec.desiredState is "unmounted"
+					if offline {
+						continue
+					}
+				}
 
-			if !mount.Ready {
 				return false, nil
 			}
 		}
@@ -1147,6 +1159,137 @@ func (r *NnfAccessReconciler) getClientMountStatus(ctx context.Context, access *
 
 func clientMountName(access *nnfv1alpha7.NnfAccess) string {
 	return access.Namespace + "-" + access.Name
+}
+
+// removeOfflineClientMounts deletes the NnfClientMount finalizer from any ClientMounts that
+// have a Compute node marked as "Offline" in the Storage resource
+func (r *NnfAccessReconciler) removeOfflineClientMounts(ctx context.Context, nnfAccess *nnfv1alpha7.NnfAccess) error {
+	log := r.Log.WithValues("NnfAccess", client.ObjectKeyFromObject(nnfAccess))
+
+	if !nnfAccess.Spec.MakeClientMounts {
+		return nil
+	}
+
+	// Optional timeout before starting to remove the finalizers
+	deletionTimeoutString := os.Getenv("NNF_CHILD_DELETION_TIMEOUT_SECONDS")
+	if len(deletionTimeoutString) > 0 {
+		childTimeout, err := strconv.Atoi(deletionTimeoutString)
+		if err != nil {
+			log.Info("Error: Invalid NNF_CHILD_DELETION_TIMEOUT_SECONDS. Defaulting to 300 seconds", "value", deletionTimeoutString)
+			childTimeout = 300
+		}
+
+		// Don't check for offline computes until after the timeout has elapsed
+		if nnfAccess.GetDeletionTimestamp().Add(time.Duration(time.Duration(childTimeout) * time.Second)).After(time.Now()) {
+			return nil
+		}
+	}
+
+	// Find all ClientMounts owned by the NnfAccess
+	clientMountList := &dwsv1alpha3.ClientMountList{}
+	matchLabels := dwsv1alpha3.MatchingOwner(nnfAccess)
+
+	listOptions := []client.ListOption{
+		matchLabels,
+	}
+
+	if err := r.List(ctx, clientMountList, listOptions...); err != nil {
+		return dwsv1alpha3.NewResourceError("could not list ClientMounts").WithError(err)
+	}
+
+	// For each ClientMount, check whether the Compute node is marked as "Offline". If it is,
+	// remove the NnfClientMount finalizer and update the resource
+	for _, clientMount := range clientMountList.Items {
+		offline, err := r.checkOfflineCompute(ctx, nnfAccess, &clientMount)
+		if err != nil {
+			return err
+		}
+
+		if !offline {
+			continue
+		}
+
+		// Remove the finalizer from the ClientMount since the compute node is offline
+		controllerutil.RemoveFinalizer(&clientMount, finalizerNnfClientMount)
+		if err := r.Update(ctx, &clientMount); err != nil {
+			if !apierrors.IsConflict(err) {
+				return dwsv1alpha3.NewResourceError("could not update ClientMount to remove finalizer for offline compute: %v", client.ObjectKeyFromObject(&clientMount)).WithError(err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// checkOfflineCompute finds the Storage resource for the Rabbit physically attached to the clientMount's
+// compute node, and checks whether the compute node is marked as "Offline" (indicating no PCIe connection)
+func (r *NnfAccessReconciler) checkOfflineCompute(ctx context.Context, nnfAccess *nnfv1alpha7.NnfAccess, clientMount *dwsv1alpha3.ClientMount) (bool, error) {
+	if nnfAccess.Spec.ClientReference == (corev1.ObjectReference{}) {
+		return false, nil
+	}
+
+	// Find the name of the Rabbit attached to the compute node
+	rabbitName, err := r.getRabbitFromClientMount(ctx, clientMount)
+	if err != nil {
+		return false, err
+	}
+
+	// Get the Storage resource for the Rabbit
+	storage := &dwsv1alpha3.Storage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rabbitName,
+			Namespace: "default",
+		},
+	}
+
+	if err := r.Get(ctx, client.ObjectKeyFromObject(storage), storage); err != nil {
+		return false, dwsv1alpha3.NewResourceError("could not get Storage %v", client.ObjectKeyFromObject(storage)).WithError(err).WithMajor()
+	}
+
+	// Check the status of the compute node in the Storage resource to determine if it's offline
+	computeName := clientMount.GetNamespace()
+	for _, compute := range storage.Status.Access.Computes {
+		if compute.Name == computeName {
+			return compute.Status == dwsv1alpha3.OfflineStatus, nil
+		}
+	}
+
+	return false, nil
+}
+
+// getRabbitFromClientMount finds the name of the Rabbit that is physically connected to the ClientMount's
+// compute node
+func (r *NnfAccessReconciler) getRabbitFromClientMount(ctx context.Context, clientMount *dwsv1alpha3.ClientMount) (string, error) {
+	// If the ClientMount has a block device reference that points to an NnNodeStorage, use the namespace of the NnfNodeStorage
+	// as the Rabbit name
+	if clientMount.Spec.Mounts[0].Device.DeviceReference.ObjectReference.Kind == reflect.TypeOf(nnfv1alpha7.NnfNodeStorage{}).Name() {
+		return clientMount.Spec.Mounts[0].Device.DeviceReference.ObjectReference.Namespace, nil
+	}
+
+	computeName := clientMount.GetNamespace()
+
+	// To find the Rabbit associated with this compute, we have to search the SystemConfiguration resource
+	systemConfiguration := &dwsv1alpha3.SystemConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: corev1.NamespaceDefault,
+		},
+	}
+
+	if err := r.Get(ctx, client.ObjectKeyFromObject(systemConfiguration), systemConfiguration); err != nil {
+		return "", dwsv1alpha3.NewResourceError("could not get SystemConfiguration %v", client.ObjectKeyFromObject(systemConfiguration)).WithError(err).WithMajor()
+	}
+
+	// Search through the SystemConfiguration to find the Compute node name
+	for _, storageNode := range systemConfiguration.Spec.StorageNodes {
+		for _, computeAccess := range storageNode.ComputesAccess {
+			if computeAccess.Name == computeName {
+				return storageNode.Name, nil
+			}
+		}
+	}
+
+	return "", dwsv1alpha3.NewResourceError("could not find compute in SystemConfiguration: %s", computeName).WithMajor()
 }
 
 // For rabbit mounts, use unique index mount directories that consist of <namespace>-<index>.  These

--- a/internal/controller/nnf_node_block_storage_controller.go
+++ b/internal/controller/nnf_node_block_storage_controller.go
@@ -188,6 +188,11 @@ func (r *NnfNodeBlockStorageReconciler) Reconcile(ctx context.Context, req ctrl.
 			return ctrl.Result{}, nil
 		}
 
+		// If the NnfNodeStorage hasn't removed the finalizer from this NnfNodeBlockStorage, then don't start
+		// the deletion process.
+		if controllerutil.ContainsFinalizer(nodeBlockStorage, finalizerNnfNodeStorage) {
+			return ctrl.Result{}, nil
+		}
 		for i := range nodeBlockStorage.Spec.Allocations {
 			// Release physical storage
 			result, err := r.deleteStorage(nodeBlockStorage, i)

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helpers
+
+import (
+	"context"
+
+	dwsv1alpha3 "github.com/DataWorkflowServices/dws/api/v1alpha3"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// getRabbitFromCompute finds the name of the Rabbit that is physically connected to the compute node
+func GetRabbitFromCompute(ctx context.Context, c client.Client, compute string) (string, error) {
+	// To find the Rabbit associated with this compute, we have to search the SystemConfiguration resource
+	systemConfiguration := &dwsv1alpha3.SystemConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: corev1.NamespaceDefault,
+		},
+	}
+
+	if err := c.Get(ctx, client.ObjectKeyFromObject(systemConfiguration), systemConfiguration); err != nil {
+		return "", dwsv1alpha3.NewResourceError("could not get SystemConfiguration %v", client.ObjectKeyFromObject(systemConfiguration)).WithError(err).WithMajor()
+	}
+
+	// Search through the SystemConfiguration to find the Compute node name
+	for _, storageNode := range systemConfiguration.Spec.StorageNodes {
+		for _, computeAccess := range storageNode.ComputesAccess {
+			if computeAccess.Name == compute {
+				return storageNode.Name, nil
+			}
+		}
+	}
+
+	return "", dwsv1alpha3.NewResourceError("could not find compute in SystemConfiguration: %s", compute).WithMajor()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/DataWorkflowServices/dws v0.0.1-0.20250409135707-54aec73a7da6
+# github.com/DataWorkflowServices/dws v0.0.1-0.20250410182135-484719f8c390
 ## explicit; go 1.22.0
 github.com/DataWorkflowServices/dws/api/v1alpha2
 github.com/DataWorkflowServices/dws/api/v1alpha3

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/DataWorkflowServices/dws v0.0.1-0.20250312162549-a682dcdf49b1
+# github.com/DataWorkflowServices/dws v0.0.1-0.20250409135707-54aec73a7da6
 ## explicit; go 1.22.0
 github.com/DataWorkflowServices/dws/api/v1alpha2
 github.com/DataWorkflowServices/dws/api/v1alpha3


### PR DESCRIPTION
…responsive

- Ignore ClientMount resources that won't transition to "unmounted" for computes that are offline during PostRun
- Remove finalizers from ClientMounts during Teardown for computes that are offline
- Allow deletion of NnfNodeStorage and NnfNodeBlockStorages to proceed in parallel between different Rabbits