### PR TITLE
Add more subcommands to nnf script

### DIFF
--- a/tools/nnf/README.md
+++ b/tools/nnf/README.md
@@ -10,10 +10,12 @@ The `nnf` command is intended as a repository-local helper tool, not a standalon
 
 - create a persistent storage instance for testing
 - destroy a persistent storage instance
+- share or unshare a persistent storage instance across users
 - inspect and drive workflow-based storage operations from a simple CLI
 - drain or undrain Rabbit nodes to control workflow scheduling
 - disable or enable Rabbit nodes to control workload manager allocations
 - check disk space usage on Rabbit nodes
+- view cluster-level state summaries, FlowSchema information, and controller versions
 
 The command operates against an existing Kubernetes environment where the relevant NNF and DWS CRDs are already installed.
 
@@ -62,7 +64,10 @@ Show command-specific help:
 ```bash
 nnf persistent create --help
 nnf persistent destroy --help
+nnf persistent share --help
+nnf persistent unshare --help
 nnf rabbit --help
+nnf system --help
 ```
 
 Enable verbose workflow logging:
@@ -207,6 +212,44 @@ Destroy a persistent storage instance:
 nnf persistent destroy --name demo-psi
 ```
 
+## persistent share
+
+Share a persistent storage instance so that any user can access it, regardless of UID. This adds the `nnf.cray.hpe.com/ignore-uid` annotation to the PersistentStorageInstance.
+
+```bash
+nnf persistent share --help
+```
+
+Key flags:
+
+- `--name` required name of the persistent storage instance to share
+- `--namespace` target namespace, default `default`
+
+Share a persistent storage instance:
+
+```bash
+nnf persistent share --name demo-psi
+```
+
+## persistent unshare
+
+Unshare a persistent storage instance so that only the owning user can access it. This removes the `nnf.cray.hpe.com/ignore-uid` annotation from the PersistentStorageInstance.
+
+```bash
+nnf persistent unshare --help
+```
+
+Key flags:
+
+- `--name` required name of the persistent storage instance to unshare
+- `--namespace` target namespace, default `default`
+
+Unshare a persistent storage instance:
+
+```bash
+nnf persistent unshare --name demo-psi
+```
+
 ## rabbit drain
 
 Drain one or more Rabbit nodes so that no new workflows are scheduled to them. This taints the Kubernetes node with `cray.nnf.node.drain=true` (both `NoSchedule` and `NoExecute`) and annotates the corresponding DWS Storage resource with `drain_date` and `drain_reason`.
@@ -285,20 +328,89 @@ nnf rabbit enable rabbit-node-0
 
 Show disk space information for Rabbit nodes. Queries each Rabbit's node-manager pod for NVMe capacity information via the Redfish CapacitySource endpoint.
 
+> **Note:** This command has moved to `nnf system df`. The `rabbit df` form is no longer available.
+
 ```bash
-nnf rabbit df --help
+nnf system df --help
 ```
 
 Show disk space for all enabled and ready Rabbits:
 
 ```bash
-nnf rabbit df
+nnf system df
 ```
 
 Show disk space for specific nodes:
 
 ```bash
-nnf rabbit df rabbit-node-0 rabbit-node-1
+nnf system df rabbit-node-0 rabbit-node-1
+```
+
+## system state
+
+Report the state of Rabbit storage resources. Displays a summary of NnfNode server health/status and DWS Storage state/status, including disabled and drained nodes with their reasons. If `flux` is available, also shows compute nodes paired with unavailable Rabbits.
+
+```bash
+nnf system state --help
+```
+
+Show the cluster state summary:
+
+```bash
+nnf system state
+```
+
+## system flowschema
+
+Display Kubernetes FlowSchema and API Priority and Fairness information. Useful for diagnosing API throttling issues.
+
+```bash
+nnf system flowschema --help
+```
+
+Key flags (mutually exclusive, one is required):
+
+- `-l` list flow schemas with their priority levels
+- `-p` list priority level configurations
+- `-c NAME` view metrics for a specific flow schema
+- `-s` summary of requests by priority level
+
+List all flow schemas:
+
+```bash
+nnf system flowschema -l
+```
+
+List priority level configurations:
+
+```bash
+nnf system flowschema -p
+```
+
+View activity for a specific flow schema:
+
+```bash
+nnf system flowschema -c nnf-webhook
+```
+
+View priority level summary:
+
+```bash
+nnf system flowschema -s
+```
+
+## system version
+
+Display version information for the NNF controller by reading labels from the `nnf-controller-manager` Deployment in the `nnf-system` namespace.
+
+```bash
+nnf system version --help
+```
+
+Show the NNF controller version:
+
+```bash
+nnf system version
 ```
 
 ## Development notes

--- a/tools/nnf/README.md
+++ b/tools/nnf/README.md
@@ -214,7 +214,7 @@ nnf persistent destroy --name demo-psi
 
 ## persistent share
 
-Share a persistent storage instance so that any user can access it, regardless of UID. This adds the `nnf.cray.hpe.com/ignore-uid` annotation to the PersistentStorageInstance.
+Share a persistent storage instance so that any user can access it, regardless of UID. This adds the `dataworkflowservices.github.io/ignore-uid` annotation to the PersistentStorageInstance.
 
 ```bash
 nnf persistent share --help
@@ -233,7 +233,7 @@ nnf persistent share --name demo-psi
 
 ## persistent unshare
 
