### PR TITLE
nnf: move 'state' sub-command from system to rabbit

### DIFF
--- a/tools/nnf/src/nnf/commands/rabbit/__init__.py
+++ b/tools/nnf/src/nnf/commands/rabbit/__init__.py
@@ -3,7 +3,7 @@
 import argparse
 
 from nnf.commands import add_command_parser
-from nnf.commands.rabbit import disable, drain, enable, undrain
+from nnf.commands.rabbit import state, disable, drain, enable, undrain
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
@@ -16,6 +16,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     sub = rabbit_parser.add_subparsers(dest="rabbit_command", metavar="<action>")
     sub.required = True
 
+    state.register(sub)
     disable.register(sub)
     drain.register(sub)
     enable.register(sub)

--- a/tools/nnf/src/nnf/commands/rabbit/state.py
+++ b/tools/nnf/src/nnf/commands/rabbit/state.py
@@ -1,4 +1,4 @@
-"""system state sub-command: report the state of Rabbit storage resources.
+"""rabbit state sub-command: report the state of Rabbit storage resources.
 
 Displays a summary of NnfNode server health/status and DWS Storage
 state/status, including disabled and drained nodes with their reasons.
@@ -46,7 +46,7 @@ _MISSING_BUCKET = "<missing>"
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
-    """Register the system state sub-command."""
+    """Register the rabbit state sub-command."""
     parser: argparse.ArgumentParser = add_command_parser(
         subparsers,
         "state",
@@ -221,7 +221,7 @@ def _build_annotation_rows(
 
 
 def run(args: argparse.Namespace) -> int:
-    """Execute the system state sub-command."""
+    """Execute the rabbit state sub-command."""
     errors = 0
 
     # --- Node Status Summary ---

--- a/tools/nnf/src/nnf/commands/system/__init__.py
+++ b/tools/nnf/src/nnf/commands/system/__init__.py
@@ -3,7 +3,7 @@
 import argparse
 
 from nnf.commands import add_command_parser
-from nnf.commands.system import df, flowschema, state, version
+from nnf.commands.system import df, flowschema, version
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
@@ -18,5 +18,4 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
 
     df.register(sub)
     flowschema.register(sub)
-    state.register(sub)
     version.register(sub)


### PR DESCRIPTION
This sub-command which reports the state of the rabbits fits a bit more naturally as `nnf rabbit state`.  This has the added benefit of allowing us to use `nnf system state` to report the kubernetes cluster state.