### PR TITLE
Default to createContainer=True in conversion routines

### DIFF
--- a/api/v1alpha10/conversion.go
+++ b/api/v1alpha10/conversion.go
@@ -73,12 +73,16 @@ func (src *NnfContainerProfile) ConvertTo(dstRaw conversion.Hub) error {
 	}
 
 	// Manually restore data.
+	// Default CreateContainer to true to match the implicit behavior of v1alpha10, which
+	// always created containers. The annotation restores the explicit value on round-trips.
+	dst.Data.CreateContainer = true
 	restored := &nnfv1alpha11.NnfContainerProfile{}
-	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil || !ok {
+	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil {
 		return err
+	} else if ok {
+		// Restore hub-only fields from the annotation.
+		dst.Data.CreateContainer = restored.Data.CreateContainer
 	}
-	// Restore hub-only fields from the annotation.
-	dst.Data.CreateContainer = restored.Data.CreateContainer
 
 	return nil
 }

--- a/api/v1alpha9/conversion.go
+++ b/api/v1alpha9/conversion.go
@@ -75,12 +75,16 @@ func (src *NnfContainerProfile) ConvertTo(dstRaw conversion.Hub) error {
 	}
 
 	// Manually restore data.
+	// Default CreateContainer to true to match the implicit behavior of v1alpha9, which
+	// always created containers. The annotation restores the explicit value on round-trips.
+	dst.Data.CreateContainer = true
 	restored := &nnfv1alpha11.NnfContainerProfile{}
-	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil || !ok {
+	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil {
 		return err
+	} else if ok {
+		// Restore hub-only fields from the annotation.
+		dst.Data.CreateContainer = restored.Data.CreateContainer
 	}
-	// Restore hub-only fields from the annotation.
-	dst.Data.CreateContainer = restored.Data.CreateContainer
 
 	return nil
 }


### PR DESCRIPTION
If a NnfContainerProfile is created with v1alpha9 or v1alpha10, default createContainer to True in the conversion routines when converting to v1alpha11. v1alpha11 is the first version to have the createContainer field. Before v1alpha11, all NnfContainerProfiles resulted in a container being created.