### PR TITLE
Add Rabbit Node commands

### DIFF
--- a/tools/nnf/README.md
+++ b/tools/nnf/README.md
@@ -2,7 +2,7 @@
 
 This directory contains a small Python helper CLI for working with NNF and DWS resources from the `nnf-sos` repository.
 
-Today the tool focuses on helper workflows around persistent storage. It is expected to grow over time with additional subcommands, so this document is the local reference point for setup, usage, and examples.
+Today the tool focuses on helper workflows around persistent storage and Rabbit node management. It is expected to grow over time with additional subcommands, so this document is the local reference point for setup, usage, and examples.
 
 ## Scope
 
@@ -11,6 +11,9 @@ The `nnf` command is intended as a repository-local helper tool, not a standalon
 - create a persistent storage instance for testing
 - destroy a persistent storage instance
 - inspect and drive workflow-based storage operations from a simple CLI
+- drain or undrain Rabbit nodes to control workflow scheduling
+- disable or enable Rabbit nodes to control workload manager allocations
+- check disk space usage on Rabbit nodes
 
 The command operates against an existing Kubernetes environment where the relevant NNF and DWS CRDs are already installed.
 
@@ -57,15 +60,16 @@ nnf --help
 Show command-specific help:
 
 ```bash
-nnf create_persistent --help
-nnf destroy_persistent --help
+nnf persistent create --help
+nnf persistent destroy --help
+nnf rabbit --help
 ```
 
 Enable verbose workflow logging:
 
 ```bash
-nnf --verbose create_persistent --help
-nnf create_persistent --verbose --help
+nnf --verbose persistent create --help
+nnf persistent create --verbose --help
 ```
 
 Both subcommands support these common flags:
@@ -78,19 +82,19 @@ Both subcommands support these common flags:
 The default timeout is `180` seconds per workflow state. On a slow or heavily loaded cluster, you may need to raise it:
 
 ```bash
-nnf create_persistent --timeout 600 ...
-nnf destroy_persistent --timeout 600 ...
+nnf persistent create --timeout 600 ...
+nnf persistent destroy --timeout 600 ...
 ```
 
-## create_persistent
+## persistent create
 
-Show help for the `create_persistent` subcommand:
+Show help for the `persistent create` subcommand:
 
 ```bash
-nnf create_persistent --help
+nnf persistent create --help
 ```
 
-Key `create_persistent` flags:
+Key `persistent create` flags:
 
 - `--name` required name of the persistent storage instance
 - `--fs-type` required filesystem type: `raw`, `xfs`, `gfs2`, `lustre`
@@ -111,7 +115,7 @@ Use `--profile` to select the `NnfStorageProfile` if the default profile is not 
 Create a simple persistent storage instance:
 
 ```bash
-nnf create_persistent \
+nnf persistent create \
   --name demo-psi \
   --fs-type xfs \
   --capacity 1GiB \
@@ -121,7 +125,7 @@ nnf create_persistent \
 Create persistent storage using multiple Rabbits:
 
 ```bash
-nnf create_persistent \
+nnf persistent create \
   --name demo-lustre \
   --fs-type lustre \
   --capacity 10GiB \
@@ -132,7 +136,7 @@ nnf create_persistent \
 For Lustre, you can optionally direct MDT and MGT allocation sets to specific Rabbits instead of using the default Rabbit list for every allocation set:
 
 ```bash
-nnf create_persistent \
+nnf persistent create \
   --name demo-lustre-tiered \
   --fs-type lustre \
   --capacity 10GiB \
@@ -153,7 +157,7 @@ If you do not specify `--rabbits-mdt` or `--rabbits-mgt`, the CLI falls back to 
 If you prefer to let the CLI choose Rabbits from the default SystemConfiguration, use `--rabbit-count` instead of `--rabbits`:
 
 ```bash
-nnf create_persistent \
+nnf persistent create \
   --name demo-random \
   --fs-type xfs \
   --capacity 5GiB \
@@ -166,7 +170,7 @@ When `--rabbit-count` is used, the CLI randomly selects that many Rabbit nodes f
 Create a standalone MGT using a profile that defines `standaloneMgtPoolName`:
 
 ```bash
-nnf create_persistent \
+nnf persistent create \
   --name demo-lustre-standalone-mgt \
   --fs-type lustre \
   --profile lustre-standalone-mgt-profile \
@@ -181,15 +185,15 @@ For a standalone-MGT profile:
 
 The CLI detects `standaloneMgtPoolName` from the selected profile and adjusts validation and the generated directive accordingly.
 
-## destroy_persistent
+## persistent destroy
 
-Show help for the `destroy_persistent` subcommand:
+Show help for the `persistent destroy` subcommand:
 
 ```bash
-nnf destroy_persistent --help
+nnf persistent destroy --help
 ```
 
-Key `destroy_persistent` flags:
+Key `persistent destroy` flags:
 
 - `--name` required name of the persistent storage instance to destroy
 - `--namespace` target namespace, default `default`
@@ -200,7 +204,101 @@ Key `destroy_persistent` flags:
 Destroy a persistent storage instance:
 
 ```bash
-nnf destroy_persistent --name demo-psi
+nnf persistent destroy --name demo-psi
+```
+
+## rabbit drain
+
+Drain one or more Rabbit nodes so that no new workflows are scheduled to them. This taints the Kubernetes node with `cray.nnf.node.drain=true` (both `NoSchedule` and `NoExecute`) and annotates the corresponding DWS Storage resource with `drain_date` and `drain_reason`.
+
+```bash
+nnf rabbit drain --help
+```
+
+Key flags:
+
+- `NODE` one or more Rabbit node names (positional)
+- `-r`, `--reason` reason for draining the node (default: `none`)
+
+Drain a single node:
+
+```bash
+nnf rabbit drain rabbit-node-0
+```
+
+Drain multiple nodes with a reason:
+
+```bash
+nnf rabbit drain rabbit-node-0 rabbit-node-1 --reason "firmware update"
+```
+
+If the storage annotation fails after the node taint succeeds, the CLI attempts to roll back the taint. If the rollback also fails, the CLI logs the error and continues to the next node.
+
+## rabbit undrain
+
+Undrain one or more Rabbit nodes so that new workflows can be scheduled to them again. This removes the `cray.nnf.node.drain` taint from the Kubernetes node and removes the `drain_date` and `drain_reason` annotations from the DWS Storage resource.
+
+```bash
+nnf rabbit undrain --help
+```
+
+Undrain a node:
+
+```bash
+nnf rabbit undrain rabbit-node-0
+```
+
+## rabbit disable
+
+Disable one or more Rabbit nodes so that the workload manager does not use them for allocations. This sets the DWS Storage resource `spec.state` to `Disabled` and annotates it with `disable_date` and `disable_reason`.
+
+```bash
+nnf rabbit disable --help
+```
+
+Key flags:
+
+- `NODE` one or more Rabbit node names (positional)
+- `-r`, `--reason` reason for disabling the node (default: `none`)
+
+Disable a node:
+
+```bash
+nnf rabbit disable rabbit-node-0 --reason "bad disk"
+```
+
+## rabbit enable
+
+Enable one or more Rabbit nodes so that the workload manager can use them for allocations again. This sets the DWS Storage resource `spec.state` to `Enabled` and removes the `disable_date` and `disable_reason` annotations.
+
+```bash
+nnf rabbit enable --help
+```
+
+Enable a node:
+
+```bash
+nnf rabbit enable rabbit-node-0
+```
+
+## rabbit df
+
+Show disk space information for Rabbit nodes. Queries each Rabbit's node-manager pod for NVMe capacity information via the Redfish CapacitySource endpoint.
+
+```bash
+nnf rabbit df --help
+```
+
+Show disk space for all enabled and ready Rabbits:
+
+```bash
+nnf rabbit df
+```
+
+Show disk space for specific nodes:
+
+```bash
+nnf rabbit df rabbit-node-0 rabbit-node-1
 ```
 
 ## Development notes

--- a/tools/nnf/README.md
+++ b/tools/nnf/README.md
@@ -232,7 +232,7 @@ Drain multiple nodes with a reason:
 nnf rabbit drain rabbit-node-0 rabbit-node-1 --reason "firmware update"
 ```
 
-If the storage annotation fails after the node taint succeeds, the CLI attempts to roll back the taint. If the rollback also fails, the CLI logs the error and continues to the next node.
+If the node taint fails after the storage annotation succeeds, the CLI attempts to roll back the annotation. If the rollback also fails, the CLI logs the error and continues to the next node.
 
 ## rabbit undrain
 

--- a/tools/nnf/src/nnf/commands/persistent/__init__.py
+++ b/tools/nnf/src/nnf/commands/persistent/__init__.py
@@ -1,0 +1,20 @@
+"""persistent sub-command group: manage DWS PersistentStorageInstances."""
+
+import argparse
+
+from nnf.commands import add_command_parser
+from nnf.commands.persistent import create, destroy
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the persistent sub-command group."""
+    persistent_parser: argparse.ArgumentParser = add_command_parser(
+        subparsers,
+        "persistent",
+        help="Manage persistent storage instances.",
+    )
+    sub = persistent_parser.add_subparsers(dest="persistent_command", metavar="<action>")
+    sub.required = True
+
+    create.register(sub)
+    destroy.register(sub)

--- a/tools/nnf/src/nnf/commands/persistent/create.py
+++ b/tools/nnf/src/nnf/commands/persistent/create.py
@@ -1,4 +1,4 @@
-"""create_persistent sub-command: create a DWS PersistentStorageInstance.
+"""persistent create sub-command: create a DWS PersistentStorageInstance.
 
 Builds a #DW create_persistent directive, submits it as a Workflow, and drives
 that Workflow through every state.  The Workflow is always deleted on exit,
@@ -10,6 +10,7 @@ import functools
 import logging
 import os
 import random
+import sys
 from typing import List, Optional
 
 import kubernetes.client.exceptions  # type: ignore[import-untyped]
@@ -25,10 +26,10 @@ LOGGER = logging.getLogger(__name__)
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
-    """Register the create_persistent sub-command."""
+    """Register the persistent create sub-command."""
     parser: argparse.ArgumentParser = add_command_parser(
         subparsers,
-        "create_persistent",
+        "create",
         help="Create a persistent storage instance.",
     )
     parser.add_argument(
@@ -103,18 +104,15 @@ def _split_nodes(values: Optional[List[str]]) -> List[str]:
     """
     if values is None:
         return []
-    result = []
-    for v in values:
-        result.extend(n.strip() for n in v.split(",") if n.strip())
-    return result
+    return [n.strip() for v in values for n in v.split(",") if n.strip()]
 
 
 def run(args: argparse.Namespace) -> int:
-    """Execute the create_persistent sub-command."""
+    """Execute the persistent create sub-command."""
     try:
         utils.validate_k8s_name(args.name, "nnf-create-persistent-")
     except ValueError as exc:
-        print(f"error: invalid --name: {exc}")
+        print(f"error: invalid --name: {exc}", file=sys.stderr)
         return 1
 
     # Resolve profile and check standaloneMgtPoolName (Lustre only).
@@ -123,7 +121,7 @@ def run(args: argparse.Namespace) -> int:
         try:
             profile_obj = profile.get_storage_profile(args.profile)
         except kubernetes.client.exceptions.ApiException as exc:
-            print(f"error: failed to fetch storage profile '{args.profile}': {exc}")
+            print(f"error: failed to fetch storage profile '{args.profile}': {exc}", file=sys.stderr)
             return 1
         standalone_mgt = profile.has_standalone_mgt(profile_obj)
 
@@ -131,23 +129,24 @@ def run(args: argparse.Namespace) -> int:
         if args.capacity is not None:
             print(
                 f"error: --capacity cannot be used with profile '{args.profile}' "
-                f"because it specifies standaloneMgtPoolName"
+                f"because it specifies standaloneMgtPoolName",
+                file=sys.stderr,
             )
             return 1
     else:
         if args.capacity is None:
-            print("error: --capacity is required when the profile does not specify standaloneMgtPoolName")
+            print("error: --capacity is required when the profile does not specify standaloneMgtPoolName", file=sys.stderr)
             return 1
         try:
             utils.parse_capacity(args.capacity)
         except ValueError as exc:
-            print(f"error: {exc}")
+            print(f"error: {exc}", file=sys.stderr)
             return 1
 
-    # Validate --rabbit-count mutual exclusion.
+    # Validate --rabbits-mdt/--rabbits-mgt require Lustre.
     if args.rabbits_mdt is not None or args.rabbits_mgt is not None:
         if args.fs_type != "lustre":
-            print("error: --rabbits-mdt and --rabbits-mgt are only valid when --fs-type is lustre")
+            print("error: --rabbits-mdt and --rabbits-mgt are only valid when --fs-type is lustre", file=sys.stderr)
             return 1
 
     # Validate --rabbit-count mutual exclusion.
@@ -162,48 +161,54 @@ def run(args: argparse.Namespace) -> int:
             if val is not None
         ]
         if conflicts:
-            print(f"error: --rabbit-count cannot be combined with: {', '.join(conflicts)}")
+            print(f"error: --rabbit-count cannot be combined with: {', '.join(conflicts)}", file=sys.stderr)
             return 1
         if args.rabbit_count < 1:
-            print("error: --rabbit-count must be at least 1")
+            print("error: --rabbit-count must be at least 1", file=sys.stderr)
             return 1
         try:
             all_rabbits = servers.get_rabbits_from_system_config()
         except (kubernetes.client.exceptions.ApiException, ValueError) as exc:
-            print(f"error: failed to read SystemConfiguration: {exc}")
+            print(f"error: failed to read SystemConfiguration: {exc}", file=sys.stderr)
             return 1
         if args.rabbit_count > len(all_rabbits):
             print(
                 f"error: --rabbit-count {args.rabbit_count} exceeds the "
-                f"{len(all_rabbits)} Rabbit(s) in the SystemConfiguration"
+                f"{len(all_rabbits)} Rabbit(s) in the SystemConfiguration",
+                file=sys.stderr,
             )
             return 1
         rabbits = random.sample(all_rabbits, args.rabbit_count)
         rabbits_mdt = None
         rabbits_mgt = None
     elif args.rabbits is None:
-        print("error: one of --rabbits or --rabbit-count is required")
+        print("error: one of --rabbits or --rabbit-count is required", file=sys.stderr)
         return 1
     else:
         rabbits = _split_nodes(args.rabbits)
