### PR TITLE
Skip persistent storage UID validation when ignore-uid annotation is set

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/NearNodeFlash/nnf-sos
 go 1.25.7
 
 require (
-	github.com/DataWorkflowServices/dws v0.0.1-0.20260421190845-90e38cb361c4
+	github.com/DataWorkflowServices/dws v0.0.1-0.20260506165801-7e73c2416704
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20260501192528-eff76bb67716
 	github.com/NearNodeFlash/nnf-ec v0.0.1-0.20260310162051-7797cd568379
 	github.com/fsnotify/fsnotify v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataWorkflowServices/dws v0.0.1-0.20260421190845-90e38cb361c4 h1:1swrE8+jaZ6k5/XV9GOxHCpT3alItx9LQTL4Q4lyIDc=
-github.com/DataWorkflowServices/dws v0.0.1-0.20260421190845-90e38cb361c4/go.mod h1:4zp8Ar95lcBjmk/GavkALeIGP9btG176rFQ08XQtVXE=
+github.com/DataWorkflowServices/dws v0.0.1-0.20260506165801-7e73c2416704 h1:/bbdHCdc+M0tIsO+Q/VOob+P56v4P9BNpGeWmtKDgB0=
+github.com/DataWorkflowServices/dws v0.0.1-0.20260506165801-7e73c2416704/go.mod h1:4zp8Ar95lcBjmk/GavkALeIGP9btG176rFQ08XQtVXE=
 github.com/HewlettPackard/structex v1.0.4 h1:RVTdN5FWhDWr1IkjllU8wxuLjISo4gr6u5ryZpzyHcA=
 github.com/HewlettPackard/structex v1.0.4/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20260501192528-eff76bb67716 h1:rYl9xcPxLMO/dy2nukD6jejrDIxQEu8T9SaTpWhsvyA=

--- a/internal/controller/directivebreakdown_controller.go
+++ b/internal/controller/directivebreakdown_controller.go
@@ -370,7 +370,7 @@ func (r *DirectiveBreakdownReconciler) createOrUpdatePersistentStorageInstance(c
 					return err
 				}
 			} else {
-				if psi.Spec.UserID != dbd.Spec.UserID {
+				if !persistentStorageIgnoresUID(psi) && psi.Spec.UserID != dbd.Spec.UserID {
 					return dwsv1alpha7.NewResourceError("existing persistent storage user ID %v does not match user ID %v", psi.Spec.UserID, dbd.Spec.UserID).WithUserMessage("User ID does not match existing persistent storage").WithFatal().WithUser()
 				}
 			}

--- a/internal/controller/nnf_workflow_controller_helpers.go
+++ b/internal/controller/nnf_workflow_controller_helpers.go
@@ -386,6 +386,20 @@ func (r *NnfWorkflowReconciler) validatePersistentInstance(ctx context.Context, 
 	return nil
 }
 
+// PersistentStorageIgnoreUIDAnnotation allows a persistentdw directive to
+// bypass the check that workflow.spec.userID matches
+// PersistentStorageInstance.spec.userID.
+//
+// This annotation applies only to persistentdw. It does not apply to
+// destroy_persistent, which still requires a matching userID.
+const PersistentStorageIgnoreUIDAnnotation = "dataworkflowservices.github.io/ignore-uid"
+
+// persistentStorageIgnoresUID returns true when the PSI has the ignore-uid
+// annotation set to "true".
+func persistentStorageIgnoresUID(psi *dwsv1alpha7.PersistentStorageInstance) bool {
+	return strings.EqualFold(psi.Annotations[PersistentStorageIgnoreUIDAnnotation], "true")
+}
+
 // validatePersistentInstance validates the persistentdw directive.
 func (r *NnfWorkflowReconciler) validatePersistentInstanceDirective(ctx context.Context, wf *dwsv1alpha7.Workflow, directive string) error {
 	// Validate that the persistent instance is available and not in the process of being deleted
@@ -403,7 +417,7 @@ func (r *NnfWorkflowReconciler) validatePersistentInstanceDirective(ctx context.
 		return dwsv1alpha7.NewResourceError("").WithUserMessage("Persistent storage instance '%s' is deleting", args["name"]).WithUser().WithFatal()
 	}
 
-	if psi.Spec.UserID != wf.Spec.UserID {
+	if !persistentStorageIgnoresUID(psi) && psi.Spec.UserID != wf.Spec.UserID {
 		return dwsv1alpha7.NewResourceError("existing persistent storage user ID %v does not match user ID %v", psi.Spec.UserID, wf.Spec.UserID).WithUserMessage("User ID does not match existing persistent storage").WithFatal().WithUser()
 	}
 

--- a/internal/controller/nnf_workflow_controller_test.go
+++ b/internal/controller/nnf_workflow_controller_test.go
@@ -1858,11 +1858,73 @@ var _ = Describe("NNF Workflow Unit Tests", func() {
 				fmt.Sprintf("#DW persistentdw name=%s", persistentStorageName),
 			}
 			Expect(k8sClient.Create(context.TODO(), workflow)).To(Succeed(), "create workflow")
-			Eventually(func() *dwsv1alpha7.WorkflowDriverStatus {
-				expected := &dwsv1alpha7.Workflow{}
-				k8sClient.Get(context.TODO(), key, expected)
-				return getErroredDriverStatus(expected)
-			}).ShouldNot(BeNil(), "have an error present")
+
+			By("Expecting the controller to set an error due to userID mismatch")
+			Eventually(func(g Gomega) error {
+				g.Expect(k8sClient.Get(context.TODO(), key, workflow)).To(Succeed())
+				if workflow.Status.Status == dwsv1alpha7.StatusError &&
+					strings.Contains(workflow.Status.Message, "User ID does not match existing persistent storage") {
+					return nil
+				}
+				return fmt.Errorf("waiting for UID mismatch error")
+			}).Should(Succeed(), "controller should report UID mismatch error")
+		})
+
+		It("succeeds at Proposal when ignore-uid annotation is set on PSI", func() {
+			By("Fabricate a persistent storage instance owned by a different user with ignore-uid annotation")
+			psi := &dwsv1alpha7.PersistentStorageInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      persistentStorageName,
+					Namespace: workflow.Namespace,
+					Annotations: map[string]string{
+						PersistentStorageIgnoreUIDAnnotation: "true",
+					},
+				},
+				Spec: dwsv1alpha7.PersistentStorageInstanceSpec{
+					Name:        persistentStorageName,
+					FsType:      "lustre",
+					DWDirective: "#DW create_persistent capacity=1GB name=" + persistentStorageName,
+					State:       dwsv1alpha7.PSIStateActive,
+					UserID:      altWorkflowUserID,
+				},
+			}
+			Expect(k8sClient.Create(context.TODO(), psi)).To(Succeed())
+
+			nnfStorage := &nnfv1alpha11.NnfStorage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      persistentStorageName,
+					Namespace: workflow.Namespace,
+				},
+				Spec: nnfv1alpha11.NnfStorageSpec{
+					FileSystemType: "lustre",
+					AllocationSets: []nnfv1alpha11.NnfStorageAllocationSetSpec{},
+				},
+			}
+			nnfStorageProfile := &nnfv1alpha11.NnfStorageProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      persistentStorageName,
+					Namespace: workflow.Namespace,
+				},
+			}
+			addPinnedStorageProfileLabel(nnfStorage, nnfStorageProfile)
+			Expect(k8sClient.Create(context.TODO(), nnfStorage)).To(Succeed())
+
+			workflow.Spec.DWDirectives = []string{
+				fmt.Sprintf("#DW persistentdw name=%s", persistentStorageName),
+			}
+			Expect(k8sClient.Create(context.TODO(), workflow)).To(Succeed(), "create workflow")
+
+			By("Expecting the workflow to reach Proposal state despite UID mismatch")
+			Eventually(func(g Gomega) error {
+				g.Expect(k8sClient.Get(context.TODO(), key, workflow)).To(Succeed())
+				if getErroredDriverStatus(workflow) != nil {
+					return fmt.Errorf("workflow entered error state: %s", workflow.Status.Message)
+				}
+				if workflow.Status.Ready && workflow.Status.State == dwsv1alpha7.StateProposal {
+					return nil
+				}
+				return fmt.Errorf("ready state not achieved")
+			}).Should(Succeed(), "reach Proposal state with ignore-uid annotation")
 		})
 	})
 })

