### PR TITLE
tests: fix import path after state moved from system to rabbit

### DIFF
--- a/tools/nnf/tests/test_system_state.py
+++ b/tools/nnf/tests/test_system_state.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 import kubernetes.client.exceptions  # type: ignore[import-untyped]
 
 from nnf import crd
-from nnf.commands.system.state import (
+from nnf.commands.rabbit.state import (
     _build_annotation_rows,
     _build_node_status_rows,
     _build_storage_status_rows,
@@ -235,7 +235,7 @@ def test_build_storage_status_rows_includes_unexpected_values() -> None:
     assert ("Cordoned", "Recovering", "1", "rabbit-9") in rows
 
 
-@patch("nnf.commands.system.state.k8s.list_objects")
+@patch("nnf.commands.rabbit.state.k8s.list_objects")
 def test_get_all_storages_uses_local_k8s_helper(mock_list_objects: MagicMock) -> None:
     mock_list_objects.return_value = {"items": [{"metadata": {"name": "rabbit-0"}}]}
 
@@ -311,9 +311,9 @@ def test_build_annotation_rows_null_annotations() -> None:
 # ---------------------------------------------------------------------------
 
 
-@patch("nnf.commands.system.state._show_disabled_computes")
-@patch("nnf.commands.system.state._get_all_storages")
-@patch("nnf.commands.system.state._get_all_nnfnodes")
+@patch("nnf.commands.rabbit.state._show_disabled_computes")
+@patch("nnf.commands.rabbit.state._get_all_storages")
+@patch("nnf.commands.rabbit.state._get_all_nnfnodes")
 def test_run_success(
     mock_nodes: MagicMock,
     mock_storages: MagicMock,
@@ -335,9 +335,9 @@ def test_run_success(
     assert "rabbit-0" in out
 
 
-@patch("nnf.commands.system.state._show_disabled_computes")
-@patch("nnf.commands.system.state._get_all_storages")
-@patch("nnf.commands.system.state._get_all_nnfnodes")
+@patch("nnf.commands.rabbit.state._show_disabled_computes")
+@patch("nnf.commands.rabbit.state._get_all_storages")
+@patch("nnf.commands.rabbit.state._get_all_nnfnodes")
 def test_run_with_annotations(
     mock_nodes: MagicMock,
     mock_storages: MagicMock,
@@ -357,9 +357,9 @@ def test_run_with_annotations(
     assert "test" in out
 
 
-@patch("nnf.commands.system.state._show_disabled_computes")
-@patch("nnf.commands.system.state._get_all_storages")
-@patch("nnf.commands.system.state._get_all_nnfnodes")
+@patch("nnf.commands.rabbit.state._show_disabled_computes")
+@patch("nnf.commands.rabbit.state._get_all_storages")
+@patch("nnf.commands.rabbit.state._get_all_nnfnodes")
 def test_run_nnfnode_api_error(
     mock_nodes: MagicMock,
     mock_storages: MagicMock,
@@ -375,9 +375,9 @@ def test_run_nnfnode_api_error(
     assert "NnfNode" in err
 
 
-@patch("nnf.commands.system.state._show_disabled_computes")
-@patch("nnf.commands.system.state._get_all_storages")
-@patch("nnf.commands.system.state._get_all_nnfnodes")
+@patch("nnf.commands.rabbit.state._show_disabled_computes")
+@patch("nnf.commands.rabbit.state._get_all_storages")
+@patch("nnf.commands.rabbit.state._get_all_nnfnodes")
 def test_run_storage_api_error(
     mock_nodes: MagicMock,
     mock_storages: MagicMock,
@@ -398,25 +398,25 @@ def test_run_storage_api_error(
 # ---------------------------------------------------------------------------
 
 
-@patch("nnf.commands.system.state.subprocess.run")
+@patch("nnf.commands.rabbit.state.subprocess.run")
 def test_run_cmd_success(mock_run: MagicMock) -> None:
     mock_run.return_value = MagicMock(returncode=0, stdout="hello\n", stderr="")
     assert _run_cmd(["echo", "hello"]) == "hello"
 
 
-@patch("nnf.commands.system.state.subprocess.run")
+@patch("nnf.commands.rabbit.state.subprocess.run")
 def test_run_cmd_failure(mock_run: MagicMock) -> None:
     mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="err")
     assert _run_cmd(["false"]) is None
 
 
-@patch("nnf.commands.system.state.subprocess.run")
+@patch("nnf.commands.rabbit.state.subprocess.run")
 def test_run_cmd_oserror(mock_run: MagicMock) -> None:
     mock_run.side_effect = OSError("not found")
     assert _run_cmd(["missing"]) is None
 
 
-@patch("nnf.commands.system.state.subprocess.run")
+@patch("nnf.commands.rabbit.state.subprocess.run")
 def test_run_cmd_timeout(mock_run: MagicMock) -> None:
     mock_run.side_effect = subprocess.TimeoutExpired("cmd", 30)
     assert _run_cmd(["slow"]) is None
@@ -427,16 +427,16 @@ def test_run_cmd_timeout(mock_run: MagicMock) -> None:
 # ---------------------------------------------------------------------------
 
 
-@patch("nnf.commands.system.state.shutil.which", return_value=None)
+@patch("nnf.commands.rabbit.state.shutil.which", return_value=None)
 def test_show_disabled_computes_no_flux(mock_which: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
     _show_disabled_computes()
     out = capsys.readouterr().out
     assert "Disabled Computes" not in out
 
 
-@patch("nnf.commands.system.state._run_cmd_print")
-@patch("nnf.commands.system.state._run_cmd")
-@patch("nnf.commands.system.state.shutil.which", return_value="/usr/bin/flux")
+@patch("nnf.commands.rabbit.state._run_cmd_print")
+@patch("nnf.commands.rabbit.state._run_cmd")
+@patch("nnf.commands.rabbit.state.shutil.which", return_value="/usr/bin/flux")
 def test_show_disabled_computes_with_flux(
     mock_which: MagicMock,
     mock_run_cmd: MagicMock,
@@ -465,10 +465,10 @@ def test_show_disabled_computes_with_flux(
     )
 
 
-@patch("nnf.commands.system.state.os.path.isfile", return_value=True)
-@patch("nnf.commands.system.state._run_cmd_print")
-@patch("nnf.commands.system.state._run_cmd")
-@patch("nnf.commands.system.state.shutil.which", return_value="/usr/bin/flux")
+@patch("nnf.commands.rabbit.state.os.path.isfile", return_value=True)
+@patch("nnf.commands.rabbit.state._run_cmd_print")
+@patch("nnf.commands.rabbit.state._run_cmd")
+@patch("nnf.commands.rabbit.state.shutil.which", return_value="/usr/bin/flux")
 def test_show_disabled_computes_with_nodeattr(
     mock_which: MagicMock,
     mock_run_cmd: MagicMock,
@@ -495,8 +495,8 @@ def test_show_disabled_computes_with_nodeattr(
     )
 
 
-@patch("nnf.commands.system.state._run_cmd")
-@patch("nnf.commands.system.state.shutil.which", return_value="/usr/bin/flux")
+@patch("nnf.commands.rabbit.state._run_cmd")
+@patch("nnf.commands.rabbit.state.shutil.which", return_value="/usr/bin/flux")
 def test_show_disabled_computes_no_badrabbit(
     mock_which: MagicMock,
     mock_run_cmd: MagicMock,
@@ -508,8 +508,8 @@ def test_show_disabled_computes_no_badrabbit(
     assert "Disabled Computes" not in out
 
 
-@patch("nnf.commands.system.state._run_cmd")
-@patch("nnf.commands.system.state.shutil.which", return_value="/usr/bin/flux")
+@patch("nnf.commands.rabbit.state._run_cmd")
+@patch("nnf.commands.rabbit.state.shutil.which", return_value="/usr/bin/flux")
 def test_show_disabled_computes_empty_jgf(
     mock_which: MagicMock,
     mock_run_cmd: MagicMock,


### PR DESCRIPTION
Commit eee84125 moved `state.py` from `commands/system/` to `commands/rabbit/` but did not update the test file. Both the `from ... import` statement and all `@patch` decorator paths in `test_system_state.py` still referenced `nnf.commands.system.state`, causing the `python-tests-3_6` and `python-tests-3_12` CI jobs to fail with an `ImportError`.

Update all references to `nnf.commands.rabbit.state`.