### PR TITLE
User Containers: Send `/shutdown` POST to long-running containers

### DIFF
--- a/config/examples/nnf_nnfcontainerprofiles.yaml
+++ b/config/examples/nnf_nnfcontainerprofiles.yaml
@@ -64,6 +64,28 @@ kind: NnfContainerProfile
 metadata:
   name: example-forever
 data:
+  postRunTimeoutSeconds: 5
+  retryLimit: 6
+  storages:
+    - name: DW_JOB_foo_local_storage
+      optional: false
+    - name: DW_PERSISTENT_foo_persistent_storage
+      optional: true
+  spec:
+    containers:
+      - name: example-forever
+        image: alpine:latest
+        command:
+          - /bin/sh
+          - -c
+          - 'while true; do date && sleep 5; done'
+---
+apiVersion: nnf.cray.hpe.com/v1alpha7
+kind: NnfContainerProfile
+metadata:
+  name: example-forever-nowait
+data:
+  postRunTimeoutSeconds: 0
   retryLimit: 6
   storages:
     - name: DW_JOB_foo_local_storage

--- a/internal/controller/nnf_workflow_controller_container_helpers.go
+++ b/internal/controller/nnf_workflow_controller_container_helpers.go
@@ -20,11 +20,19 @@
 package controller
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
 	"fmt"
+	"net"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
+	"syscall"
+	"time"
 
 	dwsv1alpha4 "github.com/DataWorkflowServices/dws/api/v1alpha4"
 	nnfv1alpha7 "github.com/NearNodeFlash/nnf-sos/api/v1alpha7"
@@ -86,6 +94,10 @@ const (
 	// containers that use "requiresContainerAuth" or "requiresCopyOffload".
 	userContainerTLSSecretName      = "nnf-dm-usercontainer-server-tls"
 	userContainerTLSSecretNamespace = corev1.NamespaceDefault
+
+	// The version of the copy offload service that this controller supports. This is used to send
+	// shutdown messages to user containers.
+	copyOffloadAPIVersion = "1.0"
 )
 
 // MPI container workflow. In this model, we use mpi-operator to create an MPIJob, which creates
@@ -794,6 +806,24 @@ func verifyUserContainerTLSSecretName(clnt client.Client, ctx context.Context) e
 	return nil
 }
 