+        if not rabbits:
+            print("error: --rabbits resolved to an empty list after normalization", file=sys.stderr)
+            return 1
         rabbits_mdt = _split_nodes(args.rabbits_mdt) or None
         rabbits_mgt = _split_nodes(args.rabbits_mgt) or None
 
     if args.alloc_count < 1:
-        print("error: --alloc-count must be at least 1")
+        print("error: --alloc-count must be at least 1", file=sys.stderr)
         return 1
 
     if standalone_mgt:
         if len(rabbits) != 1:
             print(
                 f"error: profile '{args.profile}' specifies standaloneMgtPoolName "
-                f"and requires exactly 1 Rabbit, but {len(rabbits)} were provided"
+                f"and requires exactly 1 Rabbit, but {len(rabbits)} were provided",
+                file=sys.stderr,
             )
             return 1
         if args.alloc_count != 1:
             print(
                 f"error: profile '{args.profile}' specifies standaloneMgtPoolName "
-                f"and requires --alloc-count 1"
+                f"and requires --alloc-count 1",
+                file=sys.stderr,
             )
             return 1
 

--- a/tools/nnf/src/nnf/commands/persistent/destroy.py
+++ b/tools/nnf/src/nnf/commands/persistent/destroy.py
@@ -1,4 +1,4 @@
-"""destroy_persistent sub-command: destroy a DWS PersistentStorageInstance.
+"""persistent destroy sub-command: destroy a DWS PersistentStorageInstance.
 
 Builds a #DW destroy_persistent directive, submits it as a Workflow, and drives
 that Workflow through every state.  The Workflow is always deleted on exit,
@@ -8,6 +8,7 @@ whether the command succeeds or fails.
 import argparse
 import logging
 import os
+import sys
 
 from nnf import utils
 from nnf import workflow
@@ -18,10 +19,10 @@ LOGGER = logging.getLogger(__name__)
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
-    """Register the destroy_persistent sub-command."""
+    """Register the persistent destroy sub-command."""
     parser: argparse.ArgumentParser = add_command_parser(
         subparsers,
-        "destroy_persistent",
+        "destroy",
         help="Destroy a persistent storage instance.",
     )
     parser.add_argument(
@@ -34,11 +35,11 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
 
 
 def run(args: argparse.Namespace) -> int:
-    """Execute the destroy_persistent sub-command."""
+    """Execute the persistent destroy sub-command."""
     try:
         utils.validate_k8s_name(args.name, "nnf-destroy-persistent-")
     except ValueError as exc:
-        print(f"error: invalid --name: {exc}")
+        print(f"error: invalid --name: {exc}", file=sys.stderr)
         return 1
 
     user_id: int = args.user_id if args.user_id is not None else os.getuid()

--- a/tools/nnf/src/nnf/commands/rabbit/__init__.py
+++ b/tools/nnf/src/nnf/commands/rabbit/__init__.py
@@ -1,0 +1,23 @@
+"""rabbit sub-command group: manage Rabbit node state."""
+
+import argparse
+
+from nnf.commands import add_command_parser
+from nnf.commands.rabbit import df, disable, drain, enable, undrain
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the rabbit sub-command group."""
+    rabbit_parser: argparse.ArgumentParser = add_command_parser(
+        subparsers,
+        "rabbit",
+        help="Manage Rabbit node state.",
+    )
+    sub = rabbit_parser.add_subparsers(dest="rabbit_command", metavar="<action>")
+    sub.required = True
+
+    df.register(sub)
+    disable.register(sub)
+    drain.register(sub)
+    enable.register(sub)
+    undrain.register(sub)

--- a/tools/nnf/src/nnf/commands/rabbit/_helpers.py
+++ b/tools/nnf/src/nnf/commands/rabbit/_helpers.py
@@ -1,0 +1,33 @@
+"""Shared helpers for rabbit sub-commands."""
+
+from typing import Callable, List
+
+
+# Action return codes.
+OK = 0
+ERROR = 1
+
+
+def for_each_node(
+    nodes: List[str],
+    action: Callable[[str], int],
+    success_msg: str,
+) -> int:
+    """Run *action* on each node, collecting errors.
+
+    *action* receives a node name and returns one of:
+
+    - ``OK`` (0): success — print *success_msg* and continue.
+    - ``ERROR`` (1): skip this node, continue to the next.
+
+    *success_msg* is a format string with one ``{}`` placeholder for the node
+    name.
+    """
+    errors = 0
+    for node_name in nodes:
+        rc = action(node_name)
+        if rc != OK:
+            errors += 1
+            continue
+        print(success_msg.format(node_name))
+    return 1 if errors else 0

--- a/tools/nnf/src/nnf/commands/rabbit/_helpers.py
+++ b/tools/nnf/src/nnf/commands/rabbit/_helpers.py
@@ -1,11 +1,62 @@
 """Shared helpers for rabbit sub-commands."""
 
-from typing import Callable, List
+import logging
+from typing import Any, Callable, Dict, List
 
+from nnf import crd
+from nnf import k8s
+
+
+LOGGER = logging.getLogger(__name__)
 
 # Action return codes.
 OK = 0
 ERROR = 1
+
+TAINT_KEY = "cray.nnf.node.drain"
+TAINT_VALUE = "true"
+
+
+def remove_drain_taints(node_name: str) -> None:
+    """Remove all drain taints from a node."""
+    api = k8s.get_core_v1_api()
+    node: Any = api.read_node(node_name)
+    remaining: List[Dict[str, str]] = []
+    if node.spec.taints:
+        remaining = [
+            {"key": t.key, "value": t.value or "", "effect": t.effect}
+            for t in node.spec.taints
+            if t.key != TAINT_KEY
+        ]
+
+    body: Dict[str, Any] = {
+        "spec": {
+            "taints": remaining or None,
+        }
+    }
+    k8s.patch_node(node_name, body)
+    LOGGER.info("Removed %s taint from node '%s'", TAINT_KEY, node_name)
+
+
+def remove_drain_annotations(node_name: str) -> None:
+    """Remove drain_date and drain_reason annotations from the DWS Storage resource."""
+    body: Dict[str, Any] = {
+        "metadata": {
+            "annotations": {
+                "drain_date": None,
+                "drain_reason": None,
+            }
+        }
+    }
+    k8s.patch_object(
+        group=crd.DWS_GROUP,
+        version=crd.DWS_VERSION,
+        namespace="default",
+        plural=crd.DWS_STORAGE_PLURAL,
+        name=node_name,
+        body=body,
+    )
+    LOGGER.info("Removed drain annotations from storage '%s'", node_name)
 
 
 def for_each_node(

--- a/tools/nnf/src/nnf/commands/rabbit/df.py
+++ b/tools/nnf/src/nnf/commands/rabbit/df.py
@@ -6,6 +6,7 @@ guaranteed, and provisioned bytes.
 """
 
 import argparse
+import ast
 import json
 import logging
 import sys
@@ -82,7 +83,12 @@ def _get_capacity(pod_name: str) -> Dict[str, int]:
         strip_channel_bytes=True,
     )
     LOGGER.info("raw exec output for %s: %r", pod_name, output[:200])
-    data = json.loads(output)
+    try:
+        data = json.loads(output)
+    except json.JSONDecodeError:
+        # The Redfish endpoint may return a Python-dict-formatted response
+        # (single quotes) instead of strict JSON.
+        data = ast.literal_eval(output)
     provided = data.get("ProvidedCapacity", {}).get("Data", {})
     return {
         "AllocatedBytes": provided.get("AllocatedBytes", 0),
@@ -132,7 +138,17 @@ def run(args: argparse.Namespace) -> int:
             continue
 
         if not _is_enabled_ready(storage):
-            skipped.append(rabbit)
+            if args.nodes:
+                spec_state = storage.get("spec", {}).get("state", "")
+                status_state = storage.get("status", {}).get("status", "")
+                print(
+                    f"error: '{rabbit}' is not Enabled/Ready "
+                    f"(spec.state={spec_state}, status={status_state})",
+                    file=sys.stderr,
+                )
+                errors += 1
+            else:
+                skipped.append(rabbit)
             continue
 
         pod_name = _find_node_manager_pod(rabbit, nm_pods)
@@ -144,7 +160,7 @@ def run(args: argparse.Namespace) -> int:
         try:
             cap = _get_capacity(pod_name)
         except (kubernetes.client.exceptions.ApiException, json.JSONDecodeError,
-                KeyError, ValueError) as exc:
+                KeyError, ValueError, SyntaxError) as exc:
             print(f"error: failed to get capacity from '{rabbit}': {exc}", file=sys.stderr)
             errors += 1
             continue

--- a/tools/nnf/src/nnf/commands/rabbit/df.py
+++ b/tools/nnf/src/nnf/commands/rabbit/df.py
@@ -1,0 +1,169 @@
+"""rabbit df sub-command: show disk space on Rabbit nodes.
+
+Queries each Rabbit's node-manager pod for NVMe capacity information via
+the Redfish CapacitySource endpoint and displays allocated, consumed,
+guaranteed, and provisioned bytes.
+"""
+
+import argparse
+import json
+import logging
+import sys
+from typing import Any, Dict, List, Optional
+
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+
+from nnf import crd
+from nnf import k8s
+from nnf.commands import add_command_parser
+
+
+LOGGER = logging.getLogger(__name__)
+
+_NNF_SYSTEM_NS = "nnf-system"
+_CAPACITY_URL = "localhost:50057/redfish/v1/StorageServices/NNF/CapacitySource"
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the rabbit df sub-command."""
+    parser: argparse.ArgumentParser = add_command_parser(
+        subparsers,
+        "df",
+        help="Show disk space information for Rabbit nodes.",
+    )
+    parser.add_argument(
+        "nodes",
+        nargs="*",
+        metavar="NODE",
+        help="Rabbit node names to query (default: all Enabled/Ready rabbits).",
+    )
+    parser.set_defaults(func=run)
+
+
+def _format_tib(byte_count: int) -> str:
+    """Format a byte count as TiB with 6 decimal places."""
+    tib = byte_count / (1024 ** 4)
+    return f"{tib:.6f} TiB"
+
+
+def _get_all_storages() -> List[Dict[str, Any]]:
+    """Return all DWS Storage resources in the default namespace."""
+    result = k8s.list_objects(
+        group=crd.DWS_GROUP,
+        version=crd.DWS_VERSION,
+        namespace="default",
+        plural=crd.DWS_STORAGE_PLURAL,
+    )
+    return result.get("items", [])  # type: ignore[no-any-return]
+
+
+def _is_enabled_ready(storage: Dict[str, Any]) -> bool:
+    """Return True if the Storage resource is Enabled and Ready."""
+    spec_state = storage.get("spec", {}).get("state", "")
+    status = storage.get("status", {})
+    status_state = status.get("status", "")
+    return spec_state == "Enabled" and status_state == "Ready"
+
+
+def _find_node_manager_pod(rabbit_name: str, pods: List[Any]) -> Optional[str]:
+    """Find the node-manager pod running on *rabbit_name*."""
+    for pod in pods:
+        if pod.spec.node_name == rabbit_name:
+            return pod.metadata.name  # type: ignore[no-any-return]
+    return None
+
+
+def _get_capacity(pod_name: str) -> Dict[str, int]:
+    """Exec into *pod_name* and return capacity data from the Redfish endpoint."""
+    output = k8s.exec_pod(
+        namespace=_NNF_SYSTEM_NS,
+        pod_name=pod_name,
+        command=["curl", "-sS", _CAPACITY_URL],
+        strip_channel_bytes=True,
+    )
+    LOGGER.info("raw exec output for %s: %r", pod_name, output[:200])
+    data = json.loads(output)
+    provided = data.get("ProvidedCapacity", {}).get("Data", {})
+    return {
+        "AllocatedBytes": provided.get("AllocatedBytes", 0),
+        "ConsumedBytes": provided.get("ConsumedBytes", 0),
+        "GuaranteedBytes": provided.get("GuaranteedBytes", 0),
+        "ProvisionedBytes": provided.get("ProvisionedBytes", 0),
+    }
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the rabbit df sub-command."""
+    # Fetch all Storage resources and node-manager pods up front.
+    try:
+        storages = _get_all_storages()
+    except kubernetes.client.exceptions.ApiException as exc:
+        print(f"error: failed to list Storage resources: {exc.reason}", file=sys.stderr)
+        return 1
+
+    storage_by_name: Dict[str, Dict[str, Any]] = {
+        s["metadata"]["name"]: s for s in storages
+    }
+
+    try:
+        nm_pods = k8s.list_pods(
+            namespace=_NNF_SYSTEM_NS,
+            label_selector="cray.nnf.node=true",
+            field_selector="status.phase=Running",
+        )
+    except kubernetes.client.exceptions.ApiException as exc:
+        print(f"error: failed to list node-manager pods: {exc.reason}", file=sys.stderr)
+        return 1
+
+    # Determine which rabbits to query.
+    if args.nodes:
+        rabbits = args.nodes
+    else:
+        rabbits = sorted(storage_by_name.keys())
+
+    skipped: List[str] = []
+    errors = 0
+
+    for rabbit in rabbits:
+        storage = storage_by_name.get(rabbit)
+        if storage is None:
+            print(f"error: no Storage resource found for '{rabbit}'", file=sys.stderr)
+            errors += 1
+            continue
+
+        if not _is_enabled_ready(storage):
+            skipped.append(rabbit)
+            continue
+
+        pod_name = _find_node_manager_pod(rabbit, nm_pods)
+        if pod_name is None:
+            print(f"error: no node-manager pod found on '{rabbit}'", file=sys.stderr)
+            errors += 1
+            continue
+
+        try:
+            cap = _get_capacity(pod_name)
+        except (kubernetes.client.exceptions.ApiException, json.JSONDecodeError,
+                KeyError, ValueError) as exc:
+            print(f"error: failed to get capacity from '{rabbit}': {exc}", file=sys.stderr)
+            errors += 1
+            continue
+
+        print(
+            f"{rabbit} {pod_name}"
+            f" Allocated: {_format_tib(cap['AllocatedBytes'])},"
+            f" Consumed: {_format_tib(cap['ConsumedBytes'])},"
+            f" Guaranteed: {_format_tib(cap['GuaranteedBytes'])},"
+            f" Provisioned: {_format_tib(cap['ProvisionedBytes'])}"
+        )
+
+    if skipped:
+        print()
+        print(f"{len(skipped)} rabbit(s) skipped:")
+        for rabbit in skipped:
+            storage = storage_by_name[rabbit]
+            spec_state = storage.get("spec", {}).get("state", "")
+            status_state = storage.get("status", {}).get("status", "")
+            print(f"    {rabbit}  {spec_state}  {status_state}")
+
+    return 1 if errors else 0

