### PR TITLE
Fix StorageGroup deletion for Kind environment

### DIFF
--- a/internal/controller/nnf_node_block_storage_controller.go
+++ b/internal/controller/nnf_node_block_storage_controller.go
@@ -428,7 +428,7 @@ func (r *NnfNodeBlockStorageReconciler) createBlockDevice(ctx context.Context, n
 		} else {
 			// The kind environment doesn't support endpoints beyond the Rabbit
 			if os.Getenv("ENVIRONMENT") == "kind" && endpointID != os.Getenv("RABBIT_NODE") {
-				allocationStatus.Accesses[nodeName] = nnfv1alpha7.NnfNodeBlockStorageAccessStatus{StorageGroupId: "fake-storage-group"}
+				allocationStatus.Accesses[nodeName] = nnfv1alpha7.NnfNodeBlockStorageAccessStatus{StorageGroupId: storageGroupId}
 				continue
 			}
 


### PR DESCRIPTION
The StorageGroups for compute nodes in the Kind environment is faked out. In the NnfNodeBlockStorage Status section we used a fake StorageGroup name as a reminder that this is the case. With the new code that tracks when StorageGroups are fully created and fully deleted more carefully, this was causing problems. Use the real StorageGroup name so that the Kind environment is consistent with real systems.