### PR TITLE
fix(nnf): clarify persistent create help text for --rabbits flags

### DIFF
--- a/tools/nnf/README.md
+++ b/tools/nnf/README.md
@@ -107,13 +107,19 @@ Key `persistent create` flags:
 - `--namespace` target namespace, default `default`
 - `--user-id` override owning user ID
 - `--group-id` override owning group ID
-- `--rabbits` explicit Rabbit node list
-- `--rabbits-mdt` Rabbit node list for `mdt` and `mgtmdt`
-- `--rabbits-mgt` Rabbit node list for `mgt`
-- `--rabbit-count` choose Rabbits randomly from the default SystemConfiguration instead of specifying them directly
 - `--alloc-count` number of allocations per Rabbit node, default `1`
 - `--profile` storage profile name
 - `--timeout` seconds to wait per workflow state, default `180`
+
+Rabbit selection (one of these is required):
+
+- `--rabbits` Rabbit node list for all allocation sets. Required unless `--rabbit-count` is used.
+- `--rabbit-count` pick N Rabbits at random from the SystemConfiguration. Mutually exclusive with all `--rabbits*` flags.
+
+Optional Lustre overrides (only valid with `--rabbits`):
+
+- `--rabbits-mdt` use these Rabbits for `mdt`/`mgtmdt` allocation sets instead of `--rabbits`
+- `--rabbits-mgt` use these Rabbits for `mgt` allocation sets instead of `--rabbits`
 
 Use `--profile` to select the `NnfStorageProfile` if the default profile is not desired. For Lustre, the profile drives allocation-set behavior for labels such as `ost`, `mdt`, `mgt`, and `mgtmdt`.
 

--- a/tools/nnf/src/nnf/commands/persistent/create.py
+++ b/tools/nnf/src/nnf/commands/persistent/create.py
@@ -54,7 +54,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
         nargs="+",
         default=None,
         metavar="RABBIT",
-        help="One or more Rabbit node names to allocate storage on (e.g. rabbit-node-0). Mutually exclusive with --rabbit-count.",
+        help="One or more Rabbit node names to allocate storage on (e.g. rabbit-node-0). Required unless --rabbit-count is used.",
     )
     parser.add_argument(
         "--rabbits-mdt",
@@ -62,7 +62,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
         default=None,
         dest="rabbits_mdt",
         metavar="RABBIT",
-        help="Rabbit nodes to use for mdt and mgtmdt allocation sets (default: --rabbits). Cannot be used with --rabbit-count.",
+        help="Override Rabbit nodes for mdt and mgtmdt allocation sets. Requires --rabbits. Cannot be used with --rabbit-count.",
     )
     parser.add_argument(
         "--rabbits-mgt",
@@ -70,7 +70,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
         default=None,
         dest="rabbits_mgt",
         metavar="RABBIT",
-        help="Rabbit nodes to use for mgt allocation sets (default: --rabbits). Cannot be used with --rabbit-count.",
+        help="Override Rabbit nodes for mgt allocation sets. Requires --rabbits. Cannot be used with --rabbit-count.",
     )
     parser.add_argument(
         "--rabbit-count",


### PR DESCRIPTION
- --rabbits: clarify it is required unless --rabbit-count is used
- --rabbits-mdt/--rabbits-mgt: clarify they are overrides that require --rabbits

Signed-off-by: Anthony Floeder <anthony.floeder@hpe.com>