### PR TITLE
Add HostToContainer mount propagation for /run

### DIFF
--- a/config/dp0/manager_volumes_patch.yaml
+++ b/config/dp0/manager_volumes_patch.yaml
@@ -20,6 +20,7 @@ spec:
               name: dev-dir
               mountPropagation: HostToContainer
             - mountPath: /run
+              mountPropagation: HostToContainer
               name: run-dir
             - mountPath: /var/run/dbus
               name: dbus-dir


### PR DESCRIPTION
The nnf-node-manager pod needs the /run directory from the host mounted into the container for lvmlockd. If there are nnf managed mounts in /mnt/nnf, the Rabbit code gets confused when the pod is restarted. This is because the root file system for the pod ends up in /run. For example:

/run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/b154194bfffc1990354a28ba5f290b22bff89f46f3c8228187749a259be38765/rootfs

Any NNF managed mounts will show up in that root file system as well as in /mnt/nnf. When an unmount is done on the /mnt/nnf path, the mount under the /run path still exists even though on the host it is gone. This results in the file system not getting fully unmounted (since there is still a mount in the container), and the Rabbit software unable to find a file system to unmount.

This commit changes the mount propagation of the /run dir to allow changes in the host to be reflected in the pod. This results in the unmount succeeding as expected.