### PR TITLE
Keep updating NnfNodeBlockStorage /dev until NnfNodeStorage is deleted

### DIFF
--- a/internal/controller/nnf_node_block_storage_controller.go
+++ b/internal/controller/nnf_node_block_storage_controller.go
@@ -183,14 +183,11 @@ func (r *NnfNodeBlockStorageReconciler) Reconcile(ctx context.Context, req ctrl.
 	defer func() { err = statusUpdater.CloseWithStatusUpdate(ctx, r.Client.Status(), err) }()
 	defer func() { nodeBlockStorage.Status.SetResourceErrorAndLog(err, log) }()
 
-	if !nodeBlockStorage.GetDeletionTimestamp().IsZero() {
+	// If the NnfNodeStorage hasn't removed the finalizer from this NnfNodeBlockStorage, then don't start
+	// the deletion process. We still might need the /dev paths updated for the NnfNodeStorage to properly
+	// teardown
+	if !nodeBlockStorage.GetDeletionTimestamp().IsZero() && !controllerutil.ContainsFinalizer(nodeBlockStorage, finalizerNnfNodeStorage) {
 		if !controllerutil.ContainsFinalizer(nodeBlockStorage, finalizerNnfNodeBlockStorage) {
-			return ctrl.Result{}, nil
-		}
-
-		// If the NnfNodeStorage hasn't removed the finalizer from this NnfNodeBlockStorage, then don't start
-		// the deletion process.
-		if controllerutil.ContainsFinalizer(nodeBlockStorage, finalizerNnfNodeStorage) {
 			return ctrl.Result{}, nil
 		}
 


### PR DESCRIPTION
The NnfNodeBlockStorage and NnfNodeStorage resources both get marked for deletion at the same time. This can cause an issue if the nnf-node-manager restarts before the NnfNodeStorage is fully deleted. The NnfNodeStorage controller relies on the NnfNodeBlockStorage keeping the status section up to date with the latest /dev paths for the NVMe namespaces.

This change forces the NnfNodeBlockStorage controller to skip the deletion path code until the NnfNodeStorage has finished deleting.