### PR TITLE
Propagate allocation health

### DIFF
--- a/internal/controller/nnf_persistentstorageinstance_controller.go
+++ b/internal/controller/nnf_persistentstorageinstance_controller.go
@@ -212,6 +212,9 @@ func (r *PersistentStorageReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 		if complete == true {
 			persistentStorage.Status.State = dwsv1alpha6.PSIStateActive
+			if nnfStorage.Status.Health != nnfv1alpha8.NnfStorageHealthHealthy {
+				persistentStorage.Status.State = dwsv1alpha6.PSIStateDegraded
+			}
 		}
 	}
 

--- a/internal/controller/nnf_storage_controller.go
+++ b/internal/controller/nnf_storage_controller.go
@@ -210,6 +210,19 @@ func (r *NnfStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}
 
+	overallHealth := nnfv1alpha8.NnfStorageHealthHealthy
+	for i := range storage.Spec.AllocationSets {
+		health, err := r.aggregateNodeStorageHealth(ctx, storage, i)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		if health != nnfv1alpha8.NnfStorageHealthHealthy {
+			overallHealth = health
+		}
+	}
+	storage.Status.Health = overallHealth
+
 	// Collect status information from the NnfNodeBlockStorage resources and aggregate it into the
 	// NnfStorage
 	for i := range storage.Spec.AllocationSets {
@@ -836,6 +849,45 @@ func (r *NnfStorageReconciler) aggregateNodeStorageStatus(ctx context.Context, s
 	}
 
 	return nil, nil
+}
+
+func (r *NnfStorageReconciler) aggregateNodeStorageHealth(ctx context.Context, storage *nnfv1alpha8.NnfStorage, allocationSetIndex int) (nnfv1alpha8.NnfStorageHealth, error) {
+	nnfNodeStorageList := &nnfv1alpha8.NnfNodeStorageList{}
+	matchLabels := dwsv1alpha6.MatchingOwner(storage)
+	matchLabels[nnfv1alpha8.AllocationSetLabel] = storage.Spec.AllocationSets[allocationSetIndex].Name
+
+	listOptions := []client.ListOption{
+		matchLabels,
+	}
+
+	if err := r.List(ctx, nnfNodeStorageList, listOptions...); err != nil {
+		return nnfv1alpha8.NnfStorageHealthHealthy, dwsv1alpha6.NewResourceError("could not list NnfNodeStorages").WithError(err)
+	}
+
+	// make a map with empty data of the Rabbit names to allow easy searching
+	nodeNameMap := map[string]struct{}{}
+	for _, node := range storage.Spec.AllocationSets[allocationSetIndex].Nodes {
+		nodeNameMap[node.Name] = struct{}{}
+	}
+
+	// prune out any entries that aren't in the NnfStorage. This can happen if the NnfStorage was modified
+	// after it was created, as is the case with NnfStorages from an NnfSystemStorage
+	nnfNodeStorages := []nnfv1alpha8.NnfNodeStorage{}
+	for _, nnfNodeStorage := range nnfNodeStorageList.Items {
+		if _, exists := nodeNameMap[nnfNodeStorage.GetNamespace()]; exists {
+			nnfNodeStorages = append(nnfNodeStorages, nnfNodeStorage)
+		}
+	}
+
+	storage.Status.AllocationSets[allocationSetIndex].Health = nnfv1alpha8.NnfStorageHealthHealthy
+	for _, nnfNodeStorage := range nnfNodeStorages {
+		if nnfNodeStorage.Status.Health != nnfv1alpha8.NnfStorageHealthHealthy {
+			storage.Status.AllocationSets[allocationSetIndex].Health = nnfNodeStorage.Status.Health
+			return nnfNodeStorage.Status.Health, nil
+		}
+	}
+
+	return nnfv1alpha8.NnfStorageHealthHealthy, nil
 }
 
 func (r *NnfStorageReconciler) getLustreMgt(ctx context.Context, nnfStorage *nnfv1alpha8.NnfStorage) (*nnfv1alpha8.NnfLustreMGT, error) {


### PR DESCRIPTION
This commit uses the block device health check in the NnfNodeStorage controller to populate the Health field in the NnfNodeStorage and NnfStorage resources. This information is also included in the PersistentStorageInstance resource to specify the "Active" or "Degraded" state