### PR TITLE
CRDBUMPER-unserve-api

### DIFF
--- a/api/v1alpha6/nnfaccess_types.go
+++ b/api/v1alpha6/nnfaccess_types.go
@@ -90,6 +90,7 @@ type NnfAccessStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 //+kubebuilder:printcolumn:name="DESIREDSTATE",type="string",JSONPath=".spec.desiredState",description="The desired state"
 //+kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.state",description="The current state"
 //+kubebuilder:printcolumn:name="READY",type="boolean",JSONPath=".status.ready",description="Whether the state has been achieved"

--- a/api/v1alpha6/nnfcontainerprofile_types.go
+++ b/api/v1alpha6/nnfcontainerprofile_types.go
@@ -116,6 +116,7 @@ type NnfContainerProfileStorage struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 
 // NnfContainerProfile is the Schema for the nnfcontainerprofiles API
 type NnfContainerProfile struct {
@@ -126,6 +127,7 @@ type NnfContainerProfile struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 
 // NnfContainerProfileList contains a list of NnfContainerProfile
 type NnfContainerProfileList struct {

--- a/api/v1alpha6/nnfdatamovement_types.go
+++ b/api/v1alpha6/nnfdatamovement_types.go
@@ -219,6 +219,7 @@ const (
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 //+kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.state",description="Current state"
 //+kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.status",description="Status of current state"
 //+kubebuilder:printcolumn:name="ERROR",type="string",JSONPath=".status.error.severity"

--- a/api/v1alpha6/nnfdatamovementmanager_types.go
+++ b/api/v1alpha6/nnfdatamovementmanager_types.go
@@ -75,6 +75,7 @@ type NnfDataMovementManagerStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 //+kubebuilder:printcolumn:name="READY",type="boolean",JSONPath=".status.ready",description="True if manager readied all resoures"
 //+kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 

--- a/api/v1alpha6/nnfdatamovementprofile_types.go
+++ b/api/v1alpha6/nnfdatamovementprofile_types.go
@@ -117,6 +117,7 @@ type NnfDataMovementProfileData struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 // +kubebuilder:printcolumn:name="DEFAULT",type="boolean",JSONPath=".data.default",description="True if this is the default instance"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 
@@ -129,6 +130,7 @@ type NnfDataMovementProfile struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 
 // NnfDataMovementProfileList contains a list of NnfDataMovementProfile
 type NnfDataMovementProfileList struct {

--- a/api/v1alpha6/nnflustremgt_types.go
+++ b/api/v1alpha6/nnflustremgt_types.go
@@ -96,6 +96,7 @@ type NnfLustreMGTStatusClaim struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // NnfLustreMGT is the Schema for the nnfstorageprofiles API
 type NnfLustreMGT struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1alpha6/nnfnode_types.go
+++ b/api/v1alpha6/nnfnode_types.go
@@ -98,6 +98,7 @@ type NnfDriveStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 //+kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".spec.state",description="Current desired state"
 //+kubebuilder:printcolumn:name="HEALTH",type="string",JSONPath=".status.health",description="Health of node"
 //+kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.status",description="Current status of node"

--- a/api/v1alpha6/nnfnodeblockstorage_types.go
+++ b/api/v1alpha6/nnfnodeblockstorage_types.go
@@ -97,6 +97,7 @@ type NnfNodeBlockStorageAllocationStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.ready"
 // +kubebuilder:printcolumn:name="ERROR",type="string",JSONPath=".status.error.severity"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"

--- a/api/v1alpha6/nnfnodeecdata_types.go
+++ b/api/v1alpha6/nnfnodeecdata_types.go
@@ -44,6 +44,7 @@ type NnfNodeECPrivateData map[string]string
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 
 // NnfNodeECData is the Schema for the nnfnodeecdata API
 type NnfNodeECData struct {

--- a/api/v1alpha6/nnfnodestorage_types.go
+++ b/api/v1alpha6/nnfnodestorage_types.go
@@ -121,6 +121,7 @@ type NnfNodeStorageAllocationStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.ready"
 // +kubebuilder:printcolumn:name="ERROR",type="string",JSONPath=".status.error.severity"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"

--- a/api/v1alpha6/nnfportmanager_types.go
+++ b/api/v1alpha6/nnfportmanager_types.go
@@ -113,6 +113,7 @@ type NnfPortManagerStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 
 // NnfPortManager is the Schema for the nnfportmanagers API
 type NnfPortManager struct {

--- a/api/v1alpha6/nnfstorage_types.go
+++ b/api/v1alpha6/nnfstorage_types.go
@@ -187,6 +187,7 @@ type NnfStorageStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 //+kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.ready"
 //+kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 //+kubebuilder:printcolumn:name="ERROR",type="string",JSONPath=".status.error.severity"

--- a/api/v1alpha6/nnfstorageprofile_types.go
+++ b/api/v1alpha6/nnfstorageprofile_types.go
@@ -293,6 +293,7 @@ type NnfStorageProfileData struct {
 }
 
 //+kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 //+kubebuilder:printcolumn:name="DEFAULT",type="boolean",JSONPath=".data.default",description="True if this is the default instance"
 //+kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 
@@ -305,6 +306,7 @@ type NnfStorageProfile struct {
 }
 
 //+kubebuilder:object:root=true
+// +kubebuilder:unservedversion
 
 // NnfStorageProfileList contains a list of NnfStorageProfile
 type NnfStorageProfileList struct {

--- a/api/v1alpha6/nnfsystemstorage_types.go
+++ b/api/v1alpha6/nnfsystemstorage_types.go
@@ -113,6 +113,7 @@ type NnfSystemStorageStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:unservedversion
 // NnfSystemStorage is the Schema for the nnfsystemstorages API
 type NnfSystemStorage struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crd/bases/nnf.cray.hpe.com_nnfaccesses.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfaccesses.yaml
@@ -262,7 +262,7 @@ spec:
             - state
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/nnf.cray.hpe.com_nnfcontainerprofiles.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfcontainerprofiles.yaml
@@ -14716,7 +14716,7 @@ spec:
         required:
         - data
         type: object
-    served: true
+    served: false
     storage: false
   - name: v1alpha7
     schema:

--- a/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementmanagers.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementmanagers.yaml
@@ -7316,7 +7316,7 @@ spec:
             - ready
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementprofiles.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementprofiles.yaml
@@ -157,7 +157,7 @@ spec:
           metadata:
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources: {}
   - additionalPrinterColumns:

--- a/config/crd/bases/nnf.cray.hpe.com_nnfdatamovements.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfdatamovements.yaml
@@ -413,7 +413,7 @@ spec:
                 type: string
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/nnf.cray.hpe.com_nnflustremgts.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnflustremgts.yaml
@@ -391,7 +391,7 @@ spec:
                 type: string
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/nnf.cray.hpe.com_nnfnodeblockstorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfnodeblockstorages.yaml
@@ -173,7 +173,7 @@ spec:
             - ready
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/nnf.cray.hpe.com_nnfnodeecdata.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfnodeecdata.yaml
@@ -50,7 +50,7 @@ spec:
                 type: object
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/nnf.cray.hpe.com_nnfnodes.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfnodes.yaml
@@ -170,7 +170,7 @@ spec:
                 type: string
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/nnf.cray.hpe.com_nnfnodestorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfnodestorages.yaml
@@ -289,7 +289,7 @@ spec:
                 type: boolean
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/nnf.cray.hpe.com_nnfportmanagers.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfportmanagers.yaml
@@ -244,7 +244,7 @@ spec:
             - status
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/nnf.cray.hpe.com_nnfstorageprofiles.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfstorageprofiles.yaml
@@ -713,7 +713,7 @@ spec:
           metadata:
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources: {}
   - additionalPrinterColumns:

--- a/config/crd/bases/nnf.cray.hpe.com_nnfstorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfstorages.yaml
@@ -363,7 +363,7 @@ spec:
                 type: boolean
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/nnf.cray.hpe.com_nnfsystemstorages.yaml
+++ b/config/crd/bases/nnf.cray.hpe.com_nnfsystemstorages.yaml
@@ -261,7 +261,7 @@ spec:
             - ready
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/internal/controller/conversion_test.go
+++ b/internal/controller/conversion_test.go
@@ -78,7 +78,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads NnfAccess resource via hub and via spoke v1alpha6", func() {
+		It("is unable to read NnfAccess resource via spoke v1alpha6", func() {
+			resSpoke := &nnfv1alpha6.NnfAccess{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfAccess resource via hub and via spoke v1alpha6", func() {
+			// ACTION: v1alpha6 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha6.NnfAccess{}
 			Eventually(func(g Gomega) {
@@ -149,7 +156,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads NnfContainerProfile resource via hub and via spoke v1alpha6", func() {
+		It("is unable to read NnfContainerProfile resource via spoke v1alpha6", func() {
+			resSpoke := &nnfv1alpha6.NnfContainerProfile{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfContainerProfile resource via hub and via spoke v1alpha6", func() {
+			// ACTION: v1alpha6 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha6.NnfContainerProfile{}
 			Eventually(func(g Gomega) {
@@ -214,7 +228,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads NnfDataMovement resource via hub and via spoke v1alpha6", func() {
+		It("is unable to read NnfDataMovement resource via spoke v1alpha6", func() {
+			resSpoke := &nnfv1alpha6.NnfDataMovement{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfDataMovement resource via hub and via spoke v1alpha6", func() {
+			// ACTION: v1alpha6 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha6.NnfDataMovement{}
 			Eventually(func(g Gomega) {
@@ -286,7 +307,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads NnfDataMovementManager resource via hub and via spoke v1alpha6", func() {
+		It("is unable to read NnfDataMovementManager resource via spoke v1alpha6", func() {
+			resSpoke := &nnfv1alpha6.NnfDataMovementManager{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfDataMovementManager resource via hub and via spoke v1alpha6", func() {
+			// ACTION: v1alpha6 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha6.NnfDataMovementManager{}
 			Eventually(func(g Gomega) {
@@ -351,7 +379,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads NnfDataMovementProfile resource via hub and via spoke v1alpha6", func() {
+		It("is unable to read NnfDataMovementProfile resource via spoke v1alpha6", func() {
+			resSpoke := &nnfv1alpha6.NnfDataMovementProfile{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfDataMovementProfile resource via hub and via spoke v1alpha6", func() {
+			// ACTION: v1alpha6 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha6.NnfDataMovementProfile{}
 			Eventually(func(g Gomega) {
@@ -418,7 +453,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads NnfLustreMGT resource via hub and via spoke v1alpha6", func() {
+		It("is unable to read NnfLustreMGT resource via spoke v1alpha6", func() {
+			resSpoke := &nnfv1alpha6.NnfLustreMGT{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfLustreMGT resource via hub and via spoke v1alpha6", func() {
+			// ACTION: v1alpha6 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha6.NnfLustreMGT{}
 			Eventually(func(g Gomega) {
@@ -485,7 +527,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads NnfNode resource via hub and via spoke v1alpha6", func() {
+		It("is unable to read NnfNode resource via spoke v1alpha6", func() {
+			resSpoke := &nnfv1alpha6.NnfNode{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfNode resource via hub and via spoke v1alpha6", func() {
+			// ACTION: v1alpha6 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha6.NnfNode{}
 			Eventually(func(g Gomega) {
@@ -550,7 +599,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads NnfNodeBlockStorage resource via hub and via spoke v1alpha6", func() {
+		It("is unable to read NnfNodeBlockStorage resource via spoke v1alpha6", func() {
+			resSpoke := &nnfv1alpha6.NnfNodeBlockStorage{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfNodeBlockStorage resource via hub and via spoke v1alpha6", func() {
+			// ACTION: v1alpha6 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha6.NnfNodeBlockStorage{}
 			Eventually(func(g Gomega) {
@@ -615,7 +671,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads NnfNodeECData resource via hub and via spoke v1alpha6", func() {
+		It("is unable to read NnfNodeECData resource via spoke v1alpha6", func() {
+			resSpoke := &nnfv1alpha6.NnfNodeECData{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfNodeECData resource via hub and via spoke v1alpha6", func() {
+			// ACTION: v1alpha6 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha6.NnfNodeECData{}
 			Eventually(func(g Gomega) {
@@ -680,7 +743,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads NnfNodeStorage resource via hub and via spoke v1alpha6", func() {
+		It("is unable to read NnfNodeStorage resource via spoke v1alpha6", func() {
+			resSpoke := &nnfv1alpha6.NnfNodeStorage{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfNodeStorage resource via hub and via spoke v1alpha6", func() {
+			// ACTION: v1alpha6 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha6.NnfNodeStorage{}
 			Eventually(func(g Gomega) {
@@ -747,7 +817,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads NnfPortManager resource via hub and via spoke v1alpha6", func() {
+		It("is unable to read NnfPortManager resource via spoke v1alpha6", func() {
+			resSpoke := &nnfv1alpha6.NnfPortManager{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfPortManager resource via hub and via spoke v1alpha6", func() {
+			// ACTION: v1alpha6 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha6.NnfPortManager{}
 			Eventually(func(g Gomega) {
@@ -814,7 +891,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads NnfStorage resource via hub and via spoke v1alpha6", func() {
+		It("is unable to read NnfStorage resource via spoke v1alpha6", func() {
+			resSpoke := &nnfv1alpha6.NnfStorage{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfStorage resource via hub and via spoke v1alpha6", func() {
+			// ACTION: v1alpha6 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha6.NnfStorage{}
 			Eventually(func(g Gomega) {
@@ -879,7 +963,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads NnfStorageProfile resource via hub and via spoke v1alpha6", func() {
+		It("is unable to read NnfStorageProfile resource via spoke v1alpha6", func() {
+			resSpoke := &nnfv1alpha6.NnfStorageProfile{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfStorageProfile resource via hub and via spoke v1alpha6", func() {
+			// ACTION: v1alpha6 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha6.NnfStorageProfile{}
 			Eventually(func(g Gomega) {
@@ -944,7 +1035,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads NnfSystemStorage resource via hub and via spoke v1alpha6", func() {
+		It("is unable to read NnfSystemStorage resource via spoke v1alpha6", func() {
+			resSpoke := &nnfv1alpha6.NnfSystemStorage{}
+			Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).ToNot(Succeed())
+		})
+
+		PIt("reads NnfSystemStorage resource via hub and via spoke v1alpha6", func() {
+			// ACTION: v1alpha6 is no longer served, and this test can be removed.
+
 			// Spoke should have annotation.
 			resSpoke := &nnfv1alpha6.NnfSystemStorage{}
 			Eventually(func(g Gomega) {


### PR DESCRIPTION
Mark the v1alpha6 API as unserved.

ACTION: Address the ACTION comments in internal/controller/conversion_test.go.

ACTION: Begin by running "make vet". Repair any issues that it finds.
  Then run "make test" and continue repairing issues until the tests
  pass.