--- a/tools/nnf/src/nnf/commands/rabbit/disable.py
+++ b/tools/nnf/src/nnf/commands/rabbit/disable.py
@@ -1,0 +1,83 @@
+"""rabbit disable sub-command: disable a Rabbit node.
+
+Sets the DWS Storage resource ``spec.state`` to ``Disabled`` and annotates it
+with ``disable_date`` and ``disable_reason`` so that Flux does not use the
+Rabbit for allocations.
+"""
+
+import argparse
+import datetime
+import logging
+import sys
+from typing import Any, Dict
+
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+
+from nnf import crd
+from nnf import k8s
+from nnf.commands import add_command_parser
+from nnf.commands.rabbit._helpers import ERROR, OK, for_each_node
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the rabbit disable sub-command."""
+    parser: argparse.ArgumentParser = add_command_parser(
+        subparsers,
+        "disable",
+        help="Disable a Rabbit node so Flux does not use it for allocations.",
+    )
+    parser.add_argument(
+        "nodes",
+        nargs="+",
+        metavar="NODE",
+        help="One or more Rabbit node names to disable.",
+    )
+    parser.add_argument(
+        "-r",
+        "--reason",
+        default="none",
+        help="Reason for disabling the node (default: none).",
+    )
+    parser.set_defaults(func=run)
+
+
+def _disable_storage(node_name: str, disable_date: str, disable_reason: str) -> None:
+    """Set the Storage resource state to Disabled and add annotations."""
+    body: Dict[str, Any] = {
+        "metadata": {
+            "annotations": {
+                "disable_date": disable_date,
+                "disable_reason": disable_reason,
+            }
+        },
+        "spec": {
+            "state": "Disabled",
+        },
+    }
+    k8s.patch_object(
+        group=crd.DWS_GROUP,
+        version=crd.DWS_VERSION,
+        namespace="default",
+        plural=crd.DWS_STORAGE_PLURAL,
+        name=node_name,
+        body=body,
+    )
+    LOGGER.info("Disabled storage '%s' (reason=%s)", node_name, disable_reason)
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the rabbit disable sub-command."""
+    disable_date = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+
+    def action(node_name: str) -> int:
+        try:
+            _disable_storage(node_name, disable_date, args.reason)
+        except kubernetes.client.exceptions.ApiException as exc:
+            print(f"error: failed to disable storage '{node_name}': {exc.reason}", file=sys.stderr)
+            return ERROR
+        return OK
+
+    return for_each_node(args.nodes, action, "Disabled node '{}'.")

--- a/tools/nnf/src/nnf/commands/rabbit/disable.py
+++ b/tools/nnf/src/nnf/commands/rabbit/disable.py
@@ -70,7 +70,7 @@ def _disable_storage(node_name: str, disable_date: str, disable_reason: str) -> 
 
 def run(args: argparse.Namespace) -> int:
     """Execute the rabbit disable sub-command."""
-    disable_date = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    disable_date = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
 
     def action(node_name: str) -> int:
         try:

--- a/tools/nnf/src/nnf/commands/rabbit/drain.py
+++ b/tools/nnf/src/nnf/commands/rabbit/drain.py
@@ -1,0 +1,163 @@
+"""rabbit drain sub-command: drain a Rabbit node.
+
+Taints the Kubernetes node with ``cray.nnf.node.drain=true`` (NoSchedule +
+NoExecute) and annotates the corresponding DWS Storage resource with
+``drain_date`` and ``drain_reason``.
+"""
+
+import argparse
+import datetime
+import logging
+import sys
+from typing import Any, Dict, List
+
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+
+from nnf import crd
+from nnf import k8s
+from nnf.commands import add_command_parser
+from nnf.commands.rabbit._helpers import ERROR, OK, for_each_node
+
+
+LOGGER = logging.getLogger(__name__)
+
+TAINT_KEY = "cray.nnf.node.drain"
+TAINT_VALUE = "true"
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the rabbit drain sub-command."""
+    parser: argparse.ArgumentParser = add_command_parser(
+        subparsers,
+        "drain",
+        help="Drain a Rabbit node so no new workflows are scheduled to it.",
+    )
+    parser.add_argument(
+        "nodes",
+        nargs="+",
+        metavar="NODE",
+        help="One or more Rabbit node names to drain.",
+    )
+    parser.add_argument(
+        "-r",
+        "--reason",
+        default="none",
+        help="Reason for draining the node (default: none).",
+    )
+    parser.set_defaults(func=run)
+
+
+def _apply_drain_taints(node_name: str) -> None:
+    """Taint a node with the NNF drain key (NoSchedule + NoExecute)."""
+    taints: List[Dict[str, str]] = [
+        {"key": TAINT_KEY, "value": TAINT_VALUE, "effect": "NoSchedule"},
+        {"key": TAINT_KEY, "value": TAINT_VALUE, "effect": "NoExecute"},
+    ]
+
+    # Read the current node to get existing taints.
+    api = k8s.get_core_v1_api()
+    node: Any = api.read_node(node_name)
+    existing: List[Dict[str, str]] = []
+    if node.spec.taints:
+        existing = [
+            {"key": t.key, "value": t.value or "", "effect": t.effect}
+            for t in node.spec.taints
+            if t.key != TAINT_KEY
+        ]
+
+    body: Dict[str, Any] = {
+        "spec": {
+            "taints": existing + taints,
+        }
+    }
+    k8s.patch_node(node_name, body)
+    LOGGER.info("Tainted node '%s' with %s", node_name, TAINT_KEY)
+
+
+def _remove_drain_taints(node_name: str) -> None:
+    """Remove all drain taints from a node."""
+    api = k8s.get_core_v1_api()
+    node: Any = api.read_node(node_name)
+    remaining: List[Dict[str, str]] = []
+    if node.spec.taints:
+        remaining = [
+            {"key": t.key, "value": t.value or "", "effect": t.effect}
+            for t in node.spec.taints
+            if t.key != TAINT_KEY
+        ]
+
+    body: Dict[str, Any] = {
+        "spec": {
+            "taints": remaining or None,
+        }
+    }
+    k8s.patch_node(node_name, body)
+    LOGGER.info("Removed %s taint from node '%s'", TAINT_KEY, node_name)
+
+
+def _annotate_storage(node_name: str, drain_date: str, drain_reason: str) -> None:
+    """Annotate the DWS Storage resource for *node_name* with drain metadata."""
+    body: Dict[str, Any] = {
+        "metadata": {
+            "annotations": {
+                "drain_date": drain_date,
+                "drain_reason": drain_reason,
+            }
+        }
+    }
+    k8s.patch_object(
+        group=crd.DWS_GROUP,
+        version=crd.DWS_VERSION,
+        namespace="default",
+        plural=crd.DWS_STORAGE_PLURAL,
+        name=node_name,
+        body=body,
+    )
+    LOGGER.info("Annotated storage '%s' with drain_date=%s drain_reason=%s",
+                node_name, drain_date, drain_reason)
+
+
+def _remove_drain_annotations(node_name: str) -> None:
+    """Remove drain_date and drain_reason annotations from the DWS Storage resource."""
+    body: Dict[str, Any] = {
+        "metadata": {
+            "annotations": {
+                "drain_date": None,
+                "drain_reason": None,
+            }
+        }
+    }
+    k8s.patch_object(
+        group=crd.DWS_GROUP,
+        version=crd.DWS_VERSION,
+        namespace="default",
+        plural=crd.DWS_STORAGE_PLURAL,
+        name=node_name,
+        body=body,
+    )
+    LOGGER.info("Removed drain annotations from storage '%s'", node_name)
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the rabbit drain sub-command."""
+    drain_date = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+
+    def action(node_name: str) -> int:
+        try:
+            _annotate_storage(node_name, drain_date, args.reason)
+        except kubernetes.client.exceptions.ApiException as exc:
+            print(f"error: failed to annotate storage '{node_name}': {exc.reason}", file=sys.stderr)
+            return ERROR
+
+        try:
+            _apply_drain_taints(node_name)
+        except kubernetes.client.exceptions.ApiException as exc:
+            print(f"error: failed to taint node '{node_name}': {exc.reason}", file=sys.stderr)
+            try:
+                _remove_drain_annotations(node_name)
+            except kubernetes.client.exceptions.ApiException as rollback_exc:
+                print(f"error: failed to roll back storage annotation on '{node_name}': {rollback_exc.reason}", file=sys.stderr)
+            return ERROR
+        return OK
+
+    return for_each_node(args.nodes, action, "Drained node '{}'.")

--- a/tools/nnf/src/nnf/commands/rabbit/drain.py
+++ b/tools/nnf/src/nnf/commands/rabbit/drain.py
@@ -16,13 +16,17 @@ import kubernetes.client.exceptions  # type: ignore[import-untyped]
 from nnf import crd
 from nnf import k8s
 from nnf.commands import add_command_parser
-from nnf.commands.rabbit._helpers import ERROR, OK, for_each_node
+from nnf.commands.rabbit._helpers import (
+    ERROR,
+    OK,
+    TAINT_KEY,
+    TAINT_VALUE,
+    for_each_node,
+    remove_drain_annotations,
+)
 
 
 LOGGER = logging.getLogger(__name__)
-
-TAINT_KEY = "cray.nnf.node.drain"
-TAINT_VALUE = "true"
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
@@ -74,27 +78,6 @@ def _apply_drain_taints(node_name: str) -> None:
     LOGGER.info("Tainted node '%s' with %s", node_name, TAINT_KEY)
 
 
-def _remove_drain_taints(node_name: str) -> None:
-    """Remove all drain taints from a node."""
-    api = k8s.get_core_v1_api()
-    node: Any = api.read_node(node_name)
-    remaining: List[Dict[str, str]] = []
-    if node.spec.taints:
-        remaining = [
-            {"key": t.key, "value": t.value or "", "effect": t.effect}
-            for t in node.spec.taints
-            if t.key != TAINT_KEY
-        ]
-
-    body: Dict[str, Any] = {
-        "spec": {
-            "taints": remaining or None,
-        }
-    }
-    k8s.patch_node(node_name, body)
-    LOGGER.info("Removed %s taint from node '%s'", TAINT_KEY, node_name)
-
-
 def _annotate_storage(node_name: str, drain_date: str, drain_reason: str) -> None:
     """Annotate the DWS Storage resource for *node_name* with drain metadata."""
     body: Dict[str, Any] = {
@@ -117,27 +100,6 @@ def _annotate_storage(node_name: str, drain_date: str, drain_reason: str) -> Non
                 node_name, drain_date, drain_reason)
 
 
-def _remove_drain_annotations(node_name: str) -> None:
-    """Remove drain_date and drain_reason annotations from the DWS Storage resource."""
-    body: Dict[str, Any] = {
-        "metadata": {
-            "annotations": {
-                "drain_date": None,
-                "drain_reason": None,
-            }
-        }
-    }
-    k8s.patch_object(
-        group=crd.DWS_GROUP,
-        version=crd.DWS_VERSION,
-        namespace="default",
-        plural=crd.DWS_STORAGE_PLURAL,
-        name=node_name,
-        body=body,
-    )
-    LOGGER.info("Removed drain annotations from storage '%s'", node_name)
-
-
 def run(args: argparse.Namespace) -> int:
     """Execute the rabbit drain sub-command."""
     drain_date = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
@@ -154,7 +116,7 @@ def run(args: argparse.Namespace) -> int:
         except kubernetes.client.exceptions.ApiException as exc:
             print(f"error: failed to taint node '{node_name}': {exc.reason}", file=sys.stderr)
             try:
-                _remove_drain_annotations(node_name)
+                remove_drain_annotations(node_name)
             except kubernetes.client.exceptions.ApiException as rollback_exc:
                 print(f"error: failed to roll back storage annotation on '{node_name}': {rollback_exc.reason}", file=sys.stderr)
             return ERROR

--- a/tools/nnf/src/nnf/commands/rabbit/drain.py
+++ b/tools/nnf/src/nnf/commands/rabbit/drain.py
@@ -102,7 +102,7 @@ def _annotate_storage(node_name: str, drain_date: str, drain_reason: str) -> Non
 
 def run(args: argparse.Namespace) -> int:
     """Execute the rabbit drain sub-command."""
-    drain_date = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    drain_date = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
 
     def action(node_name: str) -> int:
         try:

--- a/tools/nnf/src/nnf/commands/rabbit/enable.py
+++ b/tools/nnf/src/nnf/commands/rabbit/enable.py
@@ -1,0 +1,75 @@
+"""rabbit enable sub-command: enable a Rabbit node.
+
+Sets the DWS Storage resource ``spec.state`` to ``Enabled`` and removes the
+``disable_date`` and ``disable_reason`` annotations so that Flux can use the
+Rabbit for allocations again.
+"""
+
+import argparse
+import logging
+import sys
+from typing import Any, Dict
+
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+
+from nnf import crd
+from nnf import k8s
+from nnf.commands import add_command_parser
+from nnf.commands.rabbit._helpers import ERROR, OK, for_each_node
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the rabbit enable sub-command."""
+    parser: argparse.ArgumentParser = add_command_parser(
+        subparsers,
+        "enable",
+        help="Enable a Rabbit node so Flux can use it for allocations.",
+    )
+    parser.add_argument(
+        "nodes",
+        nargs="+",
+        metavar="NODE",
+        help="One or more Rabbit node names to enable.",
+    )
+    parser.set_defaults(func=run)
+
+
+def _enable_storage(node_name: str) -> None:
+    """Set the Storage resource state to Enabled and remove disable annotations."""
+    body: Dict[str, Any] = {
+        "metadata": {
+            "annotations": {
+                "disable_date": None,
+                "disable_reason": None,
+            }
+        },
+        "spec": {
+            "state": "Enabled",
+        },
+    }
+    k8s.patch_object(
+        group=crd.DWS_GROUP,
+        version=crd.DWS_VERSION,
+        namespace="default",
+        plural=crd.DWS_STORAGE_PLURAL,
+        name=node_name,
+        body=body,
+    )
+    LOGGER.info("Enabled storage '%s'", node_name)
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the rabbit enable sub-command."""
+
+    def action(node_name: str) -> int:
+        try:
+            _enable_storage(node_name)
+        except kubernetes.client.exceptions.ApiException as exc:
+            print(f"error: failed to enable storage '{node_name}': {exc.reason}", file=sys.stderr)
+            return ERROR
+        return OK
+
+    return for_each_node(args.nodes, action, "Enabled node '{}'.")