-Unshare a persistent storage instance so that only the owning user can access it. This removes the `nnf.cray.hpe.com/ignore-uid` annotation from the PersistentStorageInstance.
+Unshare a persistent storage instance so that only the owning user can access it. This removes the `dataworkflowservices.github.io/ignore-uid` annotation from the PersistentStorageInstance.
 
 ```bash
 nnf persistent unshare --help

--- a/tools/nnf/src/nnf/commands/__init__.py
+++ b/tools/nnf/src/nnf/commands/__init__.py
@@ -12,7 +12,7 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
         "--verbose",
         action="store_true",
         default=argparse.SUPPRESS,
-        help="Enable verbose logging for workflow progress and Kubernetes operations.",
+        help="Enable verbose logging.",
     )
 
 

--- a/tools/nnf/src/nnf/commands/persistent/__init__.py
+++ b/tools/nnf/src/nnf/commands/persistent/__init__.py
@@ -3,7 +3,7 @@
 import argparse
 
 from nnf.commands import add_command_parser
-from nnf.commands.persistent import create, destroy
+from nnf.commands.persistent import create, destroy, share, unshare
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
@@ -18,3 +18,5 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
 
     create.register(sub)
     destroy.register(sub)
+    share.register(sub)
+    unshare.register(sub)

--- a/tools/nnf/src/nnf/commands/persistent/create.py
+++ b/tools/nnf/src/nnf/commands/persistent/create.py
@@ -241,5 +241,5 @@ def run(args: argparse.Namespace) -> int:
 
     rc = workflow.create_and_run(wf, args.timeout)
     if rc == 0:
-        print(f"Persistent storage '{args.name}' created successfully.")
+        print(f"Created persistent storage '{args.name}'.")
     return rc

--- a/tools/nnf/src/nnf/commands/persistent/destroy.py
+++ b/tools/nnf/src/nnf/commands/persistent/destroy.py
@@ -10,6 +10,10 @@ import logging
 import os
 import sys
 
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+
+from nnf import crd
+from nnf import k8s
 from nnf import utils
 from nnf import workflow
 from nnf.commands import add_command_parser, add_workflow_arguments
@@ -34,6 +38,18 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     parser.set_defaults(func=run)
 
 
+def _get_psi_user_id(name: str, namespace: str) -> int:
+    """Fetch the userID from the PersistentStorageInstance spec."""
+    psi = k8s.get_object(
+        group=crd.DWS_GROUP,
+        version=crd.DWS_VERSION,
+        namespace=namespace,
+        plural=crd.DWS_PERSISTENT_STORAGE_PLURAL,
+        name=name,
+    )
+    return int(psi["spec"]["userID"])
+
+
 def run(args: argparse.Namespace) -> int:
     """Execute the persistent destroy sub-command."""
     try:
@@ -42,7 +58,24 @@ def run(args: argparse.Namespace) -> int:
         print(f"error: invalid --name: {exc}", file=sys.stderr)
         return 1
 
-    user_id: int = args.user_id if args.user_id is not None else os.getuid()
+    user_id: int
+    if args.user_id is not None:
+        user_id = args.user_id
+    else:
+        try:
+            user_id = _get_psi_user_id(args.name, args.namespace)
+        except kubernetes.client.exceptions.ApiException as exc:
+            print(
+                f"error: failed to get PersistentStorageInstance '{args.name}': {exc.reason}",
+                file=sys.stderr,
+            )
+            return 1
+        except (KeyError, ValueError) as exc:
+            print(
+                f"error: could not read userID from PersistentStorageInstance '{args.name}': {exc}",
+                file=sys.stderr,
+            )
+            return 1
     group_id: int = args.group_id if args.group_id is not None else os.getgid()
     dw_directive = f"#DW destroy_persistent name={args.name}"
 
@@ -57,5 +90,5 @@ def run(args: argparse.Namespace) -> int:
 
     rc = workflow.create_and_run(wf, args.timeout)
     if rc == 0:
-        print(f"Persistent storage '{args.name}' destroyed successfully.")
+        print(f"Destroyed persistent storage '{args.name}'.")
     return rc

--- a/tools/nnf/src/nnf/commands/persistent/share.py
+++ b/tools/nnf/src/nnf/commands/persistent/share.py
@@ -1,0 +1,62 @@
+"""persistent share sub-command: mark a PSI as shared (ignore UID checks).
+
+Adds the ``nnf.cray.hpe.com/ignore-uid`` annotation to the
+PersistentStorageInstance so that any user may access it.
+"""
+
+import argparse
+import sys
+
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+
+from nnf import crd
+from nnf import k8s
+from nnf.commands import add_command_parser
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the persistent share sub-command."""
+    parser: argparse.ArgumentParser = add_command_parser(
+        subparsers,
+        "share",
+        help="Share a persistent storage instance (add ignore-uid annotation).",
+    )
+    parser.add_argument(
+        "--name",
+        required=True,
+        help="Name of the persistent storage instance to share.",
+    )
+    parser.add_argument(
+        "--namespace",
+        default="default",
+        help="Kubernetes namespace (default: default).",
+    )
+    parser.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the persistent share sub-command."""
+    body = {
+        "metadata": {
+            "annotations": {
+                crd.NNF_IGNORE_UID_ANNOTATION: "true",
+            }
+        }
+    }
+    try:
+        k8s.patch_object(
+            group=crd.DWS_GROUP,
+            version=crd.DWS_VERSION,
+            namespace=args.namespace,
+            plural=crd.DWS_PERSISTENT_STORAGE_PLURAL,
+            name=args.name,
+            body=body,
+        )
+    except kubernetes.client.exceptions.ApiException as exc:
+        print(
+            f"error: failed to share PersistentStorageInstance '{args.name}': {exc.reason}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Shared persistent storage '{args.name}'.")
+    return 0

--- a/tools/nnf/src/nnf/commands/persistent/share.py
+++ b/tools/nnf/src/nnf/commands/persistent/share.py
@@ -1,6 +1,6 @@
 """persistent share sub-command: mark a PSI as shared (ignore UID checks).
 
-Adds the ``nnf.cray.hpe.com/ignore-uid`` annotation to the
+Adds the ``dataworkflowservices.github.io/ignore-uid`` annotation to the
 PersistentStorageInstance so that any user may access it.
 """
 
@@ -39,7 +39,7 @@ def run(args: argparse.Namespace) -> int:
     body = {
         "metadata": {
             "annotations": {
-                crd.NNF_IGNORE_UID_ANNOTATION: "true",
+                crd.DWS_IGNORE_UID_ANNOTATION: "true",
             }
         }
     }

--- a/tools/nnf/src/nnf/commands/persistent/unshare.py
+++ b/tools/nnf/src/nnf/commands/persistent/unshare.py
@@ -1,6 +1,6 @@
 """persistent unshare sub-command: remove shared access from a PSI.
 
-Removes the ``nnf.cray.hpe.com/ignore-uid`` annotation from the
+Removes the ``dataworkflowservices.github.io/ignore-uid`` annotation from the
 PersistentStorageInstance so that only the owning user may access it.
 """
 
@@ -39,7 +39,7 @@ def run(args: argparse.Namespace) -> int:
     body = {
         "metadata": {
             "annotations": {
-                crd.NNF_IGNORE_UID_ANNOTATION: None,
+                crd.DWS_IGNORE_UID_ANNOTATION: None,
             }
         }
     }

--- a/tools/nnf/src/nnf/commands/persistent/unshare.py
+++ b/tools/nnf/src/nnf/commands/persistent/unshare.py
@@ -1,0 +1,62 @@
+"""persistent unshare sub-command: remove shared access from a PSI.
+
+Removes the ``nnf.cray.hpe.com/ignore-uid`` annotation from the
+PersistentStorageInstance so that only the owning user may access it.
+"""
+
+import argparse
+import sys
+
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+
+from nnf import crd
+from nnf import k8s
+from nnf.commands import add_command_parser
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the persistent unshare sub-command."""
+    parser: argparse.ArgumentParser = add_command_parser(
+        subparsers,
+        "unshare",
+        help="Unshare a persistent storage instance (remove ignore-uid annotation).",
+    )
+    parser.add_argument(
+        "--name",
+        required=True,
+        help="Name of the persistent storage instance to unshare.",
+    )
+    parser.add_argument(
+        "--namespace",
+        default="default",
+        help="Kubernetes namespace (default: default).",
+    )
+    parser.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the persistent unshare sub-command."""
+    body = {
+        "metadata": {
+            "annotations": {
+                crd.NNF_IGNORE_UID_ANNOTATION: None,
+            }
+        }
+    }
+    try:
+        k8s.patch_object(
+            group=crd.DWS_GROUP,
+            version=crd.DWS_VERSION,
+            namespace=args.namespace,
+            plural=crd.DWS_PERSISTENT_STORAGE_PLURAL,
+            name=args.name,
+            body=body,
+        )
+    except kubernetes.client.exceptions.ApiException as exc:
+        print(
+            f"error: failed to unshare PersistentStorageInstance '{args.name}': {exc.reason}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Unshared persistent storage '{args.name}'.")
+    return 0

--- a/tools/nnf/src/nnf/commands/rabbit/__init__.py
+++ b/tools/nnf/src/nnf/commands/rabbit/__init__.py
@@ -3,7 +3,7 @@
 import argparse
 
 from nnf.commands import add_command_parser
-from nnf.commands.rabbit import df, disable, drain, enable, undrain
+from nnf.commands.rabbit import disable, drain, enable, undrain
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
@@ -16,7 +16,6 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     sub = rabbit_parser.add_subparsers(dest="rabbit_command", metavar="<action>")
     sub.required = True
 
-    df.register(sub)
     disable.register(sub)
     drain.register(sub)
     enable.register(sub)

--- a/tools/nnf/src/nnf/commands/system/__init__.py
+++ b/tools/nnf/src/nnf/commands/system/__init__.py
@@ -1,0 +1,22 @@
+"""system sub-command group: cluster-level administration."""
+
+import argparse
+
+from nnf.commands import add_command_parser
+from nnf.commands.system import df, flowschema, state, version
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the system sub-command group."""
+    system_parser: argparse.ArgumentParser = add_command_parser(
+        subparsers,
+        "system",
+        help="Cluster-level administration.",
+    )
+    sub = system_parser.add_subparsers(dest="system_command", metavar="<action>")
+    sub.required = True
+
+    df.register(sub)
+    flowschema.register(sub)
+    state.register(sub)
+    version.register(sub)

--- a/tools/nnf/src/nnf/commands/system/df.py
+++ b/tools/nnf/src/nnf/commands/system/df.py
@@ -36,7 +36,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
         "nodes",
         nargs="*",
         metavar="NODE",
-        help="Rabbit node names to query (default: all Enabled/Ready rabbits).",
+        help="Rabbit node names to query. If omitted, queries all Enabled/Ready rabbits.",
     )
     parser.set_defaults(func=run)
 

--- a/tools/nnf/src/nnf/commands/system/flowschema.py
+++ b/tools/nnf/src/nnf/commands/system/flowschema.py
@@ -141,7 +141,7 @@ def _list_priority_levels(api_version: str) -> int:
     return 0
 
 
-def _view_activity(api_version: str, cred_name: str) -> int:
+def _view_activity(api_version: str, flow_schema_name: str) -> int:
     """View metrics for a specific FlowSchema."""
     path = f"/apis/{_FLOWCONTROL_GROUP}/{api_version}/flowschemas"
     try:
@@ -153,7 +153,7 @@ def _view_activity(api_version: str, cred_name: str) -> int:
     data = json.loads(raw)
     names = [item["metadata"]["name"] for item in data.get("items", [])]
 
-    if cred_name not in names:
+    if flow_schema_name not in names:
         print("Valid flowschema NAMEs are:")
         for name in sorted(names):
             print(name)
@@ -165,7 +165,7 @@ def _view_activity(api_version: str, cred_name: str) -> int:
         print(f"error: failed to get metrics: {exc.reason}", file=sys.stderr)
         return 1
 
-    target = f'flow_schema="{cred_name}"'
+    target = f'flow_schema="{flow_schema_name}"'
     for line in metrics.splitlines():
         if target in line:
             print(line)

--- a/tools/nnf/src/nnf/commands/system/flowschema.py
+++ b/tools/nnf/src/nnf/commands/system/flowschema.py
@@ -1,0 +1,205 @@
+"""system flowschema sub-command: display FlowSchema information.
+
+Full documentation at:
+https://nearnodeflash.github.io/latest/guides/monitoring-cluster/api-priority-and-fairness/
+https://kubernetes.io/docs/concepts/cluster-administration/flow-control/
+"""
+
+import argparse
+import json
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+
+from nnf import k8s
+from nnf.commands import add_command_parser
+from nnf.table import print_table as _print_table
+
+
+_FLOWCONTROL_GROUP = "flowcontrol.apiserver.k8s.io"
+_API_VERSIONS = ["v1", "v1beta3", "v1beta2"]
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the system flowschema sub-command."""
+    parser: argparse.ArgumentParser = add_command_parser(
+        subparsers,
+        "flowschema",
+        help="Display FlowSchema information.",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "-c",
+        "--activity",
+        dest="flow_schema_name",
+        metavar="NAME",
+        help="View activity for a specific flow schema.",
+    )
+    group.add_argument(
+        "-l",
+        "--list",
+        dest="list_flowschemas",
+        action="store_true",
+        help="List flow schemas.",
+    )
+    group.add_argument(
+        "-p",
+        "--priority-levels",
+        dest="priority_levels",
+        action="store_true",
+        help="List priority level configurations.",
+    )
+    group.add_argument(
+        "-s",
+        "--summary",
+        dest="summary",
+        action="store_true",
+        help="Summary of requests by priority level.",
+    )
+    parser.set_defaults(func=run)
+
+
+def _discover_api_version() -> Optional[str]:
+    """Find an available API version for the flowcontrol group."""
+    try:
+        raw = k8s.get_raw(f"/apis/{_FLOWCONTROL_GROUP}")
+        data = json.loads(raw)
+        available = [v["version"] for v in data.get("versions", [])]
+        for version in _API_VERSIONS:
+            if version in available:
+                return version
+    except (kubernetes.client.exceptions.ApiException, json.JSONDecodeError, KeyError):
+        pass
+    return None
+
+
+def _list_flowschemas(api_version: str) -> int:
+    """List all FlowSchema resources."""
+    path = f"/apis/{_FLOWCONTROL_GROUP}/{api_version}/flowschemas"
+    try:
+        raw = k8s.get_raw(path)
+    except kubernetes.client.exceptions.ApiException as exc:
+        print(f"error: failed to list flow schemas: {exc.reason}", file=sys.stderr)
+        return 1
+
+    data = json.loads(raw)
+    items = sorted(data.get("items", []), key=lambda i: i["metadata"]["name"])
+
+    rows: List[Tuple[str, ...]] = []
+    for item in items:
+        name = item["metadata"]["name"]
+        spec = item.get("spec", {})
+        pl = spec.get("priorityLevelConfiguration", {}).get("name", "")
+        precedence = str(spec.get("matchingPrecedence", ""))
+        dm = spec.get("distinguisherMethod")
+        dm_type = dm.get("type", "") if dm else ""
+        rows.append((name, pl, precedence, dm_type))
+
+    _print_table(
+        ("NAME", "PRIORITYLEVEL", "MATCHINGPRECEDENCE", "DISTINGUISHERMETHOD"),
+        rows,
+    )
+    return 0
+
+
+def _list_priority_levels(api_version: str) -> int:
+    """List all PriorityLevelConfiguration resources."""
+    path = f"/apis/{_FLOWCONTROL_GROUP}/{api_version}/prioritylevelconfigurations"
+    try:
+        raw = k8s.get_raw(path)
+    except kubernetes.client.exceptions.ApiException as exc:
+        print(
+            f"error: failed to list priority level configurations: {exc.reason}",
+            file=sys.stderr,
+        )
+        return 1
+
+    data = json.loads(raw)
+    items = sorted(data.get("items", []), key=lambda i: i["metadata"]["name"])
+
+    rows: List[Tuple[str, ...]] = []
+    for item in items:
+        name = item["metadata"]["name"]
+        spec = item.get("spec", {})
+        type_val = spec.get("type", "")
+        limited = spec.get("limited")
+        if limited:
+            shares = str(limited.get("nominalConcurrencyShares", ""))
+            queuing = limited.get("limitResponse", {}).get("queuing", {})
+            queues = str(queuing.get("queues", "")) if queuing else ""
+            hand_size = str(queuing.get("handSize", "")) if queuing else ""
+            queue_len = str(queuing.get("queueLengthLimit", "")) if queuing else ""
+        else:
+            shares = queues = hand_size = queue_len = ""
+        rows.append((name, type_val, shares, queues, hand_size, queue_len))
+
+    _print_table(
+        ("NAME", "TYPE", "NOMINALCONCURRENCYSHARES", "QUEUES", "HANDSIZE", "QUEUELENGTHLIMIT"),
+        rows,
+    )
+    return 0
+
+
+def _view_activity(api_version: str, cred_name: str) -> int:
+    """View metrics for a specific FlowSchema."""
+    path = f"/apis/{_FLOWCONTROL_GROUP}/{api_version}/flowschemas"
+    try:
+        raw = k8s.get_raw(path)
+    except kubernetes.client.exceptions.ApiException as exc:
+        print(f"error: failed to list flow schemas: {exc.reason}", file=sys.stderr)
+        return 1
+
+    data = json.loads(raw)
+    names = [item["metadata"]["name"] for item in data.get("items", [])]
+
+    if cred_name not in names:
+        print("Valid flowschema NAMEs are:")
+        for name in sorted(names):
+            print(name)
+        return 1
+
+    try:
+        metrics = k8s.get_raw("/metrics")
+    except kubernetes.client.exceptions.ApiException as exc:
+        print(f"error: failed to get metrics: {exc.reason}", file=sys.stderr)
+        return 1
+
+    target = f'flow_schema="{cred_name}"'
+    for line in metrics.splitlines():
+        if target in line:
+            print(line)
+    return 0
+
+
+def _view_summary() -> int:
+    """Dump priority level information."""
+    try:
+        raw = k8s.get_raw("/debug/api_priority_and_fairness/dump_priority_levels")
+    except kubernetes.client.exceptions.ApiException as exc:
+        print(
+            f"error: failed to get priority level dump: {exc.reason}",
+            file=sys.stderr,
+        )
+        return 1
+    print(raw, end="")
+    return 0
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the system flowschema sub-command."""
+    if args.summary:
+        return _view_summary()
+
+    api_version = _discover_api_version()
+    if api_version is None:
+        print("error: flowcontrol API is not available on this cluster", file=sys.stderr)
+        return 1
+
+    if args.flow_schema_name:
+        return _view_activity(api_version, args.flow_schema_name)
+    elif args.list_flowschemas:
+        return _list_flowschemas(api_version)
+    elif args.priority_levels:
+        return _list_priority_levels(api_version)
+    return 0

--- a/tools/nnf/src/nnf/commands/system/state.py
+++ b/tools/nnf/src/nnf/commands/system/state.py
@@ -1,0 +1,360 @@
+"""system state sub-command: report the state of Rabbit storage resources.
+
+Displays a summary of NnfNode server health/status and DWS Storage
+state/status, including disabled and drained nodes with their reasons.
+"""
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+
+from nnf import crd
+from nnf import k8s
+from nnf.commands import add_command_parser
+from nnf.table import print_table as _print_table
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+# Health values to scan (in display order).
+_HEALTH_VALUES = ["OK", "Critical", "Warning"]
+
+# Status values for NnfNode servers (in display order).
+_NODE_STATUS_VALUES = [
+    "Ready", "Enabled", "Disabled", "NotPresent", "Offline",
+    "Starting", "Deleting", "Deleted", "Failed", "Invalid", "Fenced",
+]
+
+# State values for Storage resources.
+_STORAGE_STATES = ["Enabled", "Disabled"]
+
+# Status values for Storage resources (in display order).
+_STORAGE_STATUS_VALUES = [
+    "Starting", "Ready", "Disabled", "NotPresent", "Offline",
+    "Failed", "Degraded", "Drained", "Fenced", "Unknown",
+]
+
+_MISSING_BUCKET = "<missing>"
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the system state sub-command."""
+    parser: argparse.ArgumentParser = add_command_parser(
+        subparsers,
+        "state",
+        help="Report the state of Rabbit storage resources.",
+    )
+    parser.set_defaults(func=run)
+
+
+def _compress_hostlist(names: List[str]) -> str:
+    """Compress a list of hostnames into bracketed range notation.
+
+    For example: ["rabbit-node-1", "rabbit-node-2", "rabbit-compute-2",
+    "rabbit-compute-3", "rabbit-compute-4", "rabbit-compute-5"]
+    becomes "rabbit-compute-[2-5],rabbit-node-[1-2]".
+
+    Names that don't end in digits are left as-is.
+    """
+    if not names:
+        return ""
+    if len(names) == 1:
+        return names[0]
+
+    # Split each name into (prefix, number).  Names without a numeric
+    # suffix are kept verbatim in the output.
+    groups: Dict[str, List[int]] = {}
+    plain: List[str] = []
+    for name in sorted(names):
+        i = len(name)
+        while i > 0 and name[i - 1].isdigit():
+            i -= 1
+        if i == len(name) or i == 0:
+            plain.append(name)
+        else:
+            prefix = name[:i]
+            groups.setdefault(prefix, []).append(int(name[i:]))
+
+    parts: List[str] = []
+    for prefix in sorted(groups):
+        nums = sorted(groups[prefix])
+        if len(nums) == 1:
+            parts.append(f"{prefix}{nums[0]}")
+            continue
+        ranges: List[str] = []
+        start = end = nums[0]
+        for n in nums[1:]:
+            if n == end + 1:
+                end = n
+            else:
+                ranges.append(str(start) if start == end else f"{start}-{end}")
+                start = end = n
+        ranges.append(str(start) if start == end else f"{start}-{end}")
+        parts.append(f"{prefix}[{','.join(ranges)}]")
+
+    parts.extend(sorted(plain))
+    return ",".join(parts)
+
+
+def _get_all_nnfnodes() -> List[Dict[str, Any]]:
+    """Fetch all NnfNode resources across all namespaces."""
+    result = k8s.list_cluster_objects(
+        group=crd.NNF_GROUP,
+        version=crd.NNF_VERSION,
+        plural=crd.NNF_NODE_PLURAL,
+    )
+    return result.get("items", [])  # type: ignore[no-any-return]
+
+
+def _get_all_storages() -> List[Dict[str, Any]]:
+    """Fetch all DWS Storage resources from the default namespace."""
+    result = k8s.list_objects(
+        group=crd.DWS_GROUP,
+        version=crd.DWS_VERSION,
+        namespace="default",
+        plural=crd.DWS_STORAGE_PLURAL,
+    )
+    return result.get("items", [])  # type: ignore[no-any-return]
+
+
+def _normalize_bucket(value: Any) -> str:
+    """Normalize state/health values so missing data is still reported."""
+    if value is None:
+        return _MISSING_BUCKET
+    text = str(value).strip()
+    return text if text else _MISSING_BUCKET
+
+
+def _ordered_values(observed: List[str], preferred: List[str]) -> List[str]:
+    """Return observed values ordered by preferred display order, then extras."""
+    extras = sorted({value for value in observed if value not in preferred})
+    return [value for value in preferred if value in observed] + extras
+
+
+def _build_node_status_rows(
+    nnfnodes: List[Dict[str, Any]],
+) -> List[Tuple[str, ...]]:
+    """Build rows for the Node Status Summary table."""
+    grouped_hostnames: Dict[Tuple[str, str], List[str]] = {}
+    observed_healths: List[str] = []
+    observed_statuses: List[str] = []
+
+    for node in nnfnodes:
+        for server in node.get("status", {}).get("servers", []):
+            hostname = server.get("hostname")
+            if not hostname:
+                continue
+            health = _normalize_bucket(server.get("health"))
+            status = _normalize_bucket(server.get("status"))
+            grouped_hostnames.setdefault((health, status), []).append(hostname)
+            observed_healths.append(health)
+            observed_statuses.append(status)
+
+    rows: List[Tuple[str, ...]] = []
+    for health in _ordered_values(observed_healths, _HEALTH_VALUES):
+        for status in _ordered_values(observed_statuses, _NODE_STATUS_VALUES):
+            hostnames = grouped_hostnames.get((health, status), [])
+            if hostnames:
+                hostnames.sort()
+                compressed = _compress_hostlist(hostnames)
+                rows.append((health, status, str(len(hostnames)), compressed))
+    return rows
+
+
+def _build_storage_status_rows(
+    storages: List[Dict[str, Any]],
+) -> List[Tuple[str, ...]]:
+    """Build rows for the Storage Status Summary table."""
+    grouped_names: Dict[Tuple[str, str], List[str]] = {}
+    observed_states: List[str] = []
+    observed_statuses: List[str] = []
+
+    for storage in storages:
+        state = _normalize_bucket(storage.get("spec", {}).get("state"))
+        status = _normalize_bucket(storage.get("status", {}).get("status"))
+        grouped_names.setdefault((state, status), []).append(storage["metadata"]["name"])
+        observed_states.append(state)
+        observed_statuses.append(status)
+
+    rows: List[Tuple[str, ...]] = []
+    for state in _ordered_values(observed_states, _STORAGE_STATES):
+        for status in _ordered_values(observed_statuses, _STORAGE_STATUS_VALUES):
+            names = grouped_names.get((state, status), [])
+            if names:
+                names.sort()
+                compressed = _compress_hostlist(names)
+                rows.append((state, status, str(len(names)), compressed))
+    return rows
+
+
+def _build_annotation_rows(
+    storages: List[Dict[str, Any]],
+) -> List[Tuple[str, ...]]:
+    """Build rows for disabled/drained annotation details."""
+    rows: List[Tuple[str, ...]] = []
+    for s in storages:
+        annotations = s.get("metadata", {}).get("annotations") or {}
+        name = s["metadata"]["name"]
+        if "disable_date" in annotations:
+            rows.append((
+                "Disabled",
+                annotations.get("disable_date", ""),
+                name,
+                annotations.get("disable_reason", ""),
+            ))
+        if "drain_date" in annotations:
+            rows.append((
+                "Drained",
+                annotations.get("drain_date", ""),
+                name,
+                annotations.get("drain_reason", ""),
+            ))
+    return rows
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the system state sub-command."""
+    errors = 0
+
+    # --- Node Status Summary ---
+    print("------------------------------")
+    print("Node Status Summary")
+    print("------------------------------")
+
+    try:
+        nnfnodes = _get_all_nnfnodes()
+    except kubernetes.client.exceptions.ApiException as exc:
+        print(f"error: failed to list NnfNode resources: {exc.reason}", file=sys.stderr)
+        nnfnodes = []
+        errors += 1
+
+    node_rows = _build_node_status_rows(nnfnodes)
+    if node_rows:
+        _print_table(
+            ("HEALTH", "STATUS", "NNODES", "NODELIST"),
+            node_rows,
+            right_align=(0, 1, 2),
+        )
+
+    # --- Storage Status Summary ---
+    print()
+    print("-------------------------------")
+    print("Disabled/Drained Rabbit Summary")
+    print("-------------------------------")
+
+    try:
+        storages = _get_all_storages()
+    except kubernetes.client.exceptions.ApiException as exc:
+        print(f"error: failed to list Storage resources: {exc.reason}", file=sys.stderr)
+        storages = []
+        errors += 1
+
+    storage_rows = _build_storage_status_rows(storages)
+    if storage_rows:
+        _print_table(
+            ("STATE", "STATUS", "NNODES", "NODELIST"),
+            storage_rows,
+            right_align=(0, 1, 2),
+        )
+
+    # --- Annotation details ---
+    annotation_rows = _build_annotation_rows(storages)
+    if annotation_rows:
+        print()
+        _print_table(
+            ("STATE", "DATE", "NODELIST", "REASON"),
+            annotation_rows,
+            right_align=(0,),
+        )
+
+    # --- Disabled Computes (badrabbit+) ---
+    _show_disabled_computes()
+
+    return 1 if errors else 0
+
+
+def _run_cmd(args: List[str]) -> Optional[str]:
+    """Run a command and return its stripped stdout, or None on failure."""
+    try:
+        result = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            LOGGER.info("%s failed (rc=%d): %s", args[0], result.returncode, result.stderr.strip())
+            return None
+        return result.stdout.strip()
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        LOGGER.info("%s: %s", args[0], exc)
+        return None
+
+
+def _show_disabled_computes() -> None:
+    """Show compute nodes paired with unavailable Rabbits, if flux is available."""
+    if shutil.which("flux") is None:
+        LOGGER.info("flux not found, skipping disabled computes section")
+        return
+
+    jgf_output = _run_cmd([
+        "flux", "ion-resource", "find", "-q",
+        "--format", "jgf", "property=badrabbit",
+    ])
+    if not jgf_output:
+        return
+
+    try:
+        jgf = json.loads(jgf_output)
+    except (json.JSONDecodeError, ValueError):
+        LOGGER.info("Failed to parse JGF output")
+        return
+
+    nodes = jgf.get("graph", {}).get("nodes", [])
+    hostnames = []
+    for node in nodes:
+        meta = node.get("metadata", {})
+        if meta.get("type") == "node":
+            hostnames.append(meta.get("basename", "") + str(meta.get("id", "")))
+
+    if not hostnames:
+        return
+
+    hostlist = _run_cmd(["flux", "hostlist"] + hostnames)
+    if not hostlist:
+        hostlist = ", ".join(hostnames)
+
+    print()
+    print("------------------------------")
+    print("Disabled Computes (badrabbit+)")
+    print("------------------------------")
+
+    # Determine whether to use a cluster prefix with nodeattr.
+    scheduling_cfg = _run_cmd(["flux", "config", "get", "resource.scheduling"])
+    if scheduling_cfg and os.path.isfile(scheduling_cfg):
+        cluster_prefix = _run_cmd(["nodeattr", "-v", "cluster"])
+        if cluster_prefix:
+            _run_cmd_print(["flux", "resource", "list", "-i", cluster_prefix + hostlist])
+            return
+
+    _run_cmd_print(["flux", "resource", "list", "-i", hostlist])
+
+
+def _run_cmd_print(args: List[str]) -> None:
+    """Run a command and print its stdout directly."""
+    try:
+        subprocess.run(
+            args,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        LOGGER.info("%s: %s", args[0], exc)

--- a/tools/nnf/src/nnf/commands/system/version.py
+++ b/tools/nnf/src/nnf/commands/system/version.py
@@ -1,0 +1,48 @@
+"""system version sub-command: display NNF controller version labels."""
+
+import argparse
+import json
+import sys
+from typing import Any, Dict
+
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+
+from nnf import k8s
+from nnf.commands import add_command_parser
+
+
+_NNF_SYSTEM_NS = "nnf-system"
+_DEPLOY_NAME = "nnf-controller-manager"
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the system version sub-command."""
+    parser: argparse.ArgumentParser = add_command_parser(
+        subparsers,
+        "version",
+        help="Display version information for the NNF controller.",
+    )
+    parser.set_defaults(func=run)
+
+
+def _get_deployment_labels() -> Dict[str, Any]:
+    """Fetch labels from the nnf-controller-manager Deployment."""
+    deploy = k8s.get_deployment(
+        name=_DEPLOY_NAME,
+        namespace=_NNF_SYSTEM_NS,
+    )
+    return dict(deploy.metadata.labels or {})
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the system version sub-command."""
+    try:
+        labels = _get_deployment_labels()
+    except kubernetes.client.exceptions.ApiException as exc:
+        print(
+            f"error: failed to get deployment {_DEPLOY_NAME}: {exc.reason}",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(labels, indent=2))
+    return 0

--- a/tools/nnf/src/nnf/crd.py
+++ b/tools/nnf/src/nnf/crd.py
@@ -8,6 +8,8 @@ NNF_GROUP = "nnf.cray.hpe.com"
 # Update NNF_VERSION when the NNF CRDs are bumped (e.g. v1alpha11 → v1alpha12).
 NNF_VERSION = "v1alpha11"
 
+NNF_IGNORE_UID_ANNOTATION = "nnf.cray.hpe.com/ignore-uid"
+
 NNF_NODE_PLURAL = "nnfnodes"
 NNF_STORAGE_PLURAL = "nnfstorages"
 NNF_ACCESS_PLURAL = "nnfaccesses"

--- a/tools/nnf/src/nnf/crd.py
+++ b/tools/nnf/src/nnf/crd.py
@@ -8,7 +8,7 @@ NNF_GROUP = "nnf.cray.hpe.com"
 # Update NNF_VERSION when the NNF CRDs are bumped (e.g. v1alpha11 → v1alpha12).
 NNF_VERSION = "v1alpha11"
 
-NNF_IGNORE_UID_ANNOTATION = "nnf.cray.hpe.com/ignore-uid"
+DWS_IGNORE_UID_ANNOTATION = "dataworkflowservices.github.io/ignore-uid"
 
 NNF_NODE_PLURAL = "nnfnodes"
 NNF_STORAGE_PLURAL = "nnfstorages"

--- a/tools/nnf/src/nnf/k8s.py
+++ b/tools/nnf/src/nnf/k8s.py
@@ -68,6 +68,24 @@ def debug_api_group(group: str) -> None:
         LOGGER.info("Could not query API group '%s': %s", group, exc)
 
 
+def get_raw(path: str) -> str:
+    """Make a raw GET request to the Kubernetes API server and return the body."""
+    client = kubernetes.client.ApiClient()
+    resp = client.call_api(
+        path, "GET",
+        auth_settings=["BearerToken"],
+        _preload_content=False,
+        _return_http_data_only=True,
+    )
+    try:
+        data = resp.data
+        if isinstance(data, bytes):
+            data = data.decode("utf-8")
+        return data
+    finally:
+        resp.release_conn()
+
+
 def create_object(
     group: str,
     version: str,
@@ -141,10 +159,21 @@ def get_core_v1_api() -> kubernetes.client.CoreV1Api:
     return kubernetes.client.CoreV1Api()
 
 
+def get_apps_v1_api() -> kubernetes.client.AppsV1Api:
+    """Return a configured AppsV1Api instance."""
+    return kubernetes.client.AppsV1Api()
+
+
 def patch_node(name: str, body: Dict[str, Any]) -> Any:
     """Strategic-merge-patch a Node object."""
     api = get_core_v1_api()
     return api.patch_node(name, body)
+
+
+def get_deployment(name: str, namespace: str) -> Any:
+    """Fetch a Deployment by name and namespace."""
+    api = get_apps_v1_api()
+    return api.read_namespaced_deployment(name=name, namespace=namespace)
 
 
 def list_objects(
@@ -159,6 +188,20 @@ def list_objects(
         group=group,
         version=version,
         namespace=namespace,
+        plural=plural,
+    )
+
+
+def list_cluster_objects(
+    group: str,
+    version: str,
+    plural: str,
+) -> Dict[str, Any]:
+    """List cluster-scoped (all namespaces) custom objects."""
+    api = get_custom_objects_api()
+    return api.list_cluster_custom_object(  # type: ignore[no-any-return]
+        group=group,
+        version=version,
         plural=plural,
     )
 

--- a/tools/nnf/src/nnf/table.py
+++ b/tools/nnf/src/nnf/table.py
@@ -1,0 +1,34 @@
+"""Shared table-printing utilities."""
+
+from typing import List, Tuple
+
+
+def print_table(
+    headers: Tuple[str, ...],
+    rows: List[Tuple[str, ...]],
+    right_align: Tuple[int, ...] = (),
+) -> None:
+    """Print a column-aligned table with optional right-alignment.
+
+    Always prints the header row, even when *rows* is empty.
+    """
+    expected_width = len(headers)
+    for index, row in enumerate(rows, start=1):
+        if len(row) != expected_width:
+            raise ValueError(
+                f"row {index} has {len(row)} cells, expected {expected_width}"
+            )
+
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+    parts = []
+    for i, (h, w) in enumerate(zip(headers, widths)):
+        parts.append(h.rjust(w) if i in right_align else h.ljust(w))
+    print("  ".join(parts))
+    for row in rows:
+        parts = []
+        for i, (cell, w) in enumerate(zip(row, widths)):
+            parts.append(cell.rjust(w) if i in right_align else cell.ljust(w))
+        print("  ".join(parts))

--- a/tools/nnf/tests/test_destroy_persistent.py
+++ b/tools/nnf/tests/test_destroy_persistent.py
@@ -1,10 +1,13 @@
 """Tests for the destroy_persistent sub-command."""
 
 import argparse
+import pytest
 from typing import Dict
 from unittest.mock import MagicMock, patch
 
-from nnf.commands.persistent.destroy import run
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+
+from nnf.commands.persistent.destroy import _get_psi_user_id, run
 
 
 def _make_args(**kwargs: object) -> argparse.Namespace:
@@ -86,3 +89,64 @@ def test_run_no_state_hooks() -> None:
     wf = captured["wf"]
     assert isinstance(wf, WorkflowRun)
     assert wf.state_hooks == {}
+
+
+# ---------------------------------------------------------------------------
+# _get_psi_user_id
+# ---------------------------------------------------------------------------
+
+
+@patch("nnf.commands.persistent.destroy.k8s.get_object")
+def test_get_psi_user_id(mock_get: MagicMock) -> None:
+    mock_get.return_value = {"spec": {"userID": 5000}}
+    assert _get_psi_user_id("my-psi", "default") == 5000
+
+
+@patch("nnf.commands.persistent.destroy.k8s.get_object")
+def test_get_psi_user_id_string(mock_get: MagicMock) -> None:
+    """userID is sometimes stored as a string in the spec."""
+    mock_get.return_value = {"spec": {"userID": "1234"}}
+    assert _get_psi_user_id("my-psi", "default") == 1234
+
+
+# ---------------------------------------------------------------------------
+# run – user_id from PSI lookup
+# ---------------------------------------------------------------------------
+
+
+def test_run_user_id_from_psi() -> None:
+    """When --user-id is not supplied, run() fetches userID from the PSI."""
+    mock_car = MagicMock(return_value=0)
+    with patch("nnf.commands.persistent.destroy.workflow.create_and_run", mock_car), \
+            patch("nnf.commands.persistent.destroy._get_psi_user_id", return_value=4242):
+        assert run(_make_args(user_id=None)) == 0
+
+    wf_arg = mock_car.call_args[0][0]
+    assert wf_arg.user_id == 4242
+
+
+def test_run_user_id_cli_overrides_psi() -> None:
+    """When --user-id is supplied, run() uses it instead of the PSI."""
+    mock_car = MagicMock(return_value=0)
+    with patch("nnf.commands.persistent.destroy.workflow.create_and_run", mock_car):
+        assert run(_make_args(user_id=9999)) == 0
+
+    wf_arg = mock_car.call_args[0][0]
+    assert wf_arg.user_id == 9999
+
+
+def test_run_psi_not_found_returns_1() -> None:
+    """run() returns 1 when the PSI does not exist."""
+    with patch("nnf.commands.persistent.destroy._get_psi_user_id",
+               side_effect=kubernetes.client.exceptions.ApiException(
+                   status=404, reason="Not Found")):
+        assert run(_make_args(user_id=None)) == 1
+
+
+def test_run_psi_missing_user_id_returns_1(capsys: pytest.CaptureFixture[str]) -> None:
+    """run() returns 1 when the PSI spec has no userID field."""
+    with patch("nnf.commands.persistent.destroy._get_psi_user_id",
+               side_effect=KeyError("userID")):
+        assert run(_make_args(user_id=None)) == 1
+    err = capsys.readouterr().err
+    assert "userID" in err

--- a/tools/nnf/tests/test_persistent_share.py
+++ b/tools/nnf/tests/test_persistent_share.py
@@ -25,7 +25,7 @@ def test_run_success(mock_patch: MagicMock, capsys: pytest.CaptureFixture[str]) 
     assert run(_make_args()) == 0
     mock_patch.assert_called_once()
     body = mock_patch.call_args[1]["body"]
-    assert body["metadata"]["annotations"][crd.NNF_IGNORE_UID_ANNOTATION] == "true"
+    assert body["metadata"]["annotations"][crd.DWS_IGNORE_UID_ANNOTATION] == "true"
     out = capsys.readouterr().out
     assert "Shared" in out
 

--- a/tools/nnf/tests/test_persistent_share.py
+++ b/tools/nnf/tests/test_persistent_share.py
@@ -1,0 +1,48 @@
+"""Tests for the persistent share sub-command."""
+
+import argparse
+import pytest
+from typing import Dict
+from unittest.mock import MagicMock, patch
+
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+
+from nnf import crd
+from nnf.commands.persistent.share import run
+
+
+def _make_args(**kwargs: object) -> argparse.Namespace:
+    defaults: Dict[str, object] = {
+        "name": "my-psi",
+        "namespace": "default",
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+@patch("nnf.commands.persistent.share.k8s.patch_object")
+def test_run_success(mock_patch: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    assert run(_make_args()) == 0
+    mock_patch.assert_called_once()
+    body = mock_patch.call_args[1]["body"]
+    assert body["metadata"]["annotations"][crd.NNF_IGNORE_UID_ANNOTATION] == "true"
+    out = capsys.readouterr().out
+    assert "Shared" in out
+
+
+@patch("nnf.commands.persistent.share.k8s.patch_object")
+def test_run_patches_correct_resource(mock_patch: MagicMock) -> None:
+    run(_make_args(name="foo", namespace="bar"))
+    assert mock_patch.call_args[1]["name"] == "foo"
+    assert mock_patch.call_args[1]["namespace"] == "bar"
+
+
+@patch("nnf.commands.persistent.share.k8s.patch_object")
+def test_run_api_error(mock_patch: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_patch.side_effect = kubernetes.client.exceptions.ApiException(
+        status=404, reason="Not Found",
+    )
+    assert run(_make_args()) == 1
+    err = capsys.readouterr().err
+    assert "error" in err
+    assert "my-psi" in err

--- a/tools/nnf/tests/test_persistent_unshare.py
+++ b/tools/nnf/tests/test_persistent_unshare.py
@@ -25,7 +25,7 @@ def test_run_success(mock_patch: MagicMock, capsys: pytest.CaptureFixture[str]) 
     assert run(_make_args()) == 0
     mock_patch.assert_called_once()
     body = mock_patch.call_args[1]["body"]
-    assert body["metadata"]["annotations"][crd.NNF_IGNORE_UID_ANNOTATION] is None
+    assert body["metadata"]["annotations"][crd.DWS_IGNORE_UID_ANNOTATION] is None
     out = capsys.readouterr().out
     assert "Unshared" in out
 

--- a/tools/nnf/tests/test_persistent_unshare.py
+++ b/tools/nnf/tests/test_persistent_unshare.py
@@ -1,0 +1,48 @@
+"""Tests for the persistent unshare sub-command."""
+
+import argparse
+import pytest
+from typing import Dict
+from unittest.mock import MagicMock, patch
+
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+
+from nnf import crd
+from nnf.commands.persistent.unshare import run
+
+
+def _make_args(**kwargs: object) -> argparse.Namespace:
+    defaults: Dict[str, object] = {
+        "name": "my-psi",
+        "namespace": "default",
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+@patch("nnf.commands.persistent.unshare.k8s.patch_object")
+def test_run_success(mock_patch: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    assert run(_make_args()) == 0
+    mock_patch.assert_called_once()
+    body = mock_patch.call_args[1]["body"]
+    assert body["metadata"]["annotations"][crd.NNF_IGNORE_UID_ANNOTATION] is None
+    out = capsys.readouterr().out
+    assert "Unshared" in out
+
+
+@patch("nnf.commands.persistent.unshare.k8s.patch_object")
+def test_run_patches_correct_resource(mock_patch: MagicMock) -> None:
+    run(_make_args(name="foo", namespace="bar"))
+    assert mock_patch.call_args[1]["name"] == "foo"
+    assert mock_patch.call_args[1]["namespace"] == "bar"
+
+
+@patch("nnf.commands.persistent.unshare.k8s.patch_object")
+def test_run_api_error(mock_patch: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_patch.side_effect = kubernetes.client.exceptions.ApiException(
+        status=404, reason="Not Found",
+    )
+    assert run(_make_args()) == 1
+    err = capsys.readouterr().err
+    assert "error" in err
+    assert "my-psi" in err

--- a/tools/nnf/tests/test_rabbit_df.py
+++ b/tools/nnf/tests/test_rabbit_df.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import kubernetes.client.exceptions  # type: ignore[import-untyped]
 import pytest
 
-from nnf.commands.rabbit.df import (
+from nnf.commands.system.df import (
     _find_node_manager_pod,
     _format_tib,
     _get_all_storages,
@@ -111,7 +111,7 @@ def test_get_capacity_parses_redfish_json() -> None:
             }
         }
     })
-    with patch("nnf.commands.rabbit.df.k8s.exec_pod", return_value=redfish_json):
+    with patch("nnf.commands.system.df.k8s.exec_pod", return_value=redfish_json):
         cap = _get_capacity("nm-pod")
 
     assert cap == {
@@ -125,7 +125,7 @@ def test_get_capacity_parses_redfish_json() -> None:
 def test_get_capacity_rejects_non_json() -> None:
     """_get_capacity raises on non-JSON/non-dict responses."""
     non_json = "this is not json"
-    with patch("nnf.commands.rabbit.df.k8s.exec_pod", return_value=non_json):
+    with patch("nnf.commands.system.df.k8s.exec_pod", return_value=non_json):
         with pytest.raises((json.JSONDecodeError, ValueError, SyntaxError)):
             _get_capacity("nm-pod")
 
@@ -164,7 +164,7 @@ def test_get_capacity_python_dict_response() -> None:
         "'AllocatedBytes': 200, 'ConsumedBytes': 100, "
         "'GuaranteedBytes': 160, 'ProvisionedBytes': 180}}}"
     )
-    with patch("nnf.commands.rabbit.df.k8s.exec_pod", return_value=python_dict):
+    with patch("nnf.commands.system.df.k8s.exec_pod", return_value=python_dict):
         cap = _get_capacity("nm-pod")
 
     assert cap == {
@@ -182,7 +182,7 @@ def test_get_capacity_python_dict_response() -> None:
 
 def test_get_all_storages_returns_items() -> None:
     items = [{"metadata": {"name": "r-0"}}]
-    with patch("nnf.commands.rabbit.df.k8s.list_objects", return_value={"items": items}):
+    with patch("nnf.commands.system.df.k8s.list_objects", return_value={"items": items}):
         assert _get_all_storages() == items
 
 
@@ -212,9 +212,9 @@ def test_run_success(capsys: pytest.CaptureFixture[str]) -> None:
         }}
     })
 
-    with patch("nnf.commands.rabbit.df._get_all_storages", return_value=storages), \
-            patch("nnf.commands.rabbit.df.k8s.list_pods", return_value=pods), \
-            patch("nnf.commands.rabbit.df.k8s.exec_pod", return_value=cap_json):
+    with patch("nnf.commands.system.df._get_all_storages", return_value=storages), \
+            patch("nnf.commands.system.df.k8s.list_pods", return_value=pods), \
+            patch("nnf.commands.system.df.k8s.exec_pod", return_value=cap_json):
         rc = run(_make_args())
 
     assert rc == 0
@@ -235,9 +235,9 @@ def test_run_specific_nodes(capsys: pytest.CaptureFixture[str]) -> None:
         }}
     })
 
-    with patch("nnf.commands.rabbit.df._get_all_storages", return_value=storages), \
-            patch("nnf.commands.rabbit.df.k8s.list_pods", return_value=pods), \
-            patch("nnf.commands.rabbit.df.k8s.exec_pod", return_value=cap_json):
+    with patch("nnf.commands.system.df._get_all_storages", return_value=storages), \
+            patch("nnf.commands.system.df.k8s.list_pods", return_value=pods), \
+            patch("nnf.commands.system.df.k8s.exec_pod", return_value=cap_json):
         rc = run(_make_args(nodes=["rabbit-1"]))
 
     assert rc == 0
@@ -250,8 +250,8 @@ def test_run_skips_disabled(capsys: pytest.CaptureFixture[str]) -> None:
     """run() skips rabbits that are not Enabled/Ready and reports them."""
     storages = [_make_storage("rabbit-0", state="Disabled", status="Ready")]
 
-    with patch("nnf.commands.rabbit.df._get_all_storages", return_value=storages), \
-            patch("nnf.commands.rabbit.df.k8s.list_pods", return_value=[]):
+    with patch("nnf.commands.system.df._get_all_storages", return_value=storages), \
+            patch("nnf.commands.system.df.k8s.list_pods", return_value=[]):
         rc = run(_make_args())
 
     assert rc == 0
@@ -264,8 +264,8 @@ def test_run_explicit_disabled_node_returns_1(capsys: pytest.CaptureFixture[str]
     """run() returns an error when a user-specified node is not Enabled/Ready."""
     storages = [_make_storage("rabbit-0", state="Disabled", status="Ready")]
 
-    with patch("nnf.commands.rabbit.df._get_all_storages", return_value=storages), \
-            patch("nnf.commands.rabbit.df.k8s.list_pods", return_value=[]):
+    with patch("nnf.commands.system.df._get_all_storages", return_value=storages), \
+            patch("nnf.commands.system.df.k8s.list_pods", return_value=[]):
         rc = run(_make_args(nodes=["rabbit-0"]))
 
     assert rc == 1
@@ -276,8 +276,8 @@ def test_run_explicit_disabled_node_returns_1(capsys: pytest.CaptureFixture[str]
 
 def test_run_no_storage_resource_returns_1(capsys: pytest.CaptureFixture[str]) -> None:
     """run() reports an error when a requested rabbit has no Storage resource."""
-    with patch("nnf.commands.rabbit.df._get_all_storages", return_value=[]), \
-            patch("nnf.commands.rabbit.df.k8s.list_pods", return_value=[]):
+    with patch("nnf.commands.system.df._get_all_storages", return_value=[]), \
+            patch("nnf.commands.system.df.k8s.list_pods", return_value=[]):
         rc = run(_make_args(nodes=["rabbit-missing"]))
 
     assert rc == 1
@@ -288,8 +288,8 @@ def test_run_no_pod_returns_1(capsys: pytest.CaptureFixture[str]) -> None:
     """run() reports an error when no node-manager pod is found."""
     storages = [_make_storage("rabbit-0")]
 
-    with patch("nnf.commands.rabbit.df._get_all_storages", return_value=storages), \
-            patch("nnf.commands.rabbit.df.k8s.list_pods", return_value=[]):
+    with patch("nnf.commands.system.df._get_all_storages", return_value=storages), \
+            patch("nnf.commands.system.df.k8s.list_pods", return_value=[]):
         rc = run(_make_args())
 
     assert rc == 1
@@ -308,9 +308,9 @@ def test_run_capacity_error_continues(capsys: pytest.CaptureFixture[str]) -> Non
     })
     exc = kubernetes.client.exceptions.ApiException(status=500, reason="InternalError")
 
-    with patch("nnf.commands.rabbit.df._get_all_storages", return_value=storages), \
-            patch("nnf.commands.rabbit.df.k8s.list_pods", return_value=pods), \
-            patch("nnf.commands.rabbit.df.k8s.exec_pod", side_effect=[exc, cap_json]):
+    with patch("nnf.commands.system.df._get_all_storages", return_value=storages), \
+            patch("nnf.commands.system.df.k8s.list_pods", return_value=pods), \
+            patch("nnf.commands.system.df.k8s.exec_pod", side_effect=[exc, cap_json]):
         rc = run(_make_args())
 
     assert rc == 1
@@ -321,7 +321,7 @@ def test_run_capacity_error_continues(capsys: pytest.CaptureFixture[str]) -> Non
 def test_run_storage_list_failure_returns_1() -> None:
     """run() returns 1 when listing Storage resources fails."""
     exc = kubernetes.client.exceptions.ApiException(status=500, reason="InternalError")
-    with patch("nnf.commands.rabbit.df._get_all_storages", side_effect=exc):
+    with patch("nnf.commands.system.df._get_all_storages", side_effect=exc):
         rc = run(_make_args())
 
     assert rc == 1
@@ -330,8 +330,8 @@ def test_run_storage_list_failure_returns_1() -> None:
 def test_run_pod_list_failure_returns_1() -> None:
     """run() returns 1 when listing pods fails."""
     exc = kubernetes.client.exceptions.ApiException(status=500, reason="InternalError")
-    with patch("nnf.commands.rabbit.df._get_all_storages", return_value=[]), \
-            patch("nnf.commands.rabbit.df.k8s.list_pods", side_effect=exc):
+    with patch("nnf.commands.system.df._get_all_storages", return_value=[]), \
+            patch("nnf.commands.system.df.k8s.list_pods", side_effect=exc):
         rc = run(_make_args())
 
     assert rc == 1

--- a/tools/nnf/tests/test_system_flowschema.py
+++ b/tools/nnf/tests/test_system_flowschema.py
@@ -1,0 +1,365 @@
+"""Tests for the system flowschema sub-command."""
+
+import argparse
+import pytest
+import json
+from typing import Dict
+from unittest.mock import MagicMock, patch
+
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+
+from nnf.commands.system.flowschema import (
+    _discover_api_version,
+    _list_flowschemas,
+    _list_priority_levels,
+    _print_table,
+    _view_activity,
+    _view_summary,
+    run,
+)
+
+
+def _make_args(**kwargs: object) -> argparse.Namespace:
+    defaults: Dict[str, object] = {
+        "flow_schema_name": None,
+        "list_flowschemas": False,
+        "priority_levels": False,
+        "summary": False,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / canned responses
+# ---------------------------------------------------------------------------
+
+_DISCOVERY_RESPONSE = json.dumps({
+    "kind": "APIGroup",
+    "apiVersion": "v1",
+    "name": "flowcontrol.apiserver.k8s.io",
+    "versions": [
+        {"groupVersion": "flowcontrol.apiserver.k8s.io/v1", "version": "v1"},
+        {"groupVersion": "flowcontrol.apiserver.k8s.io/v1beta3", "version": "v1beta3"},
+    ],
+    "preferredVersion": {
+        "groupVersion": "flowcontrol.apiserver.k8s.io/v1",
+        "version": "v1",
+    },
+})
+
+_FLOWSCHEMA_LIST = json.dumps({
+    "items": [
+        {
+            "metadata": {"name": "catch-all"},
+            "spec": {
+                "priorityLevelConfiguration": {"name": "catch-all"},
+                "matchingPrecedence": 10000,
+                "distinguisherMethod": {"type": "ByUser"},
+            },
+        },
+        {
+            "metadata": {"name": "nnf-webhook"},
+            "spec": {
+                "priorityLevelConfiguration": {"name": "workload-high"},
+                "matchingPrecedence": 1000,
+                "distinguisherMethod": {"type": "ByNamespace"},
+            },
+        },
+    ],
+})
+
+_PRIORITY_LEVEL_LIST = json.dumps({
+    "items": [
+        {
+            "metadata": {"name": "catch-all"},
+            "spec": {
+                "type": "Limited",
+                "limited": {
+                    "nominalConcurrencyShares": 5,
+                    "limitResponse": {
+                        "type": "Queue",
+                        "queuing": {
+                            "queues": 64,
+                            "handSize": 6,
+                            "queueLengthLimit": 50,
+                        },
+                    },
+                },
+            },
+        },
+        {
+            "metadata": {"name": "exempt"},
+            "spec": {
+                "type": "Exempt",
+            },
+        },
+    ],
+})
+
+_METRICS_RESPONSE = (
+    "# HELP apiserver_flowcontrol_request_concurrency_limit\n"
+    'apiserver_flowcontrol_request_concurrency_limit{flow_schema="catch-all",'
+    'priority_level="catch-all"} 5\n'
+    'apiserver_flowcontrol_request_concurrency_limit{flow_schema="nnf-webhook",'
+    'priority_level="workload-high"} 30\n'
+    "# HELP apiserver_flowcontrol_dispatched_requests_total\n"
+    'apiserver_flowcontrol_dispatched_requests_total{flow_schema="catch-all",'
+    'priority_level="catch-all"} 100\n'
+    'apiserver_flowcontrol_dispatched_requests_total{flow_schema="nnf-webhook",'
+    'priority_level="workload-high"} 500\n'
+)
+
+
+# ---------------------------------------------------------------------------
+# _print_table
+# ---------------------------------------------------------------------------
+
+
+def test_print_table_basic(capsys: pytest.CaptureFixture[str]) -> None:
+    _print_table(("A", "BB"), [("x", "yy"), ("zzz", "w")])
+    out = capsys.readouterr().out
+    lines = out.strip().splitlines()
+    assert len(lines) == 3
+    assert "A" in lines[0]
+    assert "BB" in lines[0]
+    assert "zzz" in lines[2]
+
+
+def test_print_table_empty(capsys: pytest.CaptureFixture[str]) -> None:
+    _print_table(("COL1", "COL2"), [])
+    out = capsys.readouterr().out
+    lines = out.strip().splitlines()
+    assert len(lines) == 1
+    assert "COL1" in lines[0]
+
+
+# ---------------------------------------------------------------------------
+# _discover_api_version
+# ---------------------------------------------------------------------------
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_discover_api_version_v1(mock_k8s: MagicMock) -> None:
+    mock_k8s.get_raw.return_value = _DISCOVERY_RESPONSE
+    assert _discover_api_version() == "v1"
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_discover_api_version_fallback_v1beta3(mock_k8s: MagicMock) -> None:
+    response = json.dumps({"versions": [{"version": "v1beta3"}]})
+    mock_k8s.get_raw.return_value = response
+    assert _discover_api_version() == "v1beta3"
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_discover_api_version_not_available(mock_k8s: MagicMock) -> None:
+    mock_k8s.get_raw.side_effect = kubernetes.client.exceptions.ApiException(status=404)
+    assert _discover_api_version() is None
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_discover_api_version_no_known_version(mock_k8s: MagicMock) -> None:
+    response = json.dumps({"versions": [{"version": "v1alpha1"}]})
+    mock_k8s.get_raw.return_value = response
+    assert _discover_api_version() is None
+
+
+# ---------------------------------------------------------------------------
+# _list_flowschemas
+# ---------------------------------------------------------------------------
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_list_flowschemas(mock_k8s: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_k8s.get_raw.return_value = _FLOWSCHEMA_LIST
+    assert _list_flowschemas("v1") == 0
+    out = capsys.readouterr().out
+    assert "NAME" in out
+    assert "PRIORITYLEVEL" in out
+    assert "catch-all" in out
+    assert "nnf-webhook" in out
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_list_flowschemas_sorted(mock_k8s: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_k8s.get_raw.return_value = _FLOWSCHEMA_LIST
+    _list_flowschemas("v1")
+    out = capsys.readouterr().out
+    lines = out.strip().splitlines()
+    # Header + 2 rows, "catch-all" before "nnf-webhook"
+    assert lines[1].startswith("catch-all")
+    assert lines[2].startswith("nnf-webhook")
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_list_flowschemas_no_distinguisher(mock_k8s: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    data = json.dumps({
+        "items": [{
+            "metadata": {"name": "test"},
+            "spec": {
+                "priorityLevelConfiguration": {"name": "pl"},
+                "matchingPrecedence": 100,
+            },
+        }],
+    })
+    mock_k8s.get_raw.return_value = data
+    assert _list_flowschemas("v1") == 0
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_list_flowschemas_api_error(mock_k8s: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_k8s.get_raw.side_effect = kubernetes.client.exceptions.ApiException(
+        status=500, reason="Internal Server Error",
+    )
+    assert _list_flowschemas("v1") == 1
+    err = capsys.readouterr().err
+    assert "error" in err
+
+
+# ---------------------------------------------------------------------------
+# _list_priority_levels
+# ---------------------------------------------------------------------------
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_list_priority_levels(mock_k8s: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_k8s.get_raw.return_value = _PRIORITY_LEVEL_LIST
+    assert _list_priority_levels("v1") == 0
+    out = capsys.readouterr().out
+    assert "NAME" in out
+    assert "catch-all" in out
+    assert "exempt" in out
+    assert "NOMINALCONCURRENCYSHARES" in out
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_list_priority_levels_exempt_empty_fields(mock_k8s: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_k8s.get_raw.return_value = _PRIORITY_LEVEL_LIST
+    _list_priority_levels("v1")
+    out = capsys.readouterr().out
+    lines = out.strip().splitlines()
+    # "exempt" row should have empty fields for shares/queues/etc.
+    exempt_line = [line for line in lines if "Exempt" in line][0]
+    # After "Exempt" there should be only whitespace (empty columns)
+    after_exempt = exempt_line.split("Exempt", 1)[1]
+    assert after_exempt.strip() == ""
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_list_priority_levels_api_error(mock_k8s: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_k8s.get_raw.side_effect = kubernetes.client.exceptions.ApiException(
+        status=500, reason="Internal Server Error",
+    )
+    assert _list_priority_levels("v1") == 1
+    err = capsys.readouterr().err
+    assert "error" in err
+
+
+# ---------------------------------------------------------------------------
+# _view_activity
+# ---------------------------------------------------------------------------
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_view_activity_found(mock_k8s: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_k8s.get_raw.side_effect = [_FLOWSCHEMA_LIST, _METRICS_RESPONSE]
+    assert _view_activity("v1", "catch-all") == 0
+    out = capsys.readouterr().out
+    assert 'flow_schema="catch-all"' in out
+    # Should not include lines for other flow schemas
+    assert 'flow_schema="nnf-webhook"' not in out
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_view_activity_not_found(mock_k8s: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_k8s.get_raw.return_value = _FLOWSCHEMA_LIST
+    assert _view_activity("v1", "nonexistent") == 1
+    out = capsys.readouterr().out
+    assert "Valid flowschema NAMEs are:" in out
+    assert "catch-all" in out
+    assert "nnf-webhook" in out
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_view_activity_metrics_error(mock_k8s: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_k8s.get_raw.side_effect = [
+        _FLOWSCHEMA_LIST,
+        kubernetes.client.exceptions.ApiException(status=403, reason="Forbidden"),
+    ]
+    assert _view_activity("v1", "catch-all") == 1
+    err = capsys.readouterr().err
+    assert "error" in err
+
+
+# ---------------------------------------------------------------------------
+# _view_summary
+# ---------------------------------------------------------------------------
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_view_summary(mock_k8s: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_k8s.get_raw.return_value = "priority-level dump data\n"
+    assert _view_summary() == 0
+    out = capsys.readouterr().out
+    assert "priority-level dump data" in out
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_view_summary_api_error(mock_k8s: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_k8s.get_raw.side_effect = kubernetes.client.exceptions.ApiException(
+        status=500, reason="Internal Server Error",
+    )
+    assert _view_summary() == 1
+    err = capsys.readouterr().err
+    assert "error" in err
+
+
+# ---------------------------------------------------------------------------
+# run (integration)
+# ---------------------------------------------------------------------------
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_run_list_flowschemas(mock_k8s: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_k8s.get_raw.side_effect = [_DISCOVERY_RESPONSE, _FLOWSCHEMA_LIST]
+    args = _make_args(list_flowschemas=True)
+    assert run(args) == 0
+    out = capsys.readouterr().out
+    assert "catch-all" in out
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_run_priority_levels(mock_k8s: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_k8s.get_raw.side_effect = [_DISCOVERY_RESPONSE, _PRIORITY_LEVEL_LIST]
+    args = _make_args(priority_levels=True)
+    assert run(args) == 0
+    out = capsys.readouterr().out
+    assert "catch-all" in out
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_run_view_activity(mock_k8s: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_k8s.get_raw.side_effect = [
+        _DISCOVERY_RESPONSE,
+        _FLOWSCHEMA_LIST,
+        _METRICS_RESPONSE,
+    ]
+    args = _make_args(flow_schema_name="catch-all")
+    assert run(args) == 0
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_run_summary(mock_k8s: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_k8s.get_raw.return_value = "dump data\n"
+    args = _make_args(summary=True)
+    assert run(args) == 0
+
+
+@patch("nnf.commands.system.flowschema.k8s")
+def test_run_no_api_available(mock_k8s: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_k8s.get_raw.side_effect = kubernetes.client.exceptions.ApiException(status=404)
+    args = _make_args(list_flowschemas=True)
+    assert run(args) == 1
+    err = capsys.readouterr().err
+    assert "not available" in err

--- a/tools/nnf/tests/test_system_state.py
+++ b/tools/nnf/tests/test_system_state.py
@@ -1,0 +1,522 @@
+"""Tests for the system state sub-command."""
+
+import argparse
+import pytest
+import json
+import subprocess
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+
+from nnf import crd
+from nnf.commands.system.state import (
+    _build_annotation_rows,
+    _build_node_status_rows,
+    _build_storage_status_rows,
+    _compress_hostlist,
+    _get_all_storages,
+    _print_table,
+    _run_cmd,
+    _show_disabled_computes,
+    run,
+)
+
+
+def _make_args(**kwargs: object) -> argparse.Namespace:
+    defaults: Dict[str, object] = {}
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# _compress_hostlist
+# ---------------------------------------------------------------------------
+
+
+def test_compress_hostlist_empty() -> None:
+    assert _compress_hostlist([]) == ""
+
+
+def test_compress_hostlist_single() -> None:
+    assert _compress_hostlist(["rabbit-0"]) == "rabbit-0"
+
+
+def test_compress_hostlist_consecutive() -> None:
+    result = _compress_hostlist(["rabbit-0", "rabbit-1", "rabbit-2"])
+    assert result == "rabbit-[0-2]"
+
+
+def test_compress_hostlist_gaps() -> None:
+    result = _compress_hostlist(["rabbit-0", "rabbit-1", "rabbit-3", "rabbit-5"])
+    assert result == "rabbit-[0-1,3,5]"
+
+
+def test_compress_hostlist_single_in_list() -> None:
+    result = _compress_hostlist(["rabbit-5"])
+    assert result == "rabbit-5"
+
+
+def test_compress_hostlist_noncontiguous_ranges() -> None:
+    result = _compress_hostlist([
+        "rabbit-0", "rabbit-1", "rabbit-2",
+        "rabbit-10", "rabbit-11",
+    ])
+    assert result == "rabbit-[0-2,10-11]"
+
+
+def test_compress_hostlist_no_numeric_suffix() -> None:
+    result = _compress_hostlist(["nodeA", "nodeB"])
+    assert result == "nodeA,nodeB"
+
+
+def test_compress_hostlist_different_prefixes() -> None:
+    result = _compress_hostlist(["rabbit-0", "compute-1"])
+    assert result == "compute-1,rabbit-0"
+
+
+def test_compress_hostlist_multi_prefix_ranges() -> None:
+    result = _compress_hostlist([
+        "rabbit-compute-2", "rabbit-compute-3",
+        "rabbit-compute-4", "rabbit-compute-5",
+        "rabbit-node-1", "rabbit-node-2",
+    ])
+    assert result == "rabbit-compute-[2-5],rabbit-node-[1-2]"
+
+
+def test_compress_hostlist_unsorted_input() -> None:
+    result = _compress_hostlist(["rabbit-3", "rabbit-1", "rabbit-2"])
+    assert result == "rabbit-[1-3]"
+
+
+# ---------------------------------------------------------------------------
+# _print_table
+# ---------------------------------------------------------------------------
+
+
+def test_print_table_basic(capsys: pytest.CaptureFixture[str]) -> None:
+    _print_table(("A", "B"), [("x", "yy")], right_align=())
+    out = capsys.readouterr().out
+    assert "A" in out
+    assert "B" in out
+
+
+def test_print_table_right_align(capsys: pytest.CaptureFixture[str]) -> None:
+    _print_table(("NUM",), [("42",)], right_align=(0,))
+    out = capsys.readouterr().out
+    # Right-aligned, so no trailing spaces before newline for single column
+    assert "NUM" in out
+
+
+def test_print_table_empty_rows(capsys: pytest.CaptureFixture[str]) -> None:
+    _print_table(("A", "B"), [], right_align=())
+    out = capsys.readouterr().out
+    lines = out.strip().splitlines()
+    assert len(lines) == 1
+    assert "A" in lines[0]
+
+
+def test_print_table_rejects_short_rows() -> None:
+    with pytest.raises(ValueError, match="row 1 has 1 cells, expected 2"):
+        _print_table(("A", "B"), [("x",)], right_align=())
+
+
+def test_print_table_rejects_long_rows() -> None:
+    with pytest.raises(ValueError, match="row 1 has 3 cells, expected 2"):
+        _print_table(("A", "B"), [("x", "y", "z")], right_align=())
+
+
+# ---------------------------------------------------------------------------
+# _build_node_status_rows
+# ---------------------------------------------------------------------------
+
+
+def _make_nnfnode(servers: List[Dict[str, str]]) -> Dict[str, Any]:
+    return {"status": {"servers": servers}}
+
+
+def test_build_node_status_rows_basic() -> None:
+    nodes = [
+        _make_nnfnode([
+            {"hostname": "rabbit-0", "status": "Ready", "health": "OK"},
+            {"hostname": "rabbit-1", "status": "Ready", "health": "OK"},
+        ]),
+        _make_nnfnode([
+            {"hostname": "rabbit-2", "status": "Failed", "health": "Critical"},
+        ]),
+    ]
+    rows = _build_node_status_rows(nodes)
+    assert len(rows) == 2
+    # OK/Ready row
+    assert rows[0] == ("OK", "Ready", "2", "rabbit-[0-1]")
+    # Critical/Failed row
+    assert rows[1] == ("Critical", "Failed", "1", "rabbit-2")
+
+
+def test_build_node_status_rows_skips_null_hostname() -> None:
+    nodes = [
+        _make_nnfnode([
+            {"hostname": None, "status": "Ready", "health": "OK"},
+            {"hostname": "rabbit-0", "status": "Ready", "health": "OK"},
+        ]),
+    ]
+    rows = _build_node_status_rows(nodes)
+    assert len(rows) == 1
+    assert rows[0][2] == "1"
+
+
+def test_build_node_status_rows_empty() -> None:
+    assert _build_node_status_rows([]) == []
+
+
+def test_build_node_status_rows_includes_unexpected_values() -> None:
+    nodes = [
+        _make_nnfnode([
+            {"hostname": "rabbit-9", "status": "Recovering", "health": "Degraded"},
+            {"hostname": "rabbit-10", "status": None, "health": "OK"},
+        ]),
+    ]
+
+    rows = _build_node_status_rows(nodes)
+
+    assert ("OK", "<missing>", "1", "rabbit-10") in rows
+    assert ("Degraded", "Recovering", "1", "rabbit-9") in rows
+
+
+# ---------------------------------------------------------------------------
+# _build_storage_status_rows
+# ---------------------------------------------------------------------------
+
+
+def _make_storage(
+    name: str,
+    state: str,
+    status: str,
+    annotations: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
+    s: Dict[str, Any] = {
+        "metadata": {"name": name, "annotations": annotations or {}},
+        "spec": {"state": state},
+        "status": {"status": status},
+    }
+    return s
+
+
+def test_build_storage_status_rows_basic() -> None:
+    storages = [
+        _make_storage("rabbit-0", "Enabled", "Ready"),
+        _make_storage("rabbit-1", "Enabled", "Ready"),
+        _make_storage("rabbit-2", "Disabled", "Drained"),
+    ]
+    rows = _build_storage_status_rows(storages)
+    assert len(rows) == 2
+    # Enabled/Ready first (by order in constants)
+    assert rows[0] == ("Enabled", "Ready", "2", "rabbit-[0-1]")
+    assert rows[1] == ("Disabled", "Drained", "1", "rabbit-2")
+
+
+def test_build_storage_status_rows_empty() -> None:
+    assert _build_storage_status_rows([]) == []
+
+
+def test_build_storage_status_rows_includes_unexpected_values() -> None:
+    storages = [
+        _make_storage("rabbit-9", "Cordoned", "Recovering"),
+        {
+            "metadata": {"name": "rabbit-10", "annotations": {}},
+            "spec": {"state": "Enabled"},
+            "status": {"status": None},
+        },
+    ]
+
+    rows = _build_storage_status_rows(storages)
+
+    assert ("Enabled", "<missing>", "1", "rabbit-10") in rows
+    assert ("Cordoned", "Recovering", "1", "rabbit-9") in rows
+
+
+@patch("nnf.commands.system.state.k8s.list_objects")
+def test_get_all_storages_uses_local_k8s_helper(mock_list_objects: MagicMock) -> None:
+    mock_list_objects.return_value = {"items": [{"metadata": {"name": "rabbit-0"}}]}
+
+    result = _get_all_storages()
+
+    mock_list_objects.assert_called_once_with(
+        group=crd.DWS_GROUP,
+        version=crd.DWS_VERSION,
+        namespace="default",
+        plural=crd.DWS_STORAGE_PLURAL,
+    )
+    assert result == [{"metadata": {"name": "rabbit-0"}}]
+
+
+# ---------------------------------------------------------------------------
+# _build_annotation_rows
+# ---------------------------------------------------------------------------
+
+
+def test_build_annotation_rows_disabled() -> None:
+    storages = [
+        _make_storage("rabbit-0", "Disabled", "Disabled", {
+            "disable_date": "2026-05-01",
+            "disable_reason": "maintenance",
+        }),
+    ]
+    rows = _build_annotation_rows(storages)
+    assert len(rows) == 1
+    assert rows[0] == ("Disabled", "2026-05-01", "rabbit-0", "maintenance")
+
+
+def test_build_annotation_rows_drained() -> None:
+    storages = [
+        _make_storage("rabbit-1", "Enabled", "Ready", {
+            "drain_date": "2026-05-02",
+            "drain_reason": "testing",
+        }),
+    ]
+    rows = _build_annotation_rows(storages)
+    assert len(rows) == 1
+    assert rows[0] == ("Drained", "2026-05-02", "rabbit-1", "testing")
+
+
+def test_build_annotation_rows_both() -> None:
+    storages = [
+        _make_storage("rabbit-0", "Disabled", "Disabled", {
+            "disable_date": "2026-05-01",
+            "disable_reason": "hw issue",
+            "drain_date": "2026-05-01",
+            "drain_reason": "preparing",
+        }),
+    ]
+    rows = _build_annotation_rows(storages)
+    assert len(rows) == 2
+
+
+def test_build_annotation_rows_none() -> None:
+    storages = [_make_storage("rabbit-0", "Enabled", "Ready")]
+    assert _build_annotation_rows(storages) == []
+
+
+def test_build_annotation_rows_null_annotations() -> None:
+    s: Dict[str, Any] = {
+        "metadata": {"name": "rabbit-0", "annotations": None},
+        "spec": {"state": "Enabled"},
+        "status": {"status": "Ready"},
+    }
+    assert _build_annotation_rows([s]) == []
+
+
+# ---------------------------------------------------------------------------
+# run (integration)
+# ---------------------------------------------------------------------------
+
+
+@patch("nnf.commands.system.state._show_disabled_computes")
+@patch("nnf.commands.system.state._get_all_storages")
+@patch("nnf.commands.system.state._get_all_nnfnodes")
+def test_run_success(
+    mock_nodes: MagicMock,
+    mock_storages: MagicMock,
+    mock_computes: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mock_nodes.return_value = [
+        _make_nnfnode([
+            {"hostname": "rabbit-0", "status": "Ready", "health": "OK"},
+        ]),
+    ]
+    mock_storages.return_value = [
+        _make_storage("rabbit-0", "Enabled", "Ready"),
+    ]
+    assert run(_make_args()) == 0
+    out = capsys.readouterr().out
+    assert "Node Status Summary" in out
+    assert "Disabled/Drained Rabbit Summary" in out
+    assert "rabbit-0" in out
+
+
+@patch("nnf.commands.system.state._show_disabled_computes")
+@patch("nnf.commands.system.state._get_all_storages")
+@patch("nnf.commands.system.state._get_all_nnfnodes")
+def test_run_with_annotations(
+    mock_nodes: MagicMock,
+    mock_storages: MagicMock,
+    mock_computes: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mock_nodes.return_value = []
+    mock_storages.return_value = [
+        _make_storage("rabbit-0", "Disabled", "Disabled", {
+            "disable_date": "2026-05-01",
+            "disable_reason": "test",
+        }),
+    ]
+    assert run(_make_args()) == 0
+    out = capsys.readouterr().out
+    assert "2026-05-01" in out
+    assert "test" in out
+
+
+@patch("nnf.commands.system.state._show_disabled_computes")
+@patch("nnf.commands.system.state._get_all_storages")
+@patch("nnf.commands.system.state._get_all_nnfnodes")
+def test_run_nnfnode_api_error(
+    mock_nodes: MagicMock,
+    mock_storages: MagicMock,
+    mock_computes: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mock_nodes.side_effect = kubernetes.client.exceptions.ApiException(
+        status=500, reason="Internal Server Error",
+    )
+    mock_storages.return_value = []
+    assert run(_make_args()) == 1
+    err = capsys.readouterr().err
+    assert "NnfNode" in err
+
+
+@patch("nnf.commands.system.state._show_disabled_computes")
+@patch("nnf.commands.system.state._get_all_storages")
+@patch("nnf.commands.system.state._get_all_nnfnodes")
+def test_run_storage_api_error(
+    mock_nodes: MagicMock,
+    mock_storages: MagicMock,
+    mock_computes: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mock_nodes.return_value = []
+    mock_storages.side_effect = kubernetes.client.exceptions.ApiException(
+        status=500, reason="Internal Server Error",
+    )
+    assert run(_make_args()) == 1
+    err = capsys.readouterr().err
+    assert "Storage" in err
+
+
+# ---------------------------------------------------------------------------
+# _run_cmd
+# ---------------------------------------------------------------------------
+
+
+@patch("nnf.commands.system.state.subprocess.run")
+def test_run_cmd_success(mock_run: MagicMock) -> None:
+    mock_run.return_value = MagicMock(returncode=0, stdout="hello\n", stderr="")
+    assert _run_cmd(["echo", "hello"]) == "hello"
+
+
+@patch("nnf.commands.system.state.subprocess.run")
+def test_run_cmd_failure(mock_run: MagicMock) -> None:
+    mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="err")
+    assert _run_cmd(["false"]) is None
+
+
+@patch("nnf.commands.system.state.subprocess.run")
+def test_run_cmd_oserror(mock_run: MagicMock) -> None:
+    mock_run.side_effect = OSError("not found")
+    assert _run_cmd(["missing"]) is None
+
+
+@patch("nnf.commands.system.state.subprocess.run")
+def test_run_cmd_timeout(mock_run: MagicMock) -> None:
+    mock_run.side_effect = subprocess.TimeoutExpired("cmd", 30)
+    assert _run_cmd(["slow"]) is None
+
+
+# ---------------------------------------------------------------------------
+# _show_disabled_computes
+# ---------------------------------------------------------------------------
+
+
+@patch("nnf.commands.system.state.shutil.which", return_value=None)
+def test_show_disabled_computes_no_flux(mock_which: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    _show_disabled_computes()
+    out = capsys.readouterr().out
+    assert "Disabled Computes" not in out
+
+
+@patch("nnf.commands.system.state._run_cmd_print")
+@patch("nnf.commands.system.state._run_cmd")
+@patch("nnf.commands.system.state.shutil.which", return_value="/usr/bin/flux")
+def test_show_disabled_computes_with_flux(
+    mock_which: MagicMock,
+    mock_run_cmd: MagicMock,
+    mock_run_print: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    jgf = json.dumps({
+        "graph": {
+            "nodes": [
+                {"metadata": {"type": "node", "basename": "compute", "id": 0}},
+                {"metadata": {"type": "node", "basename": "compute", "id": 1}},
+                {"metadata": {"type": "core", "basename": "core", "id": 0}},
+            ],
+        },
+    })
+    mock_run_cmd.side_effect = [
+        jgf,           # flux ion-resource find
+        "compute[0-1]",  # flux hostlist
+        None,          # flux config get (not available)
+    ]
+    _show_disabled_computes()
+    out = capsys.readouterr().out
+    assert "Disabled Computes" in out
+    mock_run_print.assert_called_once_with(
+        ["flux", "resource", "list", "-i", "compute[0-1]"],
+    )
+
+
+@patch("nnf.commands.system.state.os.path.isfile", return_value=True)
+@patch("nnf.commands.system.state._run_cmd_print")
+@patch("nnf.commands.system.state._run_cmd")
+@patch("nnf.commands.system.state.shutil.which", return_value="/usr/bin/flux")
+def test_show_disabled_computes_with_nodeattr(
+    mock_which: MagicMock,
+    mock_run_cmd: MagicMock,
+    mock_run_print: MagicMock,
+    mock_isfile: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    jgf = json.dumps({
+        "graph": {
+            "nodes": [
+                {"metadata": {"type": "node", "basename": "compute", "id": 5}},
+            ],
+        },
+    })
+    mock_run_cmd.side_effect = [
+        jgf,             # flux ion-resource find
+        "compute5",      # flux hostlist
+        "/path/to/jgf",  # flux config get resource.scheduling
+        "nid",           # nodeattr -v cluster
+    ]
+    _show_disabled_computes()
+    mock_run_print.assert_called_once_with(
+        ["flux", "resource", "list", "-i", "nidcompute5"],
+    )
+
+
+@patch("nnf.commands.system.state._run_cmd")
+@patch("nnf.commands.system.state.shutil.which", return_value="/usr/bin/flux")
+def test_show_disabled_computes_no_badrabbit(
+    mock_which: MagicMock,
+    mock_run_cmd: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mock_run_cmd.return_value = None  # flux ion-resource find fails
+    _show_disabled_computes()
+    out = capsys.readouterr().out
+    assert "Disabled Computes" not in out
+
+
+@patch("nnf.commands.system.state._run_cmd")
+@patch("nnf.commands.system.state.shutil.which", return_value="/usr/bin/flux")
+def test_show_disabled_computes_empty_jgf(
+    mock_which: MagicMock,
+    mock_run_cmd: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    jgf = json.dumps({"graph": {"nodes": []}})
+    mock_run_cmd.return_value = jgf
+    _show_disabled_computes()
+    out = capsys.readouterr().out
+    assert "Disabled Computes" not in out

--- a/tools/nnf/tests/test_system_version.py
+++ b/tools/nnf/tests/test_system_version.py
@@ -1,0 +1,78 @@
+"""Tests for the system version sub-command."""
+
+import argparse
+import pytest
+import json
+from typing import Dict
+from unittest.mock import MagicMock, patch
+
+import kubernetes.client.exceptions  # type: ignore[import-untyped]
+
+from nnf.commands.system.version import _get_deployment_labels, run
+
+
+def _make_args(**kwargs: object) -> argparse.Namespace:
+    defaults: Dict[str, object] = {}
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def _make_deployment(labels: Dict[str, str]) -> MagicMock:
+    deploy = MagicMock()
+    deploy.metadata.labels = labels
+    return deploy
+
+
+# ---------------------------------------------------------------------------
+# _get_deployment_labels
+# ---------------------------------------------------------------------------
+
+
+@patch("nnf.commands.system.version.k8s.get_deployment")
+def test_get_deployment_labels(mock_get_deploy: MagicMock) -> None:
+    labels = {"app": "nnf", "version": "v0.1.0"}
+    deploy = _make_deployment(labels)
+    mock_get_deploy.return_value = deploy
+    result = _get_deployment_labels()
+    assert result == labels
+    mock_get_deploy.assert_called_once_with(
+        name="nnf-controller-manager",
+        namespace="nnf-system",
+    )
+
+
+@patch("nnf.commands.system.version.k8s.get_deployment")
+def test_get_deployment_labels_none(mock_get_deploy: MagicMock) -> None:
+    deploy = MagicMock()
+    deploy.metadata.labels = None
+    mock_get_deploy.return_value = deploy
+    result = _get_deployment_labels()
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+
+
+@patch("nnf.commands.system.version._get_deployment_labels")
+def test_run_success(mock_labels: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    labels = {"app": "nnf", "version": "v0.1.0", "build": "abc123"}
+    mock_labels.return_value = labels
+    args = _make_args()
+    assert run(args) == 0
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert parsed == labels
+
+
+@patch("nnf.commands.system.version._get_deployment_labels")
+def test_run_api_error(mock_labels: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_labels.side_effect = kubernetes.client.exceptions.ApiException(
+        status=404, reason="Not Found",
+    )
+    args = _make_args()
+    assert run(args) == 1
+    err = capsys.readouterr().err
+    assert "error" in err
+    assert "nnf-controller-manager" in err


### PR DESCRIPTION
This commit adds the flowschema, state, and version subcommands. It also adds new share and unshare subcommands for allowing persistent storage to be shared between multiple users.

The destroy persistent command was changed to automatically create a workflow with a UID that matches the UID of the persistent storage being destroyed.