### PR TITLE
nnf: add man pages for nnf utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -512,3 +512,18 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+PREFIX ?= /usr/local
+MANDIR ?= $(PREFIX)/share/man
+MAN1DIR ?= $(MANDIR)/man1
+
+MAN1PAGES = man/man1/nnf.1 man/man1/nnf-persistent.1 man/man1/nnf-rabbit.1 man/man1/nnf-system.1
+
+.PHONY: install-man uninstall-man
+
+install-man:
+	mkdir -p $(DESTDIR)$(MAN1DIR)
+	install -m 0644 $(MAN1PAGES) $(DESTDIR)$(MAN1DIR)/
+
+uninstall-man:
+	rm -f $(addprefix $(DESTDIR)$(MAN1DIR)/,$(notdir $(MAN1PAGES)))

--- a/man/man1/nnf-persistent.1
+++ b/man/man1/nnf-persistent.1
@@ -1,0 +1,285 @@
+.TH NNF-PERSISTENT 1 "2026-05-08" "nnf 0.1.0" "User Commands"
+.SH NAME
+nnf-persistent \- manage DWS PersistentStorageInstance resources
+.SH SYNOPSIS
+.B nnf persistent
+.I action
+.RI [ options ]
+
+.PP
+.B nnf persistent create
+.BI --name " NAME"
+.BI --fs-type " {raw|xfs|gfs2|lustre}"
+.RI [ --capacity " SIZE" ]
+.RI [ --rabbits " RABBIT " ...]
+.RI [ --rabbits-mdt " RABBIT " ...]
+.RI [ --rabbits-mgt " RABBIT " ...]
+.RI [ --rabbit-count " N" ]
+.RI [ --alloc-count " N" ]
+.RI [ --profile " PROFILE" ]
+.RI [ --namespace " NAMESPACE" ]
+.RI [ --user-id " UID" ]
+.RI [ --group-id " GID" ]
+.RI [ --timeout " SECONDS" ]
+.RI [ -v | --verbose ]
+
+.PP
+.B nnf persistent destroy
+.BI --name " NAME"
+.RI [ --namespace " NAMESPACE" ]
+.RI [ --user-id " UID" ]
+.RI [ --group-id " GID" ]
+.RI [ --timeout " SECONDS" ]
+.RI [ -v | --verbose ]
+
+.PP
+.B nnf persistent share
+.BI --name " NAME"
+.RI [ --namespace " NAMESPACE" ]
+.RI [ -v | --verbose ]
+
+.PP
+.B nnf persistent unshare
+.BI --name " NAME"
+.RI [ --namespace " NAMESPACE" ]
+.RI [ -v | --verbose ]
+
+.SH DESCRIPTION
+.B nnf persistent
+manages DWS PersistentStorageInstance resources.
+
+The
+.B create
+and
+.B destroy
+actions submit DWS Workflows and drive them through all workflow states. The
+Workflow is deleted on exit whether the operation succeeds or fails.
+
+The
+.B share
+and
+.B unshare
+actions are used allow a PersistentStorageInstance to be shared between users.
+
+.SH ACTIONS
+.SS create
+Create a persistent storage instance.
+
+Builds a
+.B #DW create_persistent
+directive and submits it as a Workflow.
+
+.TP
+.BI --name " NAME"
+Name of the persistent storage instance.
+.TP
+.BI --fs-type " TYPE"
+Filesystem type, one of
+.BR raw ,
+.BR xfs ,
+.BR gfs2 ,
+or
+.BR lustre .
+.TP
+.BI --capacity " SIZE"
+Allocation capacity per Rabbit, for example
+.B 1GiB
+or
+.BR 500MiB .
+Required unless the selected Lustre profile specifies
+.B standaloneMgtPoolName.
+.TP
+.BI --rabbits " RABBIT " ...
+One or more Rabbit node names. May be given as separate values or comma-separated values.
+Mutually exclusive with
+.BR --rabbit-count .
+.TP
+.BI --rabbits-mdt " RABBIT " ...
+Rabbit nodes for
+.B mdt
+and
+.B mgtmdt
+allocation sets. Defaults to
+.BR --rabbits .
+Valid only with
+.BR --fs-type " lustre" .
+Cannot be combined with
+.BR --rabbit-count .
+.TP
+.BI --rabbits-mgt " RABBIT " ...
+Rabbit nodes for
+.B mgt
+allocation sets. Defaults to
+.BR --rabbits .
+Valid only with
+.BR --fs-type " lustre" .
+Cannot be combined with
+.BR --rabbit-count .
+.TP
+.BI --rabbit-count " N"
+Number of Rabbits to choose at random from the
+.B default/default
+SystemConfiguration. Mutually exclusive with
+.BR --rabbits ,
+.BR --rabbits-mdt ,
+and
+.BR --rabbits-mgt .
+.TP
+.BI --alloc-count " N"
+Number of allocations per Rabbit node. Default is 1.
+.TP
+.BI --profile " PROFILE"
+Storage profile name to include in the directive.
+.TP
+.BI --namespace " NAMESPACE"
+Kubernetes namespace. Default is
+.BR default .
+.TP
+.BI --user-id " UID"
+User ID that owns this storage. Default is the current user ID.
+.TP
+.BI --group-id " GID"
+Group ID that owns this storage. Default is the current group ID.
+.TP
+.BI --timeout " SECONDS"
+Seconds to wait for each workflow state. Default is 180.
+.TP
+.BR -v ", " --verbose
+Enable verbose logging.
+
+.SS "create validation rules"
+.IP \(bu 2
+One of
+.B --rabbits
+or
+.B --rabbit-count
+is required.
+.IP \(bu 2
+.B --rabbit-count
+must be at least 1.
+.IP \(bu 2
+.B --alloc-count
+must be at least 1.
+.IP \(bu 2
+.B --rabbits-mdt
+and
+.B --rabbits-mgt
+are valid only for Lustre.
+.IP \(bu 2
+If a Lustre profile specifies
+.B standaloneMgtPoolName,
+then
+.B --capacity
+must not be used, exactly one Rabbit must be selected, and
+.B --alloc-count
+must be 1.
+.IP \(bu 2
+If the profile does not specify
+.B standaloneMgtPoolName,
+then
+.B --capacity
+is required.
+
+.SS destroy
+Destroy a persistent storage instance.
+
+Builds a
+.B #DW destroy_persistent
+directive and submits it as a Workflow.
+
+.TP
+.BI --name " NAME"
+Name of the persistent storage instance to destroy.
+.TP
+.BI --namespace " NAMESPACE"
+Kubernetes namespace. Default is
+.BR default .
+.TP
+.BI --user-id " UID"
+User ID for the workflow. If omitted, the command attempts to read
+.B userID
+from the target PersistentStorageInstance.
+.TP
+.BI --group-id " GID"
+Group ID for the workflow. Default is the current group ID.
+.TP
+.BI --timeout " SECONDS"
+Seconds to wait for each workflow state. Default is 180.
+.TP
+.BR -v ", " --verbose
+Enable verbose logging.
+
+.SS share
+Mark a persistent storage instance as shared by adding the
+.B dataworkflowservices.github.io/ignore-uid
+annotation.
+
+.TP
+.BI --name " NAME"
+Name of the persistent storage instance to share.
+.TP
+.BI --namespace " NAMESPACE"
+Kubernetes namespace. Default is
+.BR default .
+.TP
+.BR -v ", " --verbose
+Enable verbose logging.
+
+.SS unshare
+Remove shared access by removing the
+.B dataworkflowservices.github.io/ignore-uid
+annotation.
+
+.TP
+.BI --name " NAME"
+Name of the persistent storage instance to unshare.
+.TP
+.BI --namespace " NAMESPACE"
+Kubernetes namespace. Default is
+.BR default .
+.TP
+.BR -v ", " --verbose
+Enable verbose logging.
+
+.SH EXIT STATUS
+.TP
+.B 0
+Success.
+.TP
+.B 1
+Validation error, lookup failure, or patch failure.
+.TP
+.B 2
+Workflow creation or workflow execution failure.
+
+.SH EXAMPLES
+.TP
+Create an XFS persistent storage instance:
+.B nnf persistent create --name my-psi --fs-type xfs --capacity 1GiB --rabbits rabbit-0
+
+.TP
+Create a Lustre persistent storage instance on three random Rabbits:
+.B nnf persistent create --name lustre-a --fs-type lustre --capacity 1TiB --rabbit-count 3
+
+.TP
+Destroy a persistent storage instance:
+.B nnf persistent destroy --name my-psi
+
+.TP
+Share a persistent storage instance:
+.B nnf persistent share --name my-psi
+
+.TP
+Unshare a persistent storage instance:
+.B nnf persistent unshare --name my-psi
+
+.SH SEE ALSO
+.BR nnf (1),
+.BR nnf-rabbit (1),
+.BR nnf-system (1),
+.BR kubectl (1)
+
+.SH COPYRIGHT
+Copyright 2026 Hewlett Packard Enterprise Development LP
+.PP
+Licensed under the Apache License, Version 2.0.

--- a/man/man1/nnf-rabbit.1
+++ b/man/man1/nnf-rabbit.1
@@ -1,0 +1,167 @@
+.TH NNF-RABBIT 1 "2026-05-08" "nnf 0.1.0" "User Commands"
+.SH NAME
+nnf-rabbit \- manage Rabbit node state
+.SH SYNOPSIS
+.B nnf rabbit
+.I action
+.RI [ options ]
+
+.PP
+.B nnf rabbit state
+.RI [ -v | --verbose ]
+
+.PP
+.B nnf rabbit disable
+.RI [ -r " REASON" ]
+.I NODE
+.RI [ NODE " ..." ]
+.RI [ -v | --verbose ]
+
+.PP
+.B nnf rabbit drain
+.RI [ -r " REASON" ]
+.I NODE
+.RI [ NODE " ..." ]
+.RI [ -v | --verbose ]
+
+.PP
+.B nnf rabbit enable
+.I NODE
+.RI [ NODE " ..." ]
+.RI [ -v | --verbose ]
+
+.PP
+.B nnf rabbit undrain
+.I NODE
+.RI [ NODE " ..." ]
+.RI [ -v | --verbose ]
+
+.SH DESCRIPTION
+.B nnf rabbit
+These actions operate on Rabbit-related Kubernetes resources, including
+Kubernetes Node objects, NnfNode resources, and DWS Storage resources.
+
+.SH ACTIONS
+.SS state
+Report the state of Rabbit storage resources.
+
+This action displays a summary of:
+.IP \(bu 2
+NnfNode server health and status
+.IP \(bu 2
+DWS Storage state and status
+.IP \(bu 2
+Disabled and drained Rabbit nodes, including dates and reasons
+.IP \(bu 2
+Compute nodes associated with Rabbits that are marked with the
+badrabbit property.  These computes nodes will not be allocated by
+flux for jobs requiring rabbit resources.
+
+.TP
+.BR -v ", " --verbose
+Enable verbose logging.
+
+.SS disable
+Disable one or more Rabbit nodes so Flux does not use them for allocations.
+
+.TP
+.I NODE
+One or more Rabbit node names to disable.
+.TP
+.BI -r " REASON"
+.TQ
+.BI --reason " REASON"
+Reason for disabling the node. Default is
+.BR none .
+.TP
+.BR -v ", " --verbose
+Enable verbose logging.
+
+.SS drain
+Drain one or more Rabbit nodes to terminate the NNF pods running there.
+This can be used to unmount the global Lustre filesystem from the nnf-dm-worker
+pod.
+
+This taints the Kubernetes Node with
+.B cray.nnf.node.drain=true
+for both
+.B NoSchedule
+and
+.B NoExecute
+
+If tainting the node fails after annotations are applied, the command attempts
+to roll back the drain annotations.
+
+.TP
+.I NODE
+One or more Rabbit node names to drain.
+.TP
+.BI -r " REASON"
+.TQ
+.BI --reason " REASON"
+Reason for draining the node. Default is
+.BR none .
+.TP
+.BR -v ", " --verbose
+Enable verbose logging.
+
+.SS enable
+Enable one or more Rabbit nodes so Flux can use them for allocations again.
+
+.TP
+.I NODE
+One or more Rabbit node names to enable.
+.TP
+.BR -v ", " --verbose
+Enable verbose logging.
+
+.SS undrain
+Undrain one or more Rabbit nodes which removes the taints allowing the NNF pods
+to be scheduled and started.
+
+.TP
+.I NODE
+One or more Rabbit node names to undrain.
+.TP
+.BR -v ", " --verbose
+Enable verbose logging.
+
+.SH EXIT STATUS
+.TP
+.B 0
+Success.
+.TP
+.B 1
+One or more requested operations failed, or resource queries failed.
+
+.SH EXAMPLES
+.TP
+Show Rabbit state summary:
+.B nnf rabbit state
+
+.TP
+Disable a Rabbit with a reason:
+.B nnf rabbit disable --reason 'scheduled maintenance' rabbit-0
+
+.TP
+Drain multiple Rabbit nodes:
+.B nnf rabbit drain rabbit-0 rabbit-1
+
+.TP
+Enable a Rabbit:
+.B nnf rabbit enable rabbit-0
+
+.TP
+Undrain a Rabbit:
+.B nnf rabbit undrain rabbit-0
+
+.SH SEE ALSO
+.BR nnf (1),
+.BR nnf-persistent (1),
+.BR nnf-system (1),
+.BR kubectl (1)
+
+.SH COPYRIGHT
+Copyright 2026 Hewlett Packard Enterprise Development LP
+.PP
+Licensed under the Apache License, Version 2.0.

--- a/man/man1/nnf-system.1
+++ b/man/man1/nnf-system.1
@@ -1,0 +1,155 @@
+.TH NNF-SYSTEM 1 "2026-05-08" "nnf 0.1.0" "User Commands"
+.SH NAME
+nnf-system \- cluster-level administration for nnf
+.SH SYNOPSIS
+.B nnf system
+.I action
+.RI [ options ]
+
+.PP
+.B nnf system df
+.RI [ NODE " ..." ]
+.RI [ -v | --verbose ]
+
+.PP
+.B nnf system flowschema
+.RI [ -c " NAME" | -l | -p | -s ]
+.RI [ -v | --verbose ]
+
+.PP
+.B nnf system version
+.RI [ -v | --verbose ]
+
+.SH DESCRIPTION
+.B nnf system
+provides cluster-level administration commands for NNF-related resources.
+
+Based on the provided source, the registered system subcommands are:
+.BR df ,
+.BR flowschema ,
+and
+.BR version .
+
+.SH ACTIONS
+.SS df
+Show disk space information for Rabbit nodes.
+
+This command queries each Rabbit's node-manager pod in the
+.B nnf-system
+namespace, using the Redfish
+.B /redfish/v1/StorageServices/NNF/CapacitySource
+endpoint, and displays:
+.IP \(bu 2
+Allocated bytes
+.IP \(bu 2
+Consumed bytes
+.IP \(bu 2
+Guaranteed bytes
+.IP \(bu 2
+Provisioned bytes
+
+If no nodes are specified, the command considers all DWS Storage resources and
+queries only nodes that are in Enabled/Ready state. Nodes not in Enabled/Ready
+state are skipped and reported afterward.
+
+If nodes are explicitly named, a node that is not Enabled/Ready is treated as
+an error.
+
+.TP
+.I NODE
+Rabbit node names to query. If omitted, all Enabled/Ready Rabbits are queried.
+.TP
+.BR -v ", " --verbose
+Enable verbose logging.
+
+.SS flowschema
+Display Kubernetes API Priority and Fairness FlowSchema information.
+
+Exactly one of the following options is required:
+
+.TP
+.BI -c " NAME"
+.TQ
+.BI --activity " NAME"
+View metrics activity for a specific FlowSchema.
+.TP
+.BR -l ", " --list
+List FlowSchema resources.
+.TP
+.BR -p ", " --priority-levels
+List PriorityLevelConfiguration resources.
+.TP
+.BR -s ", " --summary
+Show the API server priority-level summary dump.
+.TP
+.BR -v ", " --verbose
+Enable verbose logging.
+
+The command discovers an available API version from the flowcontrol API group
+and prefers
+.BR v1 ,
+then
+.BR v1beta3 ,
+then
+.BR v1beta2 .
+
+.SS version
+Display version information for the NNF controller.
+
+This command reads labels from the
+.B nnf-controller-manager
+Deployment in the
+.B nnf-system
+namespace and prints them as formatted JSON.
+
+.TP
+.BR -v ", " --verbose
+Enable verbose logging.
+
+.SH EXIT STATUS
+.TP
+.B 0
+Success.
+.TP
+.B 1
+Lookup failure, API failure, or command-specific error.
+
+.SH EXAMPLES
+.TP
+Show capacity for all Enabled/Ready Rabbit nodes:
+.B nnf system df
+
+.TP
+Show capacity for selected Rabbit nodes:
+.B nnf system df rabbit-0 rabbit-1
+
+.TP
+List FlowSchemas:
+.B nnf system flowschema --list
+
+.TP
+List priority level configurations:
+.B nnf system flowschema --priority-levels
+
+.TP
+Show activity for a specific FlowSchema:
+.B nnf system flowschema --activity catch-all
+
+.TP
+Show API priority and fairness summary:
+.B nnf system flowschema --summary
+
+.TP
+Show NNF controller version labels:
+.B nnf system version
+
+.SH SEE ALSO
+.BR nnf (1),
+.BR nnf-persistent (1),
+.BR nnf-rabbit (1),
+.BR kubectl (1)
+
+.SH COPYRIGHT
+Copyright 2026 Hewlett Packard Enterprise Development LP
+.PP
+Licensed under the Apache License, Version 2.0.

--- a/man/man1/nnf.1
+++ b/man/man1/nnf.1
@@ -1,0 +1,123 @@
+.TH NNF 1 "2026-05-08" "nnf 0.1.0" "User Commands"
+.SH NAME
+nnf \- CLI tool for managing NNF and DWS resources
+.SH SYNOPSIS
+.B nnf
+.RI [ --kubeconfig " FILE" ]
+.RI [ -v | --verbose ]
+.I command
+.RI [ options ]
+
+.PP
+.B nnf persistent
+.I action
+.RI [ options ]
+
+.PP
+.B nnf rabbit
+.I action
+.RI [ options ]
+
+.PP
+.B nnf system
+.I action
+.RI [ options ]
+
+.SH DESCRIPTION
+.B nnf
+is a command-line tool for managing Near Node Flash, NNF, and Data Workflow
+Services, DWS, resources in a Kubernetes cluster.
+
+It loads Kubernetes configuration from the path given by
+.BR --kubeconfig .
+If that option is omitted, it uses normal kubeconfig resolution, such as
+.BR KUBECONFIG
+or
+.BR ~/.kube/config ,
+and falls back to in-cluster configuration when available.
+
+Subcommands are organized into functional groups:
+.TP
+.B persistent
+Manage DWS PersistentStorageInstance resources.
+.TP
+.B rabbit
+Manage Rabbit node state.
+.TP
+.B system
+Perform cluster-level administration tasks.
+
+.SH OPTIONS
+.TP
+.BI --kubeconfig " FILE"
+Optional path to a kubeconfig file.
+.TP
+.BR -v ", " --verbose
+Enable verbose logging.
+
+.SH COMMANDS
+.TP
+.B persistent
+Manage persistent storage instances.
+See
+.BR nnf-persistent (1).
+.TP
+.B rabbit
+Manage Rabbit node state.
+See
+.BR nnf-rabbit (1).
+.TP
+.B system
+Cluster-level administration.
+See
+.BR nnf-system (1).
+
+.SH EXIT STATUS
+.TP
+.B 0
+Success.
+.TP
+.B 1
+Validation failure, lookup/update failure, or partial failure for multi-node
+operations.
+.TP
+.B 2
+Workflow-related failure, or failure to load Kubernetes configuration.
+
+.SH FILES
+.TP
+.I ~/.kube/config
+Default kubeconfig path, if
+.B --kubeconfig
+and
+.B KUBECONFIG
+are not set.
+
+.SH ENVIRONMENT
+.TP
+.B KUBECONFIG
+Standard Kubernetes client environment variable for kubeconfig resolution.
+
+.SH EXAMPLES
+.TP
+Create a persistent storage instance:
+.B nnf persistent create --name my-psi --fs-type xfs --capacity 1GiB --rabbits rabbit-0
+
+.TP
+Drain a Rabbit node:
+.B nnf rabbit drain rabbit-0
+
+.TP
+Show Rabbit disk space information:
+.B nnf system df
+
+.SH SEE ALSO
+.BR nnf-persistent (1),
+.BR nnf-rabbit (1),
+.BR nnf-system (1),
+.BR kubectl (1)
+
+.SH COPYRIGHT
+Copyright 2026 Hewlett Packard Enterprise Development LP
+.PP
+Licensed under the Apache License, Version 2.0.


### PR DESCRIPTION
Add a high-level `nnf(1)` man page as well an individual pages for each available sub-command: `nnf-persistent(1)`, `nnf-rabbit(1)`, and `nnf-system(1)`.

The `nnf-rabbit(1)` page includes the 'state' action which is currently part of the nnf-system command but a PR exists to move it.