--- a/tools/nnf/src/nnf/commands/rabbit/undrain.py
+++ b/tools/nnf/src/nnf/commands/rabbit/undrain.py
@@ -8,15 +8,17 @@ Storage resource.
 import argparse
 import logging
 import sys
-from typing import Any, Dict, List
 
 import kubernetes.client.exceptions  # type: ignore[import-untyped]
 
-from nnf import crd
-from nnf import k8s
 from nnf.commands import add_command_parser
-from nnf.commands.rabbit._helpers import ERROR, OK, for_each_node
-from nnf.commands.rabbit.drain import TAINT_KEY, _remove_drain_annotations, _remove_drain_taints
+from nnf.commands.rabbit._helpers import (
+    ERROR,
+    OK,
+    for_each_node,
+    remove_drain_annotations,
+    remove_drain_taints,
+)
 
 
 LOGGER = logging.getLogger(__name__)
@@ -43,15 +45,15 @@ def run(args: argparse.Namespace) -> int:
 
     def action(node_name: str) -> int:
         try:
-            _remove_drain_annotations(node_name)
+            remove_drain_taints(node_name)
         except kubernetes.client.exceptions.ApiException as exc:
-            print(f"error: failed to remove annotations from storage '{node_name}': {exc.reason}", file=sys.stderr)
+            print(f"error: failed to untaint node '{node_name}': {exc.reason}", file=sys.stderr)
             return ERROR
 
         try:
-            _remove_drain_taints(node_name)
+            remove_drain_annotations(node_name)
         except kubernetes.client.exceptions.ApiException as exc:
-            print(f"error: failed to untaint node '{node_name}': {exc.reason}", file=sys.stderr)
+            print(f"error: failed to remove annotations from storage '{node_name}': {exc.reason}", file=sys.stderr)
             return ERROR
         return OK
 

--- a/tools/nnf/src/nnf/commands/rabbit/undrain.py
+++ b/tools/nnf/src/nnf/commands/rabbit/undrain.py
@@ -1,0 +1,58 @@
+"""rabbit undrain sub-command: undrain a Rabbit node.
+
+Removes the ``cray.nnf.node.drain`` taint from the Kubernetes node and removes
+the ``drain_date`` and ``drain_reason`` annotations from the corresponding DWS
+Storage resource.
+"""
+
+import argparse
+import logging
+import sys
+from typing import Any, Dict, List
+
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+
+from nnf import crd
+from nnf import k8s
+from nnf.commands import add_command_parser
+from nnf.commands.rabbit._helpers import ERROR, OK, for_each_node
+from nnf.commands.rabbit.drain import TAINT_KEY, _remove_drain_annotations, _remove_drain_taints
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the rabbit undrain sub-command."""
+    parser: argparse.ArgumentParser = add_command_parser(
+        subparsers,
+        "undrain",
+        help="Undrain a Rabbit node so new workflows can be scheduled to it.",
+    )
+    parser.add_argument(
+        "nodes",
+        nargs="+",
+        metavar="NODE",
+        help="One or more Rabbit node names to undrain.",
+    )
+    parser.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the rabbit undrain sub-command."""
+
+    def action(node_name: str) -> int:
+        try:
+            _remove_drain_annotations(node_name)
+        except kubernetes.client.exceptions.ApiException as exc:
+            print(f"error: failed to remove annotations from storage '{node_name}': {exc.reason}", file=sys.stderr)
+            return ERROR
+
+        try:
+            _remove_drain_taints(node_name)
+        except kubernetes.client.exceptions.ApiException as exc:
+            print(f"error: failed to untaint node '{node_name}': {exc.reason}", file=sys.stderr)
+            return ERROR
+        return OK
+
+    return for_each_node(args.nodes, action, "Undrained node '{}'.")