+func getUserContainerCACert(clnt client.Client, ctx context.Context) ([]byte, error) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      userContainerTLSSecretName,
+			Namespace: userContainerTLSSecretNamespace,
+		},
+	}
+	if err := clnt.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
+		return nil, fmt.Errorf("failed to get secret %s: %w", secret.Name, err)
+	}
+	key := "tls.crt"
+	caCert, ok := secret.Data[key]
+	if !ok {
+		return nil, fmt.Errorf("'%s 'not found in secret %s", key, secret.Name)
+	}
+	return caCert, nil
+}
+
 func (r *NnfWorkflowReconciler) setupContainerAuth(ctx context.Context, workflow *dwsv1alpha4.Workflow, log logr.Logger) (*dwsv1alpha4.WorkflowTokenSecret, error) {
 	privKey, err := r.createContainerTokenKey(ctx, workflow, log)
 	if err != nil {
@@ -915,4 +945,132 @@ func (r *NnfWorkflowReconciler) createContainerToken(ctx context.Context, workfl
 		log.Info("created token", "secret", client.ObjectKeyFromObject(tokenSecret))
 	}
 	return workflowToken, nil
+}
+
+// sendContainerShutdown sends a shutdown request to the user container. This is done by sending a
+// POST request to the `/shutdown` endpoint of the user container. This might fail if the user
+// container does not implement the `/shutdown` endpoint, but we still want to try to send the
+// request.
+func (r *NnfWorkflowReconciler) sendContainerShutdown(ctx context.Context, workflow *dwsv1alpha4.Workflow, profile *nnfv1alpha7.NnfContainerProfile) error {
+	isMPIJob := profile.Data.NnfMPISpec != nil
+
+	hosts := []string{}
+	ports := strings.Split(workflow.Status.Env["NNF_CONTAINER_PORTS"], ",")
+
+	// Build the list of hosts to send the shutdown to based on the job type
+	if isMPIJob {
+		launcher := workflow.Status.Env["NNF_CONTAINER_LAUNCHER"]
+		for _, port := range ports {
+			hosts = append(hosts, fmt.Sprintf("%s:%s", launcher, port))
+		}
+	} else {
+		// Get the targeted NNF nodes for the container jobs
+		nnfNodes, err := r.getNnfNodesFromComputes(ctx, workflow)
+		if err != nil || len(nnfNodes) <= 0 {
+			return dwsv1alpha4.NewResourceError("error obtaining the target NNF nodes for containers").WithError(err)
+		}
+		for _, node := range nnfNodes {
+			for _, port := range ports {
+				hosts = append(hosts, fmt.Sprintf("%s:%s", node, port))
+			}
+		}
+	}
+
+	if len(hosts) > 0 {
+		token, err := r.getWorkflowToken(ctx, workflow)
+		if workflow.Status.WorkflowToken != nil && err != nil {
+			return dwsv1alpha4.NewResourceError("could not get workflow token string").WithError(err)
+		}
+
+		// Send the requiest, but do not return an error if it fails. It's possible that the
+		// container doesn't have this implemented, but we need to try to send the requests anyway.
+		// The PostRunTimeout will eventually kill the container if it doesn't shut down gracefully.
+		if err := r.sendShutdownToHosts(ctx, hosts, string(token)); err != nil {
+			// Log the error but do not return it, as we want to continue with the workflow.
+			r.Log.Error(err, "could not send shutdown to user container hosts", "hosts", hosts)
+		}
+	}
+
+	return nil
+}
+
+// sendShutdownToHosts sends a shutdown request to each host in the provided list. This expects the
+// user container to have implemented a `/shutdown` endpoint that accepts a POST request. If we get
+// a connection refused error, we treat it as a success because the user container will no longer be
+// running after the shutdown.
+func (r *NnfWorkflowReconciler) sendShutdownToHosts(ctx context.Context, hosts []string, token string) error {
+
+	failedRequests := map[string]int{}
+
+	// Retrieve the CA cert for the user container and create a cert pool for the HTTP client.
+	// This should be present whether the container is using tokens or not.
+	caCert, err := getUserContainerCACert(r.Client, ctx)
+	if err != nil {
+		return err
+	}
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return fmt.Errorf("failed to append CA cert")
+	}
+
+	// Create an HTTP client with the CA cert pool and a short timeout
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: caCertPool,
+			},
+		},
+		Timeout: 1 * time.Second,
+	}
+
+	// Send a shutdown request to each host. The request is a POST to the /shutdown endpoint. If it fails,
+	// just log the error and continue to the next host.
+	for _, host := range hosts {
+		url := "https://" + host + "/shutdown"
+		body := []byte(`{"message": "shutdown"}`)
+
+		req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		// This is required for copy offload containers
+		req.Header.Set("Accepts-version", copyOffloadAPIVersion)
+
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("X-Auth-Type", "XOAUTH2")
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			// Once the shutdown completes, the user container will no longer be running, so we can ignore
+			// ECONNREFUSED errors
+			var opErr *net.OpError
+			if errors.As(err, &opErr) {
+				if sysErr, ok := opErr.Err.(*os.SyscallError); ok && sysErr.Err == syscall.ECONNREFUSED {
+					// Treat as success, do not add to failedRequests
+					continue
+				}
+			}
+			return err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			failedRequests[host] = resp.StatusCode
+		}
+	}
+
+	// If there are any failed requests, return an error with the details of the failed hosts
+	if len(failedRequests) > 0 {
+		failedRequestsStr := ""
+		for host, status := range failedRequests {
+			failedRequestsStr += fmt.Sprintf("%s: %d, ", host, status)
+		}
+		return fmt.Errorf("failed to send shutdown to some hosts: %s", failedRequestsStr)
+	}
+
+	return nil
 }

--- a/internal/controller/nnf_workflow_controller_container_helpers.go
+++ b/internal/controller/nnf_workflow_controller_container_helpers.go
@@ -982,8 +982,8 @@ func (r *NnfWorkflowReconciler) sendContainerShutdown(ctx context.Context, workf
 			return dwsv1alpha4.NewResourceError("could not get workflow token string").WithError(err)
 		}
 
