### PR TITLE
Allow a longer grace time for renewing the leader-election lease.

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -24,4 +24,14 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
+        - "--leader-elect-lease-duration=$(LEASEDURATION)"
+        - "--leader-elect-renew-deadline=$(RENEWDEADLINE)"
+        - "--leader-elect-retry-period=$(RETRYPERIOD)"
         - "--controller=storage"
+        env:
+        - name: LEASEDURATION
+          value: '120'
+        - name: RENEWDEADLINE
+          value: '60'
+        - name: RETRYPERIOD
+          value: '20'


### PR DESCRIPTION
Add some commandline args to the controller to control the LeaseDuration, RenewDeadline, and RetryPeriod. Adjust the patch that builds the manifest to insert these.