### PR TITLE
Enforce user ID ownership on persistentdw directives

### DIFF
--- a/internal/controller/nnf_workflow_controller_helpers.go
+++ b/internal/controller/nnf_workflow_controller_helpers.go
@@ -403,6 +403,10 @@ func (r *NnfWorkflowReconciler) validatePersistentInstanceDirective(ctx context.
 		return dwsv1alpha7.NewResourceError("").WithUserMessage("Persistent storage instance '%s' is deleting", args["name"]).WithUser().WithFatal()
 	}
 
+	if psi.Spec.UserID != wf.Spec.UserID {
+		return dwsv1alpha7.NewResourceError("existing persistent storage user ID %v does not match user ID %v", psi.Spec.UserID, wf.Spec.UserID).WithUserMessage("User ID does not match existing persistent storage").WithFatal().WithUser()
+	}
+
 	return nil
 }
 

--- a/internal/controller/nnf_workflow_controller_test.go
+++ b/internal/controller/nnf_workflow_controller_test.go
@@ -197,6 +197,7 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 				// DWDirective: workflow.Spec.DWDirectives[0],
 				DWDirective: "#DW create_persistent capacity=1GB name=" + name,
 				State:       dwsv1alpha7.PSIStateActive,
+				UserID:      baseWorkflowUserID,
 			},
 		}
 		Expect(k8sClient.Create(context.TODO(), psi)).To(Succeed())
@@ -1800,6 +1801,68 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 				Entry("when xfs persistentdw storage is used", "xfs", true),
 				Entry("when raw persistentdw storage is used", "raw", false),
 			)
+		})
+	})
+
+	When("enforcing persistentdw user ID ownership", func() {
+		AfterEach(func() {
+			deletePersistentStorageInstance(persistentStorageName)
+		})
+
+		It("succeeds at Proposal when user IDs match", func() {
+			createPersistentStorageInstance(persistentStorageName, "lustre")
+			workflow.Spec.DWDirectives = []string{
+				fmt.Sprintf("#DW persistentdw name=%s", persistentStorageName),
+			}
+			Expect(k8sClient.Create(context.TODO(), workflow)).To(Succeed(), "create workflow")
+			Eventually(func(g Gomega) bool {
+				g.Expect(k8sClient.Get(context.TODO(), key, workflow)).To(Succeed())
+				return workflow.Status.Ready && workflow.Status.State == dwsv1alpha7.StateProposal && getErroredDriverStatus(workflow) == nil
+			}).Should(BeTrue(), "reach Proposal state with no error")
+		})
+
+		It("errors at Proposal when accessing storage owned by a different user", func() {
+			By("Fabricate a persistent storage instance owned by a different user")
+			psi := &dwsv1alpha7.PersistentStorageInstance{
+				ObjectMeta: metav1.ObjectMeta{Name: persistentStorageName, Namespace: workflow.Namespace},
+				Spec: dwsv1alpha7.PersistentStorageInstanceSpec{
+					Name:        persistentStorageName,
+					FsType:      "lustre",
+					DWDirective: "#DW create_persistent capacity=1GB name=" + persistentStorageName,
+					State:       dwsv1alpha7.PSIStateActive,
+					UserID:      altWorkflowUserID,
+				},
+			}
+			Expect(k8sClient.Create(context.TODO(), psi)).To(Succeed())
+
+			nnfStorage := &nnfv1alpha11.NnfStorage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      persistentStorageName,
+					Namespace: workflow.Namespace,
+				},
+				Spec: nnfv1alpha11.NnfStorageSpec{
+					FileSystemType: "lustre",
+					AllocationSets: []nnfv1alpha11.NnfStorageAllocationSetSpec{},
+				},
+			}
+			nnfStorageProfile := &nnfv1alpha11.NnfStorageProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      persistentStorageName,
+					Namespace: workflow.Namespace,
+				},
+			}
+			addPinnedStorageProfileLabel(nnfStorage, nnfStorageProfile)
+			Expect(k8sClient.Create(context.TODO(), nnfStorage)).To(Succeed())
+
+			workflow.Spec.DWDirectives = []string{
+				fmt.Sprintf("#DW persistentdw name=%s", persistentStorageName),
+			}
+			Expect(k8sClient.Create(context.TODO(), workflow)).To(Succeed(), "create workflow")
+			Eventually(func() *dwsv1alpha7.WorkflowDriverStatus {
+				expected := &dwsv1alpha7.Workflow{}
+				k8sClient.Get(context.TODO(), key, expected)
+				return getErroredDriverStatus(expected)
+			}).ShouldNot(BeNil(), "have an error present")
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Block a workflow from accessing a persistent storage instance owned by a different user via the `persistentdw` directive.

The `create_persistent` and `destroy_persistent` directives already enforced user ID ownership, but `validatePersistentInstanceDirective` had no such check — any user could mount storage they did not create.

## Changes

- **`internal/controller/nnf_workflow_controller_helpers.go`**: Added a user ID check in `validatePersistentInstanceDirective`. A `persistentdw` directive now fails at Proposal with a fatal, user-facing error if the requesting workflow's `UserID` does not match the `PersistentStorageInstance`'s `UserID`.

- **`internal/controller/nnf_workflow_controller_test.go`**: Updated the `createPersistentStorageInstance` test helper to set `UserID: baseWorkflowUserID` on fabricated PSI resources (so existing tests continue to pass), and added two new tests:
  - succeeds at Proposal when user IDs match
  - errors at Proposal when accessing storage owned by a different user

Fixes NearNodeFlash/NearNodeFlash.github.io#87