-		// Send the requiest, but do not return an error if it fails. It's possible that the
-		// container doesn't have this implemented, but we need to try to send the requests anyway.
+		// Send the request but do not return an error if it fails. It's possible that the
+		// container doesn't have this implemented, but we need to try to send the request anyway.
 		// The PostRunTimeout will eventually kill the container if it doesn't shut down gracefully.
 		if err := r.sendShutdownToHosts(ctx, hosts, string(token)); err != nil {
 			// Log the error but do not return it, as we want to continue with the workflow.

--- a/internal/controller/nnf_workflow_controller_helpers.go
+++ b/internal/controller/nnf_workflow_controller_helpers.go
@@ -1760,7 +1760,7 @@ func (r *NnfWorkflowReconciler) setMPIJobTimeout(ctx context.Context, workflow *
 func (r *NnfWorkflowReconciler) getWorkflowToken(ctx context.Context, workflow *dwsv1alpha4.Workflow) (string, error) {
 
 	if workflow.Status.WorkflowToken == nil {
-		return "", dwsv1alpha4.NewResourceError("workflow token is not set for workflow '%s'", workflow.Name).WithFatal()
+		return "", nil
 	}
 
 	secret := &corev1.Secret{

--- a/internal/controller/nnf_workflow_controller_helpers.go
+++ b/internal/controller/nnf_workflow_controller_helpers.go
@@ -1714,8 +1714,7 @@ func (r *NnfWorkflowReconciler) setJobTimeout(ctx context.Context, job batchv1.J
 	// the desired timeout to that value. k8s Job's ActiveDeadLineSeconds will then
 	// terminate the pods once the deadline is hit.
 	if timeout > 0 && job.Spec.ActiveDeadlineSeconds == nil {
-		var deadline int64
-		deadline = int64((metav1.Now().Sub(job.CreationTimestamp.Time) + timeout).Seconds())
+		deadline := int64((metav1.Now().Sub(job.CreationTimestamp.Time) + timeout).Seconds())
 
 		// Update the job with the deadline
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -1758,6 +1757,34 @@ func (r *NnfWorkflowReconciler) setMPIJobTimeout(ctx context.Context, workflow *
 	return nil
 }
 
+func (r *NnfWorkflowReconciler) getWorkflowToken(ctx context.Context, workflow *dwsv1alpha4.Workflow) (string, error) {
+
+	if workflow.Status.WorkflowToken == nil {
+		return "", dwsv1alpha4.NewResourceError("workflow token is not set for workflow '%s'", workflow.Name).WithFatal()
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      workflow.Status.WorkflowToken.SecretName,
+			Namespace: workflow.Status.WorkflowToken.SecretNamespace,
+		},
+	}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
+		return "", dwsv1alpha4.NewResourceError("could not get workflow token secret '%s'", secret.Name).WithError(err)
+	}
+
+	key := "token"
+	token, ok := secret.Data[key]
+	if !ok {
+		return "", dwsv1alpha4.NewResourceError("workflow token secret '%s 'does not contain '%s' key", secret.Name, key).WithFatal()
+	}
+	if len(token) == 0 {
+		return "", dwsv1alpha4.NewResourceError("workflow token secret '%s' is empty", secret.Name).WithFatal()
+	}
+
+	return string(token), nil
+}
+
 func (r *NnfWorkflowReconciler) waitForContainersToFinish(ctx context.Context, workflow *dwsv1alpha4.Workflow, index int) (*result, error) {
 	// Get profile to determine container job type (MPI or not)
 	profile, err := getContainerProfile(ctx, r.Client, workflow, index)
@@ -1765,6 +1792,14 @@ func (r *NnfWorkflowReconciler) waitForContainersToFinish(ctx context.Context, w
 		return nil, err
 	}
 	isMPIJob := profile.Data.NnfMPISpec != nil
+
+	// If PostRunTimeoutSeconds is set to 0, then don't wait at all and don't check the results.
+	// Just move along to teardown. If any containers are still running, they will get stopped in
+	// teardown.
+	if *profile.Data.PostRunTimeoutSeconds == 0 {
+		r.Log.Info("PostRunTimeoutSeconds is set to 0, not waiting for containers to finish")
+		return nil, nil
+	}
 
 	timeout := time.Duration(0)
 	if profile.Data.PostRunTimeoutSeconds != nil {
@@ -1788,6 +1823,11 @@ func (r *NnfWorkflowReconciler) waitForContainersToFinish(ctx context.Context, w
 		}
 
 		if !finished {
+			// Send a shutdown to the user containers if they are running to stop any long running processes.
+			if err := r.sendContainerShutdown(ctx, workflow, profile); err != nil {
+				return nil, dwsv1alpha4.NewResourceError("could not send shutdown to user containers").WithError(err).WithMajor()
+			}
+
 			if err := r.setMPIJobTimeout(ctx, workflow, mpiJob, timeout); err != nil {
 				return nil, err
 			}
@@ -1806,6 +1846,11 @@ func (r *NnfWorkflowReconciler) waitForContainersToFinish(ctx context.Context, w
 
 		// Ensure all the jobs are done running before we check the conditions.
 		for _, job := range jobList.Items {
+			// Send a shutdown to the user containers if they are running to stop any long running processes.
+			if err := r.sendContainerShutdown(ctx, workflow, profile); err != nil {
+				return nil, dwsv1alpha4.NewResourceError("could not send shutdown to user containers").WithError(err).WithMajor()
+			}
+
 			// Jobs will have conditions when finished
 			if len(job.Status.Conditions) <= 0 {
 				if err := r.setJobTimeout(ctx, job, timeout); err != nil {


### PR DESCRIPTION
Any long-running user container (e.g., copy offload) that does not shut down on its own will get stuck in PostRun until the `postRunTimeoutSeconds` timeout is hit. This results in an error since the containers did not finish in the PostRun state before the timeout.

This change adds a shutdown request to the PostRun logic for user containers. The long-running container **must** implement an HTTPS server that accepts a `POST` to the `/shutdown` endpoint. This allows the user container to shut down gracefully and return success, allowing PostRun to proceed.

If the shutdown request fails, the workflow continues. In fact, we expect it to eventually fail since the user container will shut down and no longer respond. Any errors are logged and do not affect the workflow outcome. If there are issues sending the shutdown request, they are logged and the `postRunTimeoutSeconds` timeout will eventually be hit.

If `postRunTimeoutSeconds` is set to 0, PostRun does not wait for a result; it simply ignores the container result and transitions to Teardown, where the containers are cleaned up. This can be used for long-running containers that do not implement a shutdown, allowing shutdown to be forced by transitioning to Teardown.