### PR TITLE
Add a Role with core group privs for the WLM

### DIFF
--- a/config/rbac-ns/kustomization.yaml
+++ b/config/rbac-ns/kustomization.yaml
@@ -1,0 +1,10 @@
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: nnf-
+
+resources:
+- workload_manager_nnf_role_ns.yaml
+

--- a/config/rbac-ns/workload_manager_nnf_role_ns.yaml
+++ b/config/rbac-ns/workload_manager_nnf_role_ns.yaml
@@ -1,0 +1,10 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: default
+  name: workload-manager-coregrp
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "watch", "list"]
+

--- a/config/top/kustomization.yaml
+++ b/config/top/kustomization.yaml
@@ -1,3 +1,5 @@
 resources:
 - ../default
 - ../dws
+- ../rbac-ns
+

--- a/hack/flux-bindings.sh
+++ b/hack/flux-bindings.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+set -x
+
+kubectl apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flux
+subjects:
+- kind: User
+  name: flux
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: nnf-workload-manager
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: flux
+  namespace: default
+subjects:
+- kind: User
+  name: flux
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: nnf-workload-manager-coregrp
+  apiGroup: ""
+EOF
+

--- a/hack/kind-make-flux-user.sh
+++ b/hack/kind-make-flux-user.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+fluxdir=$(mktemp -d /tmp/flux-role.XXXX)
+cd "$fluxdir"
+
+CURRENT_CONTEXT=$(yq -rM .current-context ~/.kube/config)
+# shellcheck disable=SC2049
+if [[ $CURRENT_CONTEXT =~ *kind* ]]
+then
+    echo "This tool expects a basic KIND environment."
+    exit 1
+fi
+
+SERVER_ADDRESS=$(yq -rM '.clusters[]|select(.name=="'"$CURRENT_CONTEXT"'")|.cluster.server'  ~/.kube/config)
+
+docker exec kind-control-plane cat /etc/kubernetes/pki/ca.crt > ca.crt
+docker exec kind-control-plane cat /etc/kubernetes/pki/ca.key > ca.key
+
+export USERNAME=flux
+export CLUSTER_NAME=$CURRENT_CONTEXT
+
+# generate a new key
+openssl genrsa -out rabbit.key 2048
+
+# create a certificate signing request for this user
+openssl req -new -key rabbit.key -out rabbit.csr -subj "/CN=$USERNAME"
+
+# generate a certificate using the certificate authority on the k8s cluster. This certificate lasts 500 days
+openssl x509 -req -in rabbit.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out rabbit.crt -days 500
+
+# create a new kubeconfig with the server information
+kubectl config set-cluster "$CLUSTER_NAME" --kubeconfig=rabbit.conf --server="$SERVER_ADDRESS" --certificate-authority=ca.crt --embed-certs=true
+
+# add the key and cert for this user to the config
+kubectl config set-credentials "$USERNAME" --kubeconfig=rabbit.conf --client-certificate=rabbit.crt --client-key=rabbit.key --embed-certs=true
+
+# add a context
+kubectl config set-context "$USERNAME" --kubeconfig=rabbit.conf --cluster="$CLUSTER_NAME" --user="$USERNAME"
+
+# activate the context
+kubectl config use-context "$USERNAME" --kubeconfig=rabbit.conf
+
+echo "The flux kubeconfig is $fluxdir/rabbit.conf"
+


### PR DESCRIPTION
Add a new Role "nnf-workload-manager-coregrp" that allows the WLM read-only access to pods and their logs in "default" namespace.

Add some tools that make manual testing easier. The tools assume a KIND environment.