--- a/vendor/github.com/DataWorkflowServices/dws/api/v1alpha7/persistentstorageinstance_webhook.go
+++ b/vendor/github.com/DataWorkflowServices/dws/api/v1alpha7/persistentstorageinstance_webhook.go
@@ -85,10 +85,6 @@ func (r *PersistentStorageInstance) ValidateUpdate(old runtime.Object) (admissio
 		return nil, immutableError("DWDirective")
 	}
 
-	if r.Spec.UserID != oldPSI.Spec.UserID {
-		return nil, immutableError("UserID")
-	}
-
 	return nil, nil
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/DataWorkflowServices/dws v0.0.1-0.20260421190845-90e38cb361c4
+# github.com/DataWorkflowServices/dws v0.0.1-0.20260506165801-7e73c2416704
 ## explicit; go 1.25.7
 github.com/DataWorkflowServices/dws/api/v1alpha7
 github.com/DataWorkflowServices/dws/config/crd/bases


### PR DESCRIPTION
Honor the `dataworkflowservices.github.io/ignore-uid` annotation on
`PersistentStorageInstance` resources to allow cross-user access for
`persistentdw` directives.

## Changes

- Define `PersistentStorageIgnoreUIDAnnotation` constant and
  `persistentStorageIgnoresUID()` helper in `nnf_workflow_controller_helpers.go`
- Bypass UID check in `validatePersistentInstanceDirective` when annotation
  is `"true"`
- Bypass UID check in `directivebreakdown` `createOrUpdatePersistentStorageInstance`
  when annotation is `"true"`
- `destroy_persistent` retains the UID check unconditionally
- Update tests: controller-level UID enforcement replaces the former webhook rejection
- Add test for successful Proposal with `ignore-uid` annotation set
- Re-vendor DWS to latest master