### PR TITLE
pkg/filesystem/kind: make Mount symlink creation idempotent

### DIFF
--- a/pkg/filesystem/kind.go
+++ b/pkg/filesystem/kind.go
@@ -85,7 +85,18 @@ func (m *KindFileSystem) Mount(ctx context.Context, path string, complete bool) 
 	}
 
 	if err := os.Symlink(m.Path, path); err != nil {
-		return false, fmt.Errorf("could not create symlink mount %s: %w", path, err)
+		if !os.IsExist(err) {
+			return false, fmt.Errorf("could not create symlink mount %s: %w", path, err)
+		}
+		// Symlink already exists — verify it points to the correct target
+		existing, readErr := os.Readlink(path)
+		if readErr != nil {
+			return false, fmt.Errorf("could not read existing symlink %s: %w", path, readErr)
+		}
+		if existing != m.Path {
+			return false, fmt.Errorf("symlink %s exists but points to %s, expected %s", path, existing, m.Path)
+		}
+		// Symlink exists and points to the correct target — treat as success
 	}
 
 	m.Log.Info("Mounted mock file system in kind", "filesystem", m.Path, "mount", path)


### PR DESCRIPTION
On kind clusters, all worker nodes share the same host directory for /mnt/nnf. When multiple rabbit nodes reconcile a ClientMount for the same workflow, the second node's os.Symlink call fails with EEXIST because the first node already created the symlink, causing the workflow to get stuck in PreRun indefinitely.

Fix by treating EEXIST as success when the existing symlink already points to the correct target. If it points to a different target, return an error as that indicates a genuine conflict.

This has no effect in production where each Rabbit node has its own physical /mnt/nnf and symlink collisions cannot occur.

Signed-off-by: Anthony Floeder <anthony.floeder@hpe.com>