--- a/tools/nnf/src/nnf/k8s.py
+++ b/tools/nnf/src/nnf/k8s.py
@@ -187,10 +187,11 @@ def exec_pod(
 ) -> str:
     """Execute a command inside a pod and return stdout.
 
-    When *strip_channel_bytes* is ``True``, leading WebSocket channel-marker
-    bytes (``\\x00``–``\\x03``) are stripped from the output.  Enable this
-    when the response is expected to be text or JSON and the Kubernetes
-    stream may include binary framing.
+    When *strip_channel_bytes* is ``True``, WebSocket channel-marker bytes
+    (``\\x00``–``\\x03``) are removed from the output.  These bytes can
+    appear at frame boundaries throughout the response.  Enable this when
+    the response is expected to be text or JSON and the Kubernetes stream
+    may include binary framing.
     """
     api = get_core_v1_api()
     kwargs: Dict[str, Any] = {
@@ -208,5 +209,5 @@ def exec_pod(
         api.connect_get_namespaced_pod_exec, **kwargs
     )
     if strip_channel_bytes:
-        raw = raw.lstrip("\x00\x01\x02\x03")
+        raw = raw.translate({0: None, 1: None, 2: None, 3: None})
     return raw

--- a/tools/nnf/src/nnf/k8s.py
+++ b/tools/nnf/src/nnf/k8s.py
@@ -1,13 +1,14 @@
 """Shared Kubernetes client helpers."""
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import urllib.parse
 
 import kubernetes  # type: ignore[import-untyped]
 import kubernetes.client  # type: ignore[import-untyped]
 import kubernetes.config  # type: ignore[import-untyped]
+import kubernetes.stream  # type: ignore[import-untyped]
 
 
 LOGGER = logging.getLogger(__name__)
@@ -128,3 +129,84 @@ def delete_object(
         plural=plural,
         name=name,
     )
+
+
+# ---------------------------------------------------------------------------
+# Core-API helpers (Nodes)
+# ---------------------------------------------------------------------------
+
+
+def get_core_v1_api() -> kubernetes.client.CoreV1Api:
+    """Return a configured CoreV1Api instance."""
+    return kubernetes.client.CoreV1Api()
+
+
+def patch_node(name: str, body: Dict[str, Any]) -> Any:
+    """Strategic-merge-patch a Node object."""
+    api = get_core_v1_api()
+    return api.patch_node(name, body)
+
+
+def list_objects(
+    group: str,
+    version: str,
+    namespace: str,
+    plural: str,
+) -> Dict[str, Any]:
+    """List namespaced custom objects."""
+    api = get_custom_objects_api()
+    return api.list_namespaced_custom_object(  # type: ignore[no-any-return]
+        group=group,
+        version=version,
+        namespace=namespace,
+        plural=plural,
+    )
+
+
+def list_pods(
+    namespace: str,
+    label_selector: str = "",
+    field_selector: str = "",
+) -> List[Any]:
+    """List pods in a namespace, optionally filtering by label or field selector."""
+    api = get_core_v1_api()
+    result = api.list_namespaced_pod(
+        namespace=namespace,
+        label_selector=label_selector,
+        field_selector=field_selector,
+    )
+    return result.items  # type: ignore[no-any-return]
+
+
+def exec_pod(
+    namespace: str,
+    pod_name: str,
+    command: List[str],
+    container: Optional[str] = None,
+    strip_channel_bytes: bool = False,
+) -> str:
+    """Execute a command inside a pod and return stdout.
+
+    When *strip_channel_bytes* is ``True``, leading WebSocket channel-marker
+    bytes (``\\x00``–``\\x03``) are stripped from the output.  Enable this
+    when the response is expected to be text or JSON and the Kubernetes
+    stream may include binary framing.
+    """
+    api = get_core_v1_api()
+    kwargs: Dict[str, Any] = {
+        "name": pod_name,
+        "namespace": namespace,
+        "command": command,
+        "stderr": False,
+        "stdin": False,
+        "stdout": True,
+        "tty": False,
+    }
+    if container is not None:
+        kwargs["container"] = container
+    raw: str = kubernetes.stream.stream(
+        api.connect_get_namespaced_pod_exec, **kwargs
+    )
+    if strip_channel_bytes:
+        raw = raw.lstrip("\x00\x01\x02\x03")
+    return raw

--- a/tools/nnf/src/nnf/workflow.py
+++ b/tools/nnf/src/nnf/workflow.py
@@ -5,6 +5,7 @@ advance it through the full state machine, populate its Servers/Computes
 resources at the appropriate states, and clean up when done."""
 
 import logging
+import sys
 import time
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -267,7 +268,7 @@ def create_and_run(wf: WorkflowRun, timeout: int) -> int:
             body=wf.manifest,
         )
     except kubernetes.client.exceptions.ApiException as exc:
-        print(f"error: failed to create Workflow: {exc.reason} (HTTP {exc.status})")
+        print(f"error: failed to create Workflow: {exc.reason} (HTTP {exc.status})", file=sys.stderr)
         LOGGER.info("Full error body: %s", exc.body)
         k8s.debug_api_group(crd.DWS_GROUP)
         return 2
@@ -277,7 +278,7 @@ def create_and_run(wf: WorkflowRun, timeout: int) -> int:
     try:
         ok, msg = run_to_completion(wf, timeout)
         if not ok:
-            print(f"error: {msg}")
+            print(f"error: {msg}", file=sys.stderr)
             return 2
     except Exception:
         teardown_and_delete(wf.name, wf.namespace, timeout)

--- a/tools/nnf/tests/test_create_persistent.py
+++ b/tools/nnf/tests/test_create_persistent.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from nnf.commands.create_persistent import run
+from nnf.commands.persistent.create import run
 from nnf.utils import parse_capacity, validate_k8s_name
 
 
@@ -97,7 +97,7 @@ def _make_args(**kwargs: object) -> argparse.Namespace:
 def test_run_success() -> None:
     """run() returns 0 when the Workflow is created and completes successfully."""
     mock_car = MagicMock(return_value=0)
-    with patch("nnf.commands.create_persistent.workflow.create_and_run", mock_car):
+    with patch("nnf.commands.persistent.create.workflow.create_and_run", mock_car):
         assert run(_make_args()) == 0
 
     mock_car.assert_called_once()
@@ -117,9 +117,9 @@ def test_run_comma_separated_rabbits() -> None:
         captured["wf"] = wf
         return 0
 
-    with patch("nnf.commands.create_persistent.workflow.create_and_run",
+    with patch("nnf.commands.persistent.create.workflow.create_and_run",
                side_effect=fake_create_and_run), \
-            patch("nnf.commands.create_persistent.servers.fill_servers_default",
+            patch("nnf.commands.persistent.create.servers.fill_servers_default",
                   return_value=(True, "")) as mock_fill:
         assert run(_make_args(rabbits=["rabbit-0,rabbit-1", "rabbit-2"])) == 0
         hooks = captured["wf"].state_hooks["Proposal"]  # type: ignore[index]
@@ -140,9 +140,9 @@ def test_run_post_proposal_hook_calls_fill_servers_default() -> None:
         captured["wf"] = wf
         return 0
 
-    with patch("nnf.commands.create_persistent.workflow.create_and_run",
+    with patch("nnf.commands.persistent.create.workflow.create_and_run",
                side_effect=fake_create_and_run), \
-            patch("nnf.commands.create_persistent.servers.fill_servers_default", return_value=(True, "")) as mock_fill:
+            patch("nnf.commands.persistent.create.servers.fill_servers_default", return_value=(True, "")) as mock_fill:
         assert run(_make_args(rabbits=["rabbit-0", "rabbit-1"])) == 0
 
         wf = captured["wf"]
@@ -195,7 +195,7 @@ def test_run_no_capacity_no_profile_returns_1() -> None:
 def test_run_no_capacity_profile_without_standalone_mgt_returns_1() -> None:
     """run() returns 1 when --capacity is omitted and the profile has no standaloneMgtPoolName."""
     plain_profile: Dict[str, object] = {"data": {"lustreStorage": {}}}
-    with patch("nnf.commands.create_persistent.profile.get_storage_profile",
+    with patch("nnf.commands.persistent.create.profile.get_storage_profile",
                return_value=plain_profile):
         assert run(_make_args(capacity=None, profile="plain")) == 1
 
@@ -205,7 +205,7 @@ def test_run_capacity_with_standalone_mgt_profile_returns_1() -> None:
     mgt_profile: Dict[str, object] = {
         "data": {"lustreStorage": {"mgtOptions": {"standaloneMgtPoolName": "main-pool"}}}
     }
-    with patch("nnf.commands.create_persistent.profile.get_storage_profile",
+    with patch("nnf.commands.persistent.create.profile.get_storage_profile",
                return_value=mgt_profile):
         assert run(_make_args(capacity="1GiB", profile="mgt-profile")) == 1
 
@@ -216,9 +216,9 @@ def test_run_standalone_mgt_profile_omits_capacity_from_directive() -> None:
         "data": {"lustreStorage": {"mgtOptions": {"standaloneMgtPoolName": "main-pool"}}}
     }
     mock_car = MagicMock(return_value=0)
-    with patch("nnf.commands.create_persistent.profile.get_storage_profile",
+    with patch("nnf.commands.persistent.create.profile.get_storage_profile",
                return_value=mgt_profile), \
-            patch("nnf.commands.create_persistent.workflow.create_and_run", mock_car):
+            patch("nnf.commands.persistent.create.workflow.create_and_run", mock_car):
         assert run(_make_args(capacity=None, profile="mgt-profile")) == 0
 
     wf_arg = mock_car.call_args[0][0]
@@ -231,14 +231,14 @@ def test_run_profile_fetch_error_returns_1() -> None:
     """run() returns 1 when fetching the storage profile fails."""
     import kubernetes.client.exceptions  # type: ignore[import-untyped]
     exc = kubernetes.client.exceptions.ApiException(status=404, reason="NotFound")
-    with patch("nnf.commands.create_persistent.profile.get_storage_profile",
+    with patch("nnf.commands.persistent.create.profile.get_storage_profile",
                side_effect=exc):
         assert run(_make_args(profile="missing-profile")) == 1
 
 
 def test_run_profile_unexpected_error_propagates() -> None:
     """run() should not swallow unexpected profile lookup failures."""
-    with patch("nnf.commands.create_persistent.profile.get_storage_profile",
+    with patch("nnf.commands.persistent.create.profile.get_storage_profile",
                side_effect=RuntimeError("boom")):
         with pytest.raises(RuntimeError, match="boom"):
             run(_make_args(profile="broken-profile"))
@@ -246,8 +246,8 @@ def test_run_profile_unexpected_error_propagates() -> None:
 
 def test_run_non_lustre_fs_type_skips_profile_check() -> None:
     """run() does not fetch the storage profile when fs_type is not lustre."""
-    with patch("nnf.commands.create_persistent.profile.get_storage_profile") as mock_get, \
-            patch("nnf.commands.create_persistent.workflow.create_and_run", return_value=0):
+    with patch("nnf.commands.persistent.create.profile.get_storage_profile") as mock_get, \
+            patch("nnf.commands.persistent.create.workflow.create_and_run", return_value=0):
         assert run(_make_args(fs_type="xfs", profile="some-profile")) == 0
     mock_get.assert_not_called()
 
@@ -257,7 +257,7 @@ def test_run_standalone_mgt_multiple_rabbits_returns_1() -> None:
     mgt_profile: Dict[str, object] = {
         "data": {"lustreStorage": {"mgtOptions": {"standaloneMgtPoolName": "main-pool"}}}
     }
-    with patch("nnf.commands.create_persistent.profile.get_storage_profile",
+    with patch("nnf.commands.persistent.create.profile.get_storage_profile",
                return_value=mgt_profile):
         assert run(_make_args(capacity=None, profile="mgt-profile",
                               rabbits=["rabbit-0", "rabbit-1"])) == 1
@@ -268,7 +268,7 @@ def test_run_standalone_mgt_alloc_count_gt1_returns_1() -> None:
     mgt_profile: Dict[str, object] = {
         "data": {"lustreStorage": {"mgtOptions": {"standaloneMgtPoolName": "main-pool"}}}
     }
-    with patch("nnf.commands.create_persistent.profile.get_storage_profile",
+    with patch("nnf.commands.persistent.create.profile.get_storage_profile",
                return_value=mgt_profile):
         assert run(_make_args(capacity=None, profile="mgt-profile",
                               rabbits=["rabbit-0"], alloc_count=2)) == 1
@@ -277,6 +277,11 @@ def test_run_standalone_mgt_alloc_count_gt1_returns_1() -> None:
 def test_run_no_rabbits_source_returns_1() -> None:
     """run() returns 1 when neither --rabbits nor --rabbit-count is given."""
     assert run(_make_args(rabbits=None, rabbit_count=None)) == 1
+
+
+def test_run_rabbits_separator_only_returns_1() -> None:
+    """run() returns 1 when --rabbits contains only separators (empty after normalization)."""
+    assert run(_make_args(rabbits=[",", ",,"])) == 1
 
 
 def test_run_rabbit_count_with_rabbits_returns_1() -> None:
@@ -304,7 +309,7 @@ def test_run_rabbit_count_exceeds_available_returns_1() -> None:
     _sys_config = {
         "spec": {"storageNodes": [{"name": "r-0", "type": "Rabbit"}]}
     }
-    with patch("nnf.commands.create_persistent.servers.get_rabbits_from_system_config",
+    with patch("nnf.commands.persistent.create.servers.get_rabbits_from_system_config",
                return_value=["r-0"]):
         assert run(_make_args(rabbit_count=5, rabbits=None)) == 1
 
@@ -320,11 +325,11 @@ def test_run_rabbit_count_picks_random_rabbits() -> None:
         captured["wf"] = wf
         return 0
 
-    with patch("nnf.commands.create_persistent.workflow.create_and_run",
+    with patch("nnf.commands.persistent.create.workflow.create_and_run",
                side_effect=fake_create_and_run), \
-            patch("nnf.commands.create_persistent.servers.get_rabbits_from_system_config",
+            patch("nnf.commands.persistent.create.servers.get_rabbits_from_system_config",
                   return_value=all_rabbits), \
-            patch("nnf.commands.create_persistent.servers.fill_servers_default",
+            patch("nnf.commands.persistent.create.servers.fill_servers_default",
                   return_value=(True, "")) as mock_fill:
         assert run(_make_args(rabbit_count=3, rabbits=None)) == 0
         hooks = captured["wf"].state_hooks["Proposal"]  # type: ignore[index]
@@ -341,7 +346,7 @@ def test_run_rabbit_count_picks_random_rabbits() -> None:
 
 def test_run_rabbit_count_unexpected_error_propagates() -> None:
     """run() should not swallow unexpected SystemConfiguration lookup failures."""
-    with patch("nnf.commands.create_persistent.servers.get_rabbits_from_system_config",
+    with patch("nnf.commands.persistent.create.servers.get_rabbits_from_system_config",
                side_effect=RuntimeError("boom")):
         with pytest.raises(RuntimeError, match="boom"):
             run(_make_args(rabbit_count=1, rabbits=None))
@@ -349,11 +354,11 @@ def test_run_rabbit_count_unexpected_error_propagates() -> None:
 
 def test_run_create_api_error_returns_2() -> None:
     """run() returns exit code 2 when the initial Workflow creation fails."""
-    with patch("nnf.commands.create_persistent.workflow.create_and_run", return_value=2):
+    with patch("nnf.commands.persistent.create.workflow.create_and_run", return_value=2):
         assert run(_make_args()) == 2
 
 
 def test_run_workflow_failure_returns_2() -> None:
     """run() returns exit code 2 when run_to_completion reports failure."""
-    with patch("nnf.commands.create_persistent.workflow.create_and_run", return_value=2):
+    with patch("nnf.commands.persistent.create.workflow.create_and_run", return_value=2):
         assert run(_make_args()) == 2

--- a/tools/nnf/tests/test_destroy_persistent.py
+++ b/tools/nnf/tests/test_destroy_persistent.py
@@ -4,7 +4,7 @@ import argparse
 from typing import Dict
 from unittest.mock import MagicMock, patch
 
-from nnf.commands.destroy_persistent import run
+from nnf.commands.persistent.destroy import run
 
 
 def _make_args(**kwargs: object) -> argparse.Namespace:
@@ -27,7 +27,7 @@ def test_run_invalid_name_returns_1() -> None:
 def test_run_success() -> None:
     """run() returns 0 when the Workflow is created and completes successfully."""
     mock_car = MagicMock(return_value=0)
-    with patch("nnf.commands.destroy_persistent.workflow.create_and_run", mock_car):
+    with patch("nnf.commands.persistent.destroy.workflow.create_and_run", mock_car):
         assert run(_make_args()) == 0
 
     mock_car.assert_called_once()
@@ -40,7 +40,7 @@ def test_run_success() -> None:
 def test_run_directive_contains_name() -> None:
     """run() builds the correct #DW destroy_persistent directive."""
     mock_car = MagicMock(return_value=0)
-    with patch("nnf.commands.destroy_persistent.workflow.create_and_run", mock_car):
+    with patch("nnf.commands.persistent.destroy.workflow.create_and_run", mock_car):
         assert run(_make_args(name="my-lustre")) == 0
 
     wf_arg = mock_car.call_args[0][0]
@@ -50,7 +50,7 @@ def test_run_directive_contains_name() -> None:
 def test_run_workflow_name() -> None:
     """run() uses nnf-destroy-persistent-{name} as the Workflow name."""
     mock_car = MagicMock(return_value=0)
-    with patch("nnf.commands.destroy_persistent.workflow.create_and_run", mock_car):
+    with patch("nnf.commands.persistent.destroy.workflow.create_and_run", mock_car):
         assert run(_make_args(name="my-psi")) == 0
 
     wf_arg = mock_car.call_args[0][0]
@@ -59,13 +59,13 @@ def test_run_workflow_name() -> None:
 
 def test_run_create_api_error_returns_2() -> None:
     """run() returns exit code 2 when Workflow creation fails."""
-    with patch("nnf.commands.destroy_persistent.workflow.create_and_run", return_value=2):
+    with patch("nnf.commands.persistent.destroy.workflow.create_and_run", return_value=2):
         assert run(_make_args()) == 2
 
 
 def test_run_workflow_failure_returns_2() -> None:
     """run() returns exit code 2 when run_to_completion reports failure."""
-    with patch("nnf.commands.destroy_persistent.workflow.create_and_run", return_value=2):
+    with patch("nnf.commands.persistent.destroy.workflow.create_and_run", return_value=2):
         assert run(_make_args()) == 2
 
 
@@ -79,7 +79,7 @@ def test_run_no_state_hooks() -> None:
         captured["wf"] = wf
         return 0
 
-    with patch("nnf.commands.destroy_persistent.workflow.create_and_run",
+    with patch("nnf.commands.persistent.destroy.workflow.create_and_run",
                side_effect=fake_create_and_run):
         assert run(_make_args()) == 0
 

--- a/tools/nnf/tests/test_k8s.py
+++ b/tools/nnf/tests/test_k8s.py
@@ -73,3 +73,41 @@ def test_delete_object_calls_api() -> None:
     mock_api.delete_namespaced_custom_object.assert_called_once_with(
         group="g", version="v", namespace="ns", plural="plural", name="test"
     )
+
+
+# ---------------------------------------------------------------------------
+# exec_pod
+# ---------------------------------------------------------------------------
+
+
+def test_exec_pod_strips_channel_bytes() -> None:
+    """exec_pod strips leading WebSocket channel-marker bytes when opted in."""
+    raw = "\x01{\"key\": \"value\"}"
+    mock_api = MagicMock()
+    with patch("nnf.k8s.get_core_v1_api", return_value=mock_api), \
+            patch("kubernetes.stream.stream", return_value=raw):
+        result = k8s.exec_pod("ns", "pod", ["echo"], strip_channel_bytes=True)
+
+    assert result == '{"key": "value"}'
+
+
+def test_exec_pod_preserves_channel_bytes_by_default() -> None:
+    """exec_pod does not strip channel bytes unless asked."""
+    raw = "\x01{\"key\": \"value\"}"
+    mock_api = MagicMock()
+    with patch("nnf.k8s.get_core_v1_api", return_value=mock_api), \
+            patch("kubernetes.stream.stream", return_value=raw):
+        result = k8s.exec_pod("ns", "pod", ["echo"])
+
+    assert result == raw
+
+
+def test_exec_pod_returns_clean_output_unchanged() -> None:
+    """exec_pod returns already-clean output as-is."""
+    clean = '{"key": "value"}'
+    mock_api = MagicMock()
+    with patch("nnf.k8s.get_core_v1_api", return_value=mock_api), \
+            patch("kubernetes.stream.stream", return_value=clean):
+        result = k8s.exec_pod("ns", "pod", ["echo"])
+
+    assert result == clean

--- a/tools/nnf/tests/test_k8s.py
+++ b/tools/nnf/tests/test_k8s.py
@@ -81,8 +81,19 @@ def test_delete_object_calls_api() -> None:
 
 
 def test_exec_pod_strips_channel_bytes() -> None:
-    """exec_pod strips leading WebSocket channel-marker bytes when opted in."""
+    """exec_pod strips WebSocket channel-marker bytes when opted in."""
     raw = "\x01{\"key\": \"value\"}"
+    mock_api = MagicMock()
+    with patch("nnf.k8s.get_core_v1_api", return_value=mock_api), \
+            patch("kubernetes.stream.stream", return_value=raw):
+        result = k8s.exec_pod("ns", "pod", ["echo"], strip_channel_bytes=True)
+
+    assert result == '{"key": "value"}'
+
+
+def test_exec_pod_strips_embedded_channel_bytes() -> None:
+    """exec_pod removes channel-marker bytes at frame boundaries mid-string."""
+    raw = "\x01{\"key\":\x01 \"value\"}"
     mock_api = MagicMock()
     with patch("nnf.k8s.get_core_v1_api", return_value=mock_api), \
             patch("kubernetes.stream.stream", return_value=raw):

--- a/tools/nnf/tests/test_main.py
+++ b/tools/nnf/tests/test_main.py
@@ -46,7 +46,8 @@ def test_build_parser_accepts_verbose_before_subcommand() -> None:
     """The shared verbose flag can be parsed at the top level."""
     args = build_parser().parse_args([
         "--verbose",
-        "create_persistent",
+        "persistent",
+        "create",
         "--name",
         "psi",
         "--fs-type",
@@ -58,13 +59,14 @@ def test_build_parser_accepts_verbose_before_subcommand() -> None:
     ])
 
     assert args.verbose is True
-    assert args.command == "create_persistent"
+    assert args.command == "persistent"
 
 
 def test_build_parser_accepts_verbose_after_subcommand() -> None:
     """The shared verbose flag can also be parsed after the subcommand."""
     args = build_parser().parse_args([
-        "create_persistent",
+        "persistent",
+        "create",
         "--verbose",
         "--name",
         "psi",
@@ -77,4 +79,4 @@ def test_build_parser_accepts_verbose_after_subcommand() -> None:
     ])
 
     assert args.verbose is True
-    assert args.command == "create_persistent"
+    assert args.command == "persistent"

--- a/tools/nnf/tests/test_rabbit_df.py
+++ b/tools/nnf/tests/test_rabbit_df.py
@@ -123,10 +123,10 @@ def test_get_capacity_parses_redfish_json() -> None:
 
 
 def test_get_capacity_rejects_non_json() -> None:
-    """_get_capacity raises JSONDecodeError for non-JSON responses."""
+    """_get_capacity raises on non-JSON/non-dict responses."""
     non_json = "this is not json"
     with patch("nnf.commands.rabbit.df.k8s.exec_pod", return_value=non_json):
-        with pytest.raises(json.JSONDecodeError):
+        with pytest.raises((json.JSONDecodeError, ValueError, SyntaxError)):
             _get_capacity("nm-pod")
 
 
@@ -154,6 +154,24 @@ def test_get_capacity_with_channel_byte_prefix() -> None:
         "ConsumedBytes": 50,
         "GuaranteedBytes": 80,
         "ProvisionedBytes": 90,
+    }
+
+
+def test_get_capacity_python_dict_response() -> None:
+    """_get_capacity handles Python-dict-formatted responses (single quotes)."""
+    python_dict = (
+        "{'ProvidedCapacity': {'Data': {"
+        "'AllocatedBytes': 200, 'ConsumedBytes': 100, "
+        "'GuaranteedBytes': 160, 'ProvisionedBytes': 180}}}"
+    )
+    with patch("nnf.commands.rabbit.df.k8s.exec_pod", return_value=python_dict):
+        cap = _get_capacity("nm-pod")
+
+    assert cap == {
+        "AllocatedBytes": 200,
+        "ConsumedBytes": 100,
+        "GuaranteedBytes": 160,
+        "ProvisionedBytes": 180,
     }
 
 
@@ -240,6 +258,20 @@ def test_run_skips_disabled(capsys: pytest.CaptureFixture[str]) -> None:
     out = capsys.readouterr().out
     assert "skipped" in out
     assert "rabbit-0" in out
+
+
+def test_run_explicit_disabled_node_returns_1(capsys: pytest.CaptureFixture[str]) -> None:
+    """run() returns an error when a user-specified node is not Enabled/Ready."""
+    storages = [_make_storage("rabbit-0", state="Disabled", status="Ready")]
+
+    with patch("nnf.commands.rabbit.df._get_all_storages", return_value=storages), \
+            patch("nnf.commands.rabbit.df.k8s.list_pods", return_value=[]):
+        rc = run(_make_args(nodes=["rabbit-0"]))
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "not Enabled/Ready" in err
+    assert "rabbit-0" in err
 
 
 def test_run_no_storage_resource_returns_1(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tools/nnf/tests/test_rabbit_df.py
+++ b/tools/nnf/tests/test_rabbit_df.py
@@ -1,0 +1,305 @@
+"""Tests for the rabbit df sub-command."""
+
+import argparse
+import json
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+import pytest
+
+from nnf.commands.rabbit.df import (
+    _find_node_manager_pod,
+    _format_tib,
+    _get_all_storages,
+    _get_capacity,
+    _is_enabled_ready,
+    run,
+)
+
+
+def _make_args(**kwargs: object) -> argparse.Namespace:
+    defaults: Dict[str, object] = {
+        "nodes": [],
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# _format_tib
+# ---------------------------------------------------------------------------
+
+
+def test_format_tib_one_tib() -> None:
+    assert _format_tib(1024**4) == "1.000000 TiB"
+
+
+def test_format_tib_zero() -> None:
+    assert _format_tib(0) == "0.000000 TiB"
+
+
+def test_format_tib_fractional() -> None:
+    result = _format_tib(512 * 1024**3)
+    assert result == "0.500000 TiB"
+
+
+# ---------------------------------------------------------------------------
+# _is_enabled_ready
+# ---------------------------------------------------------------------------
+
+
+def test_is_enabled_ready_true() -> None:
+    storage: Dict[str, Any] = {
+        "spec": {"state": "Enabled"},
+        "status": {"status": "Ready"},
+    }
+    assert _is_enabled_ready(storage) is True
+
+
+def test_is_enabled_ready_disabled() -> None:
+    storage: Dict[str, Any] = {
+        "spec": {"state": "Disabled"},
+        "status": {"status": "Ready"},
+    }
+    assert _is_enabled_ready(storage) is False
+
+
+def test_is_enabled_ready_not_ready() -> None:
+    storage: Dict[str, Any] = {
+        "spec": {"state": "Enabled"},
+        "status": {"status": "NotReady"},
+    }
+    assert _is_enabled_ready(storage) is False
+
+
+# ---------------------------------------------------------------------------
+# _find_node_manager_pod
+# ---------------------------------------------------------------------------
+
+
+def _make_pod(name: str, node_name: str) -> MagicMock:
+    pod = MagicMock()
+    pod.metadata.name = name
+    pod.spec.node_name = node_name
+    return pod
+
+
+def test_find_node_manager_pod_found() -> None:
+    pods = [_make_pod("nm-abc", "rabbit-0"), _make_pod("nm-def", "rabbit-1")]
+    assert _find_node_manager_pod("rabbit-1", pods) == "nm-def"
+
+
+def test_find_node_manager_pod_not_found() -> None:
+    pods = [_make_pod("nm-abc", "rabbit-0")]
+    assert _find_node_manager_pod("rabbit-99", pods) is None
+
+
+# ---------------------------------------------------------------------------
+# _get_capacity
+# ---------------------------------------------------------------------------
+
+
+def test_get_capacity_parses_redfish_json() -> None:
+    redfish_json = json.dumps({
+        "ProvidedCapacity": {
+            "Data": {
+                "AllocatedBytes": 1000,
+                "ConsumedBytes": 200,
+                "GuaranteedBytes": 800,
+                "ProvisionedBytes": 900,
+            }
+        }
+    })
+    with patch("nnf.commands.rabbit.df.k8s.exec_pod", return_value=redfish_json):
+        cap = _get_capacity("nm-pod")
+
+    assert cap == {
+        "AllocatedBytes": 1000,
+        "ConsumedBytes": 200,
+        "GuaranteedBytes": 800,
+        "ProvisionedBytes": 900,
+    }
+
+
+def test_get_capacity_rejects_non_json() -> None:
+    """_get_capacity raises JSONDecodeError for non-JSON responses."""
+    non_json = "this is not json"
+    with patch("nnf.commands.rabbit.df.k8s.exec_pod", return_value=non_json):
+        with pytest.raises(json.JSONDecodeError):
+            _get_capacity("nm-pod")
+
+
+def test_get_capacity_with_channel_byte_prefix() -> None:
+    """_get_capacity parses JSON correctly when exec_pod strips channel bytes."""
+    prefixed = "\x01" + json.dumps({
+        "ProvidedCapacity": {
+            "Data": {
+                "AllocatedBytes": 100,
+                "ConsumedBytes": 50,
+                "GuaranteedBytes": 80,
+                "ProvisionedBytes": 90,
+            }
+        }
+    })
+    # Patch the raw kubernetes stream to return channel-byte-prefixed output;
+    # exec_pod (with strip_channel_bytes=True) will clean it before
+    # _get_capacity calls json.loads.
+    with patch("nnf.k8s.get_core_v1_api"), \
+            patch("kubernetes.stream.stream", return_value=prefixed):
+        cap = _get_capacity("nm-pod")
+
+    assert cap == {
+        "AllocatedBytes": 100,
+        "ConsumedBytes": 50,
+        "GuaranteedBytes": 80,
+        "ProvisionedBytes": 90,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _get_all_storages
+# ---------------------------------------------------------------------------
+
+
+def test_get_all_storages_returns_items() -> None:
+    items = [{"metadata": {"name": "r-0"}}]
+    with patch("nnf.commands.rabbit.df.k8s.list_objects", return_value={"items": items}):
+        assert _get_all_storages() == items
+
+
+# ---------------------------------------------------------------------------
+# run() — happy path
+# ---------------------------------------------------------------------------
+
+
+def _make_storage(name: str, state: str = "Enabled", status: str = "Ready") -> Dict[str, Any]:
+    return {
+        "metadata": {"name": name},
+        "spec": {"state": state},
+        "status": {"status": status},
+    }
+
+
+def test_run_success(capsys: pytest.CaptureFixture[str]) -> None:
+    """run() prints capacity for Enabled/Ready rabbits."""
+    storages = [_make_storage("rabbit-0")]
+    pods = [_make_pod("nm-abc", "rabbit-0")]
+    cap_json = json.dumps({
+        "ProvidedCapacity": {"Data": {
+            "AllocatedBytes": 1024**4,
+            "ConsumedBytes": 0,
+            "GuaranteedBytes": 1024**4,
+            "ProvisionedBytes": 1024**4,
+        }}
+    })
+
+    with patch("nnf.commands.rabbit.df._get_all_storages", return_value=storages), \
+            patch("nnf.commands.rabbit.df.k8s.list_pods", return_value=pods), \
+            patch("nnf.commands.rabbit.df.k8s.exec_pod", return_value=cap_json):
+        rc = run(_make_args())
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "rabbit-0" in out
+    assert "nm-abc" in out
+    assert "Allocated:" in out
+
+
+def test_run_specific_nodes(capsys: pytest.CaptureFixture[str]) -> None:
+    """run() only queries requested nodes."""
+    storages = [_make_storage("rabbit-0"), _make_storage("rabbit-1")]
+    pods = [_make_pod("nm-abc", "rabbit-0"), _make_pod("nm-def", "rabbit-1")]
+    cap_json = json.dumps({
+        "ProvidedCapacity": {"Data": {
+            "AllocatedBytes": 0, "ConsumedBytes": 0,
+            "GuaranteedBytes": 0, "ProvisionedBytes": 0,
+        }}
+    })
+
+    with patch("nnf.commands.rabbit.df._get_all_storages", return_value=storages), \
+            patch("nnf.commands.rabbit.df.k8s.list_pods", return_value=pods), \
+            patch("nnf.commands.rabbit.df.k8s.exec_pod", return_value=cap_json):
+        rc = run(_make_args(nodes=["rabbit-1"]))
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "rabbit-1" in out
+    assert "rabbit-0" not in out
+
+
+def test_run_skips_disabled(capsys: pytest.CaptureFixture[str]) -> None:
+    """run() skips rabbits that are not Enabled/Ready and reports them."""
+    storages = [_make_storage("rabbit-0", state="Disabled", status="Ready")]
+
+    with patch("nnf.commands.rabbit.df._get_all_storages", return_value=storages), \
+            patch("nnf.commands.rabbit.df.k8s.list_pods", return_value=[]):
+        rc = run(_make_args())
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "skipped" in out
+    assert "rabbit-0" in out
+
+
+def test_run_no_storage_resource_returns_1(capsys: pytest.CaptureFixture[str]) -> None:
+    """run() reports an error when a requested rabbit has no Storage resource."""
+    with patch("nnf.commands.rabbit.df._get_all_storages", return_value=[]), \
+            patch("nnf.commands.rabbit.df.k8s.list_pods", return_value=[]):
+        rc = run(_make_args(nodes=["rabbit-missing"]))
+
+    assert rc == 1
+    assert "no Storage resource" in capsys.readouterr().err
+
+
+def test_run_no_pod_returns_1(capsys: pytest.CaptureFixture[str]) -> None:
+    """run() reports an error when no node-manager pod is found."""
+    storages = [_make_storage("rabbit-0")]
+
+    with patch("nnf.commands.rabbit.df._get_all_storages", return_value=storages), \
+            patch("nnf.commands.rabbit.df.k8s.list_pods", return_value=[]):
+        rc = run(_make_args())
+
+    assert rc == 1
+    assert "no node-manager pod" in capsys.readouterr().err
+
+
+def test_run_capacity_error_continues(capsys: pytest.CaptureFixture[str]) -> None:
+    """run() continues to the next rabbit when capacity fetch fails."""
+    storages = [_make_storage("rabbit-0"), _make_storage("rabbit-1")]
+    pods = [_make_pod("nm-abc", "rabbit-0"), _make_pod("nm-def", "rabbit-1")]
+    cap_json = json.dumps({
+        "ProvidedCapacity": {"Data": {
+            "AllocatedBytes": 0, "ConsumedBytes": 0,
+            "GuaranteedBytes": 0, "ProvisionedBytes": 0,
+        }}
+    })
+    exc = kubernetes.client.exceptions.ApiException(status=500, reason="InternalError")
+
+    with patch("nnf.commands.rabbit.df._get_all_storages", return_value=storages), \
+            patch("nnf.commands.rabbit.df.k8s.list_pods", return_value=pods), \
+            patch("nnf.commands.rabbit.df.k8s.exec_pod", side_effect=[exc, cap_json]):
+        rc = run(_make_args())
+
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "rabbit-1" in out  # second rabbit succeeded
+
+
+def test_run_storage_list_failure_returns_1() -> None:
+    """run() returns 1 when listing Storage resources fails."""
+    exc = kubernetes.client.exceptions.ApiException(status=500, reason="InternalError")
+    with patch("nnf.commands.rabbit.df._get_all_storages", side_effect=exc):
+        rc = run(_make_args())
+
+    assert rc == 1
+
+
+def test_run_pod_list_failure_returns_1() -> None:
+    """run() returns 1 when listing pods fails."""
+    exc = kubernetes.client.exceptions.ApiException(status=500, reason="InternalError")
+    with patch("nnf.commands.rabbit.df._get_all_storages", return_value=[]), \
+            patch("nnf.commands.rabbit.df.k8s.list_pods", side_effect=exc):
+        rc = run(_make_args())
+
+    assert rc == 1

--- a/tools/nnf/tests/test_rabbit_disable.py
+++ b/tools/nnf/tests/test_rabbit_disable.py
@@ -1,0 +1,88 @@
+"""Tests for the rabbit disable sub-command."""
+
+import argparse
+from typing import Dict
+from unittest.mock import patch
+
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+
+from nnf.commands.rabbit.disable import _disable_storage, run
+
+
+def _make_args(**kwargs: object) -> argparse.Namespace:
+    defaults: Dict[str, object] = {
+        "nodes": ["rabbit-0"],
+        "reason": "none",
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# _disable_storage
+# ---------------------------------------------------------------------------
+
+
+def test_disable_storage_patches_state_and_annotations() -> None:
+    """_disable_storage sets spec.state and both annotations."""
+    with patch("nnf.commands.rabbit.disable.k8s.patch_object") as mock_patch:
+        _disable_storage("rabbit-0", "2026-04-27T10:30:00", "maintenance")
+
+    mock_patch.assert_called_once()
+    _, kwargs = mock_patch.call_args
+    assert kwargs["name"] == "rabbit-0"
+    body = kwargs["body"]
+    assert body["spec"]["state"] == "Disabled"
+    annotations = body["metadata"]["annotations"]
+    assert annotations["disable_date"] == "2026-04-27T10:30:00"
+    assert annotations["disable_reason"] == "maintenance"
+
+
+# ---------------------------------------------------------------------------
+# run()
+# ---------------------------------------------------------------------------
+
+
+def test_run_success_single_node() -> None:
+    """run() returns 0 for a single successful disable."""
+    with patch("nnf.commands.rabbit.disable._disable_storage"):
+        rc = run(_make_args())
+
+    assert rc == 0
+
+
+def test_run_success_multiple_nodes() -> None:
+    """run() disables every node in the list."""
+    with patch("nnf.commands.rabbit.disable._disable_storage") as mock_dis:
+        rc = run(_make_args(nodes=["rabbit-0", "rabbit-1", "rabbit-2"]))
+
+    assert rc == 0
+    assert mock_dis.call_count == 3
+
+
+def test_run_custom_reason() -> None:
+    """run() passes the --reason value through."""
+    with patch("nnf.commands.rabbit.disable._disable_storage") as mock_dis:
+        run(_make_args(reason="bad disk"))
+
+    assert mock_dis.call_args[0][2] == "bad disk"
+
+
+def test_run_failure_continues_to_next_node() -> None:
+    """run() continues to the next node when one fails."""
+    exc = kubernetes.client.exceptions.ApiException(status=404, reason="NotFound")
+    with patch("nnf.commands.rabbit.disable._disable_storage",
+               side_effect=[exc, None]) as mock_dis:
+        rc = run(_make_args(nodes=["bad-node", "good-node"]))
+
+    assert rc == 1
+    assert mock_dis.call_count == 2
+
+
+def test_run_all_fail_returns_1() -> None:
+    """run() returns 1 when all nodes fail."""
+    exc = kubernetes.client.exceptions.ApiException(status=500, reason="InternalError")
+    with patch("nnf.commands.rabbit.disable._disable_storage", side_effect=exc):
+        rc = run(_make_args(nodes=["rabbit-0", "rabbit-1"]))
+
+    assert rc == 1

--- a/tools/nnf/tests/test_rabbit_drain.py
+++ b/tools/nnf/tests/test_rabbit_drain.py
@@ -157,7 +157,7 @@ def test_run_taint_failure_continues_to_next_node() -> None:
     exc = kubernetes.client.exceptions.ApiException(status=404, reason="NotFound")
     with patch("nnf.commands.rabbit.drain._annotate_storage"), \
             patch("nnf.commands.rabbit.drain._apply_drain_taints", side_effect=[exc, None]), \
-            patch("nnf.commands.rabbit.drain._remove_drain_annotations"):
+            patch("nnf.commands.rabbit.drain.remove_drain_annotations"):
         rc = run(_make_args(nodes=["bad-node", "good-node"]))
 
     assert rc == 1
@@ -181,7 +181,7 @@ def test_run_taint_failure_rollback_failure_continues() -> None:
     with patch("nnf.commands.rabbit.drain._annotate_storage"), \
             patch("nnf.commands.rabbit.drain._apply_drain_taints",
                   side_effect=[taint_exc, None]), \
-            patch("nnf.commands.rabbit.drain._remove_drain_annotations",
+            patch("nnf.commands.rabbit.drain.remove_drain_annotations",
                   side_effect=[rollback_exc, None]):
         rc = run(_make_args(nodes=["rabbit-0", "rabbit-1"]))
 

--- a/tools/nnf/tests/test_rabbit_drain.py
+++ b/tools/nnf/tests/test_rabbit_drain.py
@@ -1,0 +1,198 @@
+"""Tests for the rabbit drain sub-command."""
+
+import argparse
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+import pytest
+
+from nnf.commands.rabbit.drain import (
+    TAINT_KEY,
+    TAINT_VALUE,
+    _annotate_storage,
+    _apply_drain_taints,
+    run,
+)
+
+
+def _make_args(**kwargs: object) -> argparse.Namespace:
+    defaults: Dict[str, object] = {
+        "nodes": ["rabbit-0"],
+        "reason": "none",
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# _apply_drain_taints
+# ---------------------------------------------------------------------------
+
+
+def _make_node(existing_taints: Optional[List[Any]] = None) -> MagicMock:
+    """Return a mock Node object with optional existing taints."""
+    node = MagicMock()
+    node.spec.taints = existing_taints
+    return node
+
+
+def _make_taint(key: str, value: str, effect: str) -> MagicMock:
+    t = MagicMock()
+    t.key = key
+    t.value = value
+    t.effect = effect
+    return t
+
+
+def test_apply_drain_taints_no_existing_taints() -> None:
+    """Applies both drain taints when the node has no existing taints."""
+    node = _make_node(existing_taints=None)
+    with patch("nnf.commands.rabbit.drain.k8s.get_core_v1_api") as mock_api_fn, \
+            patch("nnf.commands.rabbit.drain.k8s.patch_node") as mock_patch:
+        mock_api_fn.return_value.read_node.return_value = node
+        _apply_drain_taints("rabbit-0")
+
+    mock_patch.assert_called_once()
+    body = mock_patch.call_args[0][1]
+    taints = body["spec"]["taints"]
+    assert len(taints) == 2
+    assert taints[0] == {"key": TAINT_KEY, "value": TAINT_VALUE, "effect": "NoSchedule"}
+    assert taints[1] == {"key": TAINT_KEY, "value": TAINT_VALUE, "effect": "NoExecute"}
+
+
+def test_apply_drain_taints_preserves_existing_taints() -> None:
+    """Existing non-drain taints are preserved."""
+    other_taint = _make_taint("other-key", "val", "NoSchedule")
+    node = _make_node(existing_taints=[other_taint])
+    with patch("nnf.commands.rabbit.drain.k8s.get_core_v1_api") as mock_api_fn, \
+            patch("nnf.commands.rabbit.drain.k8s.patch_node") as mock_patch:
+        mock_api_fn.return_value.read_node.return_value = node
+        _apply_drain_taints("rabbit-0")
+
+    body = mock_patch.call_args[0][1]
+    taints = body["spec"]["taints"]
+    assert len(taints) == 3
+    assert taints[0] == {"key": "other-key", "value": "val", "effect": "NoSchedule"}
+
+
+def test_apply_drain_taints_replaces_existing_drain_taints() -> None:
+    """Existing drain taints are replaced rather than duplicated."""
+    old_drain = _make_taint(TAINT_KEY, "old", "NoSchedule")
+    other_taint = _make_taint("keep-me", "yes", "NoExecute")
+    node = _make_node(existing_taints=[old_drain, other_taint])
+    with patch("nnf.commands.rabbit.drain.k8s.get_core_v1_api") as mock_api_fn, \
+            patch("nnf.commands.rabbit.drain.k8s.patch_node") as mock_patch:
+        mock_api_fn.return_value.read_node.return_value = node
+        _apply_drain_taints("rabbit-0")
+
+    body = mock_patch.call_args[0][1]
+    taints = body["spec"]["taints"]
+    # 1 preserved + 2 new drain taints
+    assert len(taints) == 3
+    keys = [t["key"] for t in taints]
+    assert keys.count(TAINT_KEY) == 2
+    assert keys.count("keep-me") == 1
+
+
+# ---------------------------------------------------------------------------
+# _annotate_storage
+# ---------------------------------------------------------------------------
+
+
+def test_annotate_storage_patches_with_drain_metadata() -> None:
+    """_annotate_storage sends the correct merge-patch body."""
+    with patch("nnf.commands.rabbit.drain.k8s.patch_object") as mock_patch:
+        _annotate_storage("rabbit-0", "2026-04-27T10:30:00", "maintenance")
+
+    mock_patch.assert_called_once()
+    _, kwargs = mock_patch.call_args
+    assert kwargs["name"] == "rabbit-0"
+    annotations = kwargs["body"]["metadata"]["annotations"]
+    assert annotations["drain_date"] == "2026-04-27T10:30:00"
+    assert annotations["drain_reason"] == "maintenance"
+
+
+# ---------------------------------------------------------------------------
+# run()
+# ---------------------------------------------------------------------------
+
+
+def test_run_success_single_node() -> None:
+    """run() returns 0 and prints success for a single node."""
+    with patch("nnf.commands.rabbit.drain._apply_drain_taints") as mock_taint, \
+            patch("nnf.commands.rabbit.drain._annotate_storage") as mock_annotate:
+        rc = run(_make_args())
+
+    assert rc == 0
+    mock_taint.assert_called_once_with("rabbit-0")
+    mock_annotate.assert_called_once()
+    call_args = mock_annotate.call_args[0]
+    assert call_args[0] == "rabbit-0"
+    assert call_args[2] == "none"
+
+
+def test_run_success_multiple_nodes() -> None:
+    """run() drains every node in the list."""
+    args = _make_args(nodes=["rabbit-0", "rabbit-1", "rabbit-2"])
+    with patch("nnf.commands.rabbit.drain._apply_drain_taints"), \
+            patch("nnf.commands.rabbit.drain._annotate_storage") as mock_annotate:
+        rc = run(args)
+
+    assert rc == 0
+    assert mock_annotate.call_count == 3
+
+
+def test_run_custom_reason() -> None:
+    """run() passes the --reason value to _annotate_storage."""
+    with patch("nnf.commands.rabbit.drain._apply_drain_taints"), \
+            patch("nnf.commands.rabbit.drain._annotate_storage") as mock_annotate:
+        run(_make_args(reason="disk failure"))
+
+    assert mock_annotate.call_args[0][2] == "disk failure"
+
+
+def test_run_taint_failure_continues_to_next_node() -> None:
+    """run() continues to the next node when tainting fails."""
+    exc = kubernetes.client.exceptions.ApiException(status=404, reason="NotFound")
+    with patch("nnf.commands.rabbit.drain._annotate_storage"), \
+            patch("nnf.commands.rabbit.drain._apply_drain_taints", side_effect=[exc, None]), \
+            patch("nnf.commands.rabbit.drain._remove_drain_annotations"):
+        rc = run(_make_args(nodes=["bad-node", "good-node"]))
+
+    assert rc == 1
+
+
+def test_run_annotate_failure_continues_to_next_node() -> None:
+    """run() continues to the next node when annotation fails."""
+    exc = kubernetes.client.exceptions.ApiException(status=500, reason="InternalError")
+    with patch("nnf.commands.rabbit.drain._annotate_storage",
+                  side_effect=[exc, None]), \
+            patch("nnf.commands.rabbit.drain._apply_drain_taints"):
+        rc = run(_make_args(nodes=["rabbit-0", "rabbit-1"]))
+
+    assert rc == 1
+
+
+def test_run_taint_failure_rollback_failure_continues() -> None:
+    """run() continues to the next node when rollback of storage annotation also fails."""
+    taint_exc = kubernetes.client.exceptions.ApiException(status=500, reason="InternalError")
+    rollback_exc = kubernetes.client.exceptions.ApiException(status=500, reason="RollbackFailed")
+    with patch("nnf.commands.rabbit.drain._annotate_storage"), \
+            patch("nnf.commands.rabbit.drain._apply_drain_taints",
+                  side_effect=[taint_exc, None]), \
+            patch("nnf.commands.rabbit.drain._remove_drain_annotations",
+                  side_effect=[rollback_exc, None]):
+        rc = run(_make_args(nodes=["rabbit-0", "rabbit-1"]))
+
+    # rabbit-0 failed (taint + rollback), rabbit-1 succeeded → errors > 0
+    assert rc == 1
+
+
+def test_run_all_fail_returns_1() -> None:
+    """run() returns 1 when all nodes fail."""
+    exc = kubernetes.client.exceptions.ApiException(status=404, reason="NotFound")
+    with patch("nnf.commands.rabbit.drain._annotate_storage", side_effect=exc):
+        rc = run(_make_args(nodes=["rabbit-0", "rabbit-1"]))
+
+    assert rc == 1

--- a/tools/nnf/tests/test_rabbit_enable.py
+++ b/tools/nnf/tests/test_rabbit_enable.py
@@ -1,0 +1,79 @@
+"""Tests for the rabbit enable sub-command."""
+
+import argparse
+from typing import Dict
+from unittest.mock import patch
+
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+
+from nnf.commands.rabbit.enable import _enable_storage, run
+
+
+def _make_args(**kwargs: object) -> argparse.Namespace:
+    defaults: Dict[str, object] = {
+        "nodes": ["rabbit-0"],
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# _enable_storage
+# ---------------------------------------------------------------------------
+
+
+def test_enable_storage_patches_state_and_removes_annotations() -> None:
+    """_enable_storage sets spec.state to Enabled and nulls disable annotations."""
+    with patch("nnf.commands.rabbit.enable.k8s.patch_object") as mock_patch:
+        _enable_storage("rabbit-0")
+
+    mock_patch.assert_called_once()
+    _, kwargs = mock_patch.call_args
+    assert kwargs["name"] == "rabbit-0"
+    body = kwargs["body"]
+    assert body["spec"]["state"] == "Enabled"
+    annotations = body["metadata"]["annotations"]
+    assert annotations["disable_date"] is None
+    assert annotations["disable_reason"] is None
+
+
+# ---------------------------------------------------------------------------
+# run()
+# ---------------------------------------------------------------------------
+
+
+def test_run_success_single_node() -> None:
+    """run() returns 0 for a single successful enable."""
+    with patch("nnf.commands.rabbit.enable._enable_storage"):
+        rc = run(_make_args())
+
+    assert rc == 0
+
+
+def test_run_success_multiple_nodes() -> None:
+    """run() enables every node in the list."""
+    with patch("nnf.commands.rabbit.enable._enable_storage") as mock_en:
+        rc = run(_make_args(nodes=["rabbit-0", "rabbit-1", "rabbit-2"]))
+
+    assert rc == 0
+    assert mock_en.call_count == 3
+
+
+def test_run_failure_continues_to_next_node() -> None:
+    """run() continues to the next node when one fails."""
+    exc = kubernetes.client.exceptions.ApiException(status=404, reason="NotFound")
+    with patch("nnf.commands.rabbit.enable._enable_storage",
+               side_effect=[exc, None]) as mock_en:
+        rc = run(_make_args(nodes=["bad-node", "good-node"]))
+
+    assert rc == 1
+    assert mock_en.call_count == 2
+
+
+def test_run_all_fail_returns_1() -> None:
+    """run() returns 1 when all nodes fail."""
+    exc = kubernetes.client.exceptions.ApiException(status=500, reason="InternalError")
+    with patch("nnf.commands.rabbit.enable._enable_storage", side_effect=exc):
+        rc = run(_make_args(nodes=["rabbit-0", "rabbit-1"]))
+
+    assert rc == 1

--- a/tools/nnf/tests/test_rabbit_undrain.py
+++ b/tools/nnf/tests/test_rabbit_undrain.py
@@ -1,0 +1,153 @@
+"""Tests for the rabbit undrain sub-command."""
+
+import argparse
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+import pytest
+
+from nnf.commands.rabbit.drain import TAINT_KEY, _remove_drain_annotations
+from nnf.commands.rabbit.undrain import (
+    _remove_drain_taints,
+    run,
+)
+
+
+def _make_args(**kwargs: object) -> argparse.Namespace:
+    defaults: Dict[str, object] = {
+        "nodes": ["rabbit-0"],
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def _make_taint(key: str, value: str, effect: str) -> MagicMock:
+    t = MagicMock()
+    t.key = key
+    t.value = value
+    t.effect = effect
+    return t
+
+
+def _make_node(existing_taints: Optional[List[Any]] = None) -> MagicMock:
+    node = MagicMock()
+    node.spec.taints = existing_taints
+    return node
+
+
+# ---------------------------------------------------------------------------
+# _remove_drain_taints
+# ---------------------------------------------------------------------------
+
+
+def test_remove_drain_taints_removes_drain_keeps_others() -> None:
+    """Drain taints are removed; other taints are preserved."""
+    drain_taint = _make_taint(TAINT_KEY, "true", "NoSchedule")
+    other_taint = _make_taint("other-key", "val", "NoSchedule")
+    node = _make_node([drain_taint, other_taint])
+    with patch("nnf.commands.rabbit.undrain.k8s.get_core_v1_api") as mock_api_fn, \
+            patch("nnf.commands.rabbit.undrain.k8s.patch_node") as mock_patch:
+        mock_api_fn.return_value.read_node.return_value = node
+        _remove_drain_taints("rabbit-0")
+
+    body = mock_patch.call_args[0][1]
+    taints = body["spec"]["taints"]
+    assert len(taints) == 1
+    assert taints[0]["key"] == "other-key"
+
+
+def test_remove_drain_taints_sets_none_when_no_taints_remain() -> None:
+    """Taints field is set to None when no taints remain."""
+    drain_taint = _make_taint(TAINT_KEY, "true", "NoExecute")
+    node = _make_node([drain_taint])
+    with patch("nnf.commands.rabbit.undrain.k8s.get_core_v1_api") as mock_api_fn, \
+            patch("nnf.commands.rabbit.undrain.k8s.patch_node") as mock_patch:
+        mock_api_fn.return_value.read_node.return_value = node
+        _remove_drain_taints("rabbit-0")
+
+    body = mock_patch.call_args[0][1]
+    assert body["spec"]["taints"] is None
+
+
+def test_remove_drain_taints_no_existing_taints() -> None:
+    """No error when node has no taints at all."""
+    node = _make_node(None)
+    with patch("nnf.commands.rabbit.undrain.k8s.get_core_v1_api") as mock_api_fn, \
+            patch("nnf.commands.rabbit.undrain.k8s.patch_node") as mock_patch:
+        mock_api_fn.return_value.read_node.return_value = node
+        _remove_drain_taints("rabbit-0")
+
+    body = mock_patch.call_args[0][1]
+    assert body["spec"]["taints"] is None
+
+
+# ---------------------------------------------------------------------------
+# _remove_drain_annotations
+# ---------------------------------------------------------------------------
+
+
+def test_remove_drain_annotations_nulls_annotations() -> None:
+    """_remove_drain_annotations sends None for both drain annotations."""
+    with patch("nnf.commands.rabbit.undrain.k8s.patch_object") as mock_patch:
+        _remove_drain_annotations("rabbit-0")
+
+    _, kwargs = mock_patch.call_args
+    assert kwargs["name"] == "rabbit-0"
+    annotations = kwargs["body"]["metadata"]["annotations"]
+    assert annotations["drain_date"] is None
+    assert annotations["drain_reason"] is None
+
+
+# ---------------------------------------------------------------------------
+# run()
+# ---------------------------------------------------------------------------
+
+
+def test_run_success_single_node() -> None:
+    """run() returns 0 for a single successful undrain."""
+    with patch("nnf.commands.rabbit.undrain._remove_drain_taints"), \
+            patch("nnf.commands.rabbit.undrain._remove_drain_annotations"):
+        rc = run(_make_args())
+
+    assert rc == 0
+
+
+def test_run_success_multiple_nodes() -> None:
+    """run() undrains every node in the list."""
+    with patch("nnf.commands.rabbit.undrain._remove_drain_taints"), \
+            patch("nnf.commands.rabbit.undrain._remove_drain_annotations") as mock_ann:
+        rc = run(_make_args(nodes=["rabbit-0", "rabbit-1", "rabbit-2"]))
+
+    assert rc == 0
+    assert mock_ann.call_count == 3
+
+
+def test_run_taint_failure_continues_to_next_node() -> None:
+    """run() continues to the next node when untainting fails."""
+    exc = kubernetes.client.exceptions.ApiException(status=404, reason="NotFound")
+    with patch("nnf.commands.rabbit.undrain._remove_drain_annotations"), \
+            patch("nnf.commands.rabbit.undrain._remove_drain_taints", side_effect=[exc, None]):
+        rc = run(_make_args(nodes=["bad-node", "good-node"]))
+
+    assert rc == 1
+
+
+def test_run_annotation_failure_continues_to_next_node() -> None:
+    """run() continues to the next node when annotation removal fails."""
+    exc = kubernetes.client.exceptions.ApiException(status=500, reason="InternalError")
+    with patch("nnf.commands.rabbit.undrain._remove_drain_annotations",
+                  side_effect=[exc, None]), \
+            patch("nnf.commands.rabbit.undrain._remove_drain_taints"):
+        rc = run(_make_args(nodes=["rabbit-0", "rabbit-1"]))
+
+    assert rc == 1
+
+
+def test_run_all_fail_returns_1() -> None:
+    """run() returns 1 when all nodes fail."""
+    exc = kubernetes.client.exceptions.ApiException(status=404, reason="NotFound")
+    with patch("nnf.commands.rabbit.undrain._remove_drain_annotations", side_effect=exc):
+        rc = run(_make_args(nodes=["rabbit-0", "rabbit-1"]))
+
+    assert rc == 1

--- a/tools/nnf/tests/test_rabbit_undrain.py
+++ b/tools/nnf/tests/test_rabbit_undrain.py
@@ -7,9 +7,9 @@ from unittest.mock import MagicMock, patch
 import kubernetes.client.exceptions  # type: ignore[import-untyped]
 import pytest
 
-from nnf.commands.rabbit.drain import TAINT_KEY, _remove_drain_annotations
+from nnf.commands.rabbit._helpers import TAINT_KEY, remove_drain_annotations
 from nnf.commands.rabbit.undrain import (
-    _remove_drain_taints,
+    remove_drain_taints,
     run,
 )
 
@@ -37,7 +37,7 @@ def _make_node(existing_taints: Optional[List[Any]] = None) -> MagicMock:
 
 
 # ---------------------------------------------------------------------------
-# _remove_drain_taints
+# remove_drain_taints
 # ---------------------------------------------------------------------------
 
 
@@ -46,10 +46,10 @@ def test_remove_drain_taints_removes_drain_keeps_others() -> None:
     drain_taint = _make_taint(TAINT_KEY, "true", "NoSchedule")
     other_taint = _make_taint("other-key", "val", "NoSchedule")
     node = _make_node([drain_taint, other_taint])
-    with patch("nnf.commands.rabbit.undrain.k8s.get_core_v1_api") as mock_api_fn, \
-            patch("nnf.commands.rabbit.undrain.k8s.patch_node") as mock_patch:
+    with patch("nnf.commands.rabbit._helpers.k8s.get_core_v1_api") as mock_api_fn, \
+            patch("nnf.commands.rabbit._helpers.k8s.patch_node") as mock_patch:
         mock_api_fn.return_value.read_node.return_value = node
-        _remove_drain_taints("rabbit-0")
+        remove_drain_taints("rabbit-0")
 
     body = mock_patch.call_args[0][1]
     taints = body["spec"]["taints"]
@@ -61,10 +61,10 @@ def test_remove_drain_taints_sets_none_when_no_taints_remain() -> None:
     """Taints field is set to None when no taints remain."""
     drain_taint = _make_taint(TAINT_KEY, "true", "NoExecute")
     node = _make_node([drain_taint])
-    with patch("nnf.commands.rabbit.undrain.k8s.get_core_v1_api") as mock_api_fn, \
-            patch("nnf.commands.rabbit.undrain.k8s.patch_node") as mock_patch:
+    with patch("nnf.commands.rabbit._helpers.k8s.get_core_v1_api") as mock_api_fn, \
+            patch("nnf.commands.rabbit._helpers.k8s.patch_node") as mock_patch:
         mock_api_fn.return_value.read_node.return_value = node
-        _remove_drain_taints("rabbit-0")
+        remove_drain_taints("rabbit-0")
 
     body = mock_patch.call_args[0][1]
     assert body["spec"]["taints"] is None
@@ -73,24 +73,24 @@ def test_remove_drain_taints_sets_none_when_no_taints_remain() -> None:
 def test_remove_drain_taints_no_existing_taints() -> None:
     """No error when node has no taints at all."""
     node = _make_node(None)
-    with patch("nnf.commands.rabbit.undrain.k8s.get_core_v1_api") as mock_api_fn, \
-            patch("nnf.commands.rabbit.undrain.k8s.patch_node") as mock_patch:
+    with patch("nnf.commands.rabbit._helpers.k8s.get_core_v1_api") as mock_api_fn, \
+            patch("nnf.commands.rabbit._helpers.k8s.patch_node") as mock_patch:
         mock_api_fn.return_value.read_node.return_value = node
-        _remove_drain_taints("rabbit-0")
+        remove_drain_taints("rabbit-0")
 
     body = mock_patch.call_args[0][1]
     assert body["spec"]["taints"] is None
 
 
 # ---------------------------------------------------------------------------
-# _remove_drain_annotations
+# remove_drain_annotations
 # ---------------------------------------------------------------------------
 
 
 def test_remove_drain_annotations_nulls_annotations() -> None:
-    """_remove_drain_annotations sends None for both drain annotations."""
-    with patch("nnf.commands.rabbit.undrain.k8s.patch_object") as mock_patch:
-        _remove_drain_annotations("rabbit-0")
+    """remove_drain_annotations sends None for both drain annotations."""
+    with patch("nnf.commands.rabbit._helpers.k8s.patch_object") as mock_patch:
+        remove_drain_annotations("rabbit-0")
 
     _, kwargs = mock_patch.call_args
     assert kwargs["name"] == "rabbit-0"
@@ -106,8 +106,8 @@ def test_remove_drain_annotations_nulls_annotations() -> None:
 
 def test_run_success_single_node() -> None:
     """run() returns 0 for a single successful undrain."""
-    with patch("nnf.commands.rabbit.undrain._remove_drain_taints"), \
-            patch("nnf.commands.rabbit.undrain._remove_drain_annotations"):
+    with patch("nnf.commands.rabbit.undrain.remove_drain_taints"), \
+            patch("nnf.commands.rabbit.undrain.remove_drain_annotations"):
         rc = run(_make_args())
 
     assert rc == 0
@@ -115,8 +115,8 @@ def test_run_success_single_node() -> None:
 
 def test_run_success_multiple_nodes() -> None:
     """run() undrains every node in the list."""
-    with patch("nnf.commands.rabbit.undrain._remove_drain_taints"), \
-            patch("nnf.commands.rabbit.undrain._remove_drain_annotations") as mock_ann:
+    with patch("nnf.commands.rabbit.undrain.remove_drain_taints"), \
+            patch("nnf.commands.rabbit.undrain.remove_drain_annotations") as mock_ann:
         rc = run(_make_args(nodes=["rabbit-0", "rabbit-1", "rabbit-2"]))
 
     assert rc == 0
@@ -126,8 +126,8 @@ def test_run_success_multiple_nodes() -> None:
 def test_run_taint_failure_continues_to_next_node() -> None:
     """run() continues to the next node when untainting fails."""
     exc = kubernetes.client.exceptions.ApiException(status=404, reason="NotFound")
-    with patch("nnf.commands.rabbit.undrain._remove_drain_annotations"), \
-            patch("nnf.commands.rabbit.undrain._remove_drain_taints", side_effect=[exc, None]):
+    with patch("nnf.commands.rabbit.undrain.remove_drain_taints", side_effect=[exc, None]), \
+            patch("nnf.commands.rabbit.undrain.remove_drain_annotations"):
         rc = run(_make_args(nodes=["bad-node", "good-node"]))
 
     assert rc == 1
@@ -136,9 +136,9 @@ def test_run_taint_failure_continues_to_next_node() -> None:
 def test_run_annotation_failure_continues_to_next_node() -> None:
     """run() continues to the next node when annotation removal fails."""
     exc = kubernetes.client.exceptions.ApiException(status=500, reason="InternalError")
-    with patch("nnf.commands.rabbit.undrain._remove_drain_annotations",
-                  side_effect=[exc, None]), \
-            patch("nnf.commands.rabbit.undrain._remove_drain_taints"):
+    with patch("nnf.commands.rabbit.undrain.remove_drain_taints"), \
+            patch("nnf.commands.rabbit.undrain.remove_drain_annotations",
+                  side_effect=[exc, None]):
         rc = run(_make_args(nodes=["rabbit-0", "rabbit-1"]))
 
     assert rc == 1
@@ -147,7 +147,7 @@ def test_run_annotation_failure_continues_to_next_node() -> None:
 def test_run_all_fail_returns_1() -> None:
     """run() returns 1 when all nodes fail."""
     exc = kubernetes.client.exceptions.ApiException(status=404, reason="NotFound")
-    with patch("nnf.commands.rabbit.undrain._remove_drain_annotations", side_effect=exc):
+    with patch("nnf.commands.rabbit.undrain.remove_drain_taints", side_effect=exc):
         rc = run(_make_args(nodes=["rabbit-0", "rabbit-1"]))
 
     assert rc == 1


### PR DESCRIPTION
This commit adds some more commands to the nnf tool to manage Rabbit nodes. Specifically, it adds: drain, undrain, disable, enable, and df.

This commit also changes the format of the persistent create and destroy commands to allow better grouping of commands. The format is now: nnf persistent create/destroy ...