### PR TITLE
Add hostlist expansion support to nnf CLI

### DIFF
--- a/tools/nnf/README.md
+++ b/tools/nnf/README.md
@@ -91,6 +91,30 @@ nnf persistent create --timeout 600 ...
 nnf persistent destroy --timeout 600 ...
 ```
 
+## Hostlist Support
+
+Rabbit node arguments accept plain node names and hostlist patterns in standard bracket notation.
+
+Examples:
+
+- `rabbit-node-[0-3]`
+- `rzadams[201-208]`
+- `rzadams[201,207-208]`
+
+This works for:
+
+- `nnf rabbit disable|drain|enable|undrain NODE...`
+- `nnf persistent create --rabbits ...`
+- `nnf persistent create --rabbits-mdt ...`
+- `nnf persistent create --rabbits-mgt ...`
+
+In most shells, brackets are glob characters, so quote hostlist arguments:
+
+```bash
+nnf rabbit disable 'rzadams[201-208]'
+nnf persistent create --name demo --fs-type xfs --capacity 1GiB --rabbits 'rabbit-node-[0-3]'
+```
+
 ## persistent create
 
 Show help for the `persistent create` subcommand:
@@ -113,13 +137,13 @@ Key `persistent create` flags:
 
 Rabbit selection (one of these is required):
 
-- `--rabbits` Rabbit node list for all allocation sets. Required unless `--rabbit-count` is used.
+- `--rabbits` Rabbit node list for all allocation sets. Accepts names and hostlist patterns. Required unless `--rabbit-count` is used.
 - `--rabbit-count` pick N Rabbits at random from the SystemConfiguration. Mutually exclusive with all `--rabbits*` flags.
 
 Optional Lustre overrides (only valid with `--rabbits`):
 
-- `--rabbits-mdt` use these Rabbits for `mdt`/`mgtmdt` allocation sets instead of `--rabbits`
-- `--rabbits-mgt` use these Rabbits for `mgt` allocation sets instead of `--rabbits`
+- `--rabbits-mdt` use these Rabbits for `mdt`/`mgtmdt` allocation sets instead of `--rabbits`; accepts hostlist patterns
+- `--rabbits-mgt` use these Rabbits for `mgt` allocation sets instead of `--rabbits`; accepts hostlist patterns
 
 Use `--profile` to select the `NnfStorageProfile` if the default profile is not desired. For Lustre, the profile drives allocation-set behavior for labels such as `ost`, `mdt`, `mgt`, and `mgtmdt`.
 
@@ -142,6 +166,17 @@ nnf persistent create \
   --capacity 10GiB \
   --profile lustre-storage-profile \
   --rabbits rabbit-node-0 rabbit-node-1
+```
+
+Create persistent storage using a hostlist pattern:
+
+```bash
+nnf persistent create \
+  --name demo-lustre-range \
+  --fs-type lustre \
+  --capacity 10GiB \
+  --profile lustre-storage-profile \
+  --rabbits 'rabbit-node-[0-3]'
 ```
 
 For Lustre, you can optionally direct MDT and MGT allocation sets to specific Rabbits instead of using the default Rabbit list for every allocation set:
@@ -266,7 +301,7 @@ nnf rabbit drain --help
 
 Key flags:
 
-- `NODE` one or more Rabbit node names (positional)
+- `NODE` one or more Rabbit node names or hostlist patterns (positional)
 - `-r`, `--reason` reason for draining the node (default: `none`)
 
 Drain a single node:
@@ -279,6 +314,12 @@ Drain multiple nodes with a reason:
 
 ```bash
 nnf rabbit drain rabbit-node-0 rabbit-node-1 --reason "firmware update"
+```
+
+Drain nodes using a hostlist pattern:
+
+```bash
+nnf rabbit drain 'rzadams[201-208]' --reason "firmware update"
 ```
 
 If the node taint fails after the storage annotation succeeds, the CLI attempts to roll back the annotation. If the rollback also fails, the CLI logs the error and continues to the next node.
@@ -307,13 +348,19 @@ nnf rabbit disable --help
 
 Key flags:
 
-- `NODE` one or more Rabbit node names (positional)
+- `NODE` one or more Rabbit node names or hostlist patterns (positional)
 - `-r`, `--reason` reason for disabling the node (default: `none`)
 
 Disable a node:
 
 ```bash
 nnf rabbit disable rabbit-node-0 --reason "bad disk"
+```
+
+Disable nodes using a hostlist pattern:
+
+```bash
+nnf rabbit disable 'rzadams[201-208]' --reason "maintenance"
 ```
 
 ## rabbit enable
@@ -328,6 +375,12 @@ Enable a node:
 
 ```bash
 nnf rabbit enable rabbit-node-0
+```
+
+Enable nodes using a hostlist pattern:
+
+```bash
+nnf rabbit enable 'rzadams[201,207-208]'
 ```
 
 ## rabbit df

--- a/tools/nnf/pyproject.toml
+++ b/tools/nnf/pyproject.toml
@@ -14,6 +14,7 @@ version = "0.1.0"
 requires-python = ">=3.6"
 dependencies = [
     "kubernetes>=12.0,<24",
+    "python-hostlist",
 ]
 
 [project.optional-dependencies]

--- a/tools/nnf/setup.py
+++ b/tools/nnf/setup.py
@@ -16,7 +16,7 @@ if setuptools_major_version() < 61:
         "python_requires": ">=3.6",
         "package_dir": {"": "src"},
         "packages": find_packages(where="src"),
-        "install_requires": ["kubernetes>=12.0,<24"],
+        "install_requires": ["kubernetes>=12.0,<24", "python-hostlist"],
         "extras_require": {
             "test": [
                 "pytest>=6.2.5,<7.1; python_version < '3.7'",

--- a/tools/nnf/src/nnf/commands/persistent/create.py
+++ b/tools/nnf/src/nnf/commands/persistent/create.py
@@ -20,6 +20,7 @@ from nnf import servers
 from nnf import utils
 from nnf import workflow
 from nnf.commands import add_command_parser, add_workflow_arguments
+from nnf.hostlist import BadHostlist, expand_args
 
 
 LOGGER = logging.getLogger(__name__)
@@ -54,7 +55,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
         nargs="+",
         default=None,
         metavar="RABBIT",
-        help="One or more Rabbit node names to allocate storage on (e.g. rabbit-node-0). Required unless --rabbit-count is used.",
+        help="One or more Rabbit node names or hostlist patterns to allocate storage on (for example rabbit-node-[0-3]). Required unless --rabbit-count is used.",
     )
     parser.add_argument(
         "--rabbits-mdt",
@@ -62,7 +63,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
         default=None,
         dest="rabbits_mdt",
         metavar="RABBIT",
-        help="Override Rabbit nodes for mdt and mgtmdt allocation sets. Requires --rabbits. Cannot be used with --rabbit-count.",
+        help="Override Rabbit nodes or hostlist patterns for mdt and mgtmdt allocation sets. Requires --rabbits. Cannot be used with --rabbit-count.",
     )
     parser.add_argument(
         "--rabbits-mgt",
@@ -70,7 +71,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
         default=None,
         dest="rabbits_mgt",
         metavar="RABBIT",
-        help="Override Rabbit nodes for mgt allocation sets. Requires --rabbits. Cannot be used with --rabbit-count.",
+        help="Override Rabbit nodes or hostlist patterns for mgt allocation sets. Requires --rabbits. Cannot be used with --rabbit-count.",
     )
     parser.add_argument(
         "--rabbit-count",
@@ -94,17 +95,6 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
     )
     add_workflow_arguments(parser)
     parser.set_defaults(func=run)
-
-
-def _split_nodes(values: Optional[List[str]]) -> List[str]:
-    """Flatten a list of node name arguments, splitting each on commas.
-
-    Allows users to write either ``--rabbits a b c`` or ``--rabbits a,b,c``
-    (or a mix of both).
-    """
-    if values is None:
-        return []
-    return [n.strip() for v in values for n in v.split(",") if n.strip()]
 
 
 def run(args: argparse.Namespace) -> int:
@@ -185,12 +175,20 @@ def run(args: argparse.Namespace) -> int:
         print("error: one of --rabbits or --rabbit-count is required", file=sys.stderr)
         return 1
     else:
-        rabbits = _split_nodes(args.rabbits)
+        try:
+            rabbits = expand_args(args.rabbits)
+        except BadHostlist as exc:
+            print(f"error: --rabbits: {exc}", file=sys.stderr)
+            return 1
         if not rabbits:
             print("error: --rabbits resolved to an empty list after normalization", file=sys.stderr)
             return 1
-        rabbits_mdt = _split_nodes(args.rabbits_mdt) or None
-        rabbits_mgt = _split_nodes(args.rabbits_mgt) or None
+        try:
+            rabbits_mdt = expand_args(args.rabbits_mdt) or None
+            rabbits_mgt = expand_args(args.rabbits_mgt) or None
+        except BadHostlist as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
 
     if args.alloc_count < 1:
         print("error: --alloc-count must be at least 1", file=sys.stderr)

--- a/tools/nnf/src/nnf/commands/rabbit/_helpers.py
+++ b/tools/nnf/src/nnf/commands/rabbit/_helpers.py
@@ -1,10 +1,12 @@
 """Shared helpers for rabbit sub-commands."""
 
 import logging
+import sys
 from typing import Any, Callable, Dict, List
 
 from nnf import crd
 from nnf import k8s
+from nnf.hostlist import BadHostlist, expand_args
 
 
 LOGGER = logging.getLogger(__name__)
@@ -74,8 +76,16 @@ def for_each_node(
     *success_msg* is a format string with one ``{}`` placeholder for the node
     name.
     """
+    try:
+        expanded = expand_args(nodes)
+    except BadHostlist as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    if not expanded:
+        print("error: node list resolved to zero hosts", file=sys.stderr)
+        return 1
     errors = 0
-    for node_name in nodes:
+    for node_name in expanded:
         rc = action(node_name)
         if rc != OK:
             errors += 1

--- a/tools/nnf/src/nnf/commands/rabbit/disable.py
+++ b/tools/nnf/src/nnf/commands/rabbit/disable.py
@@ -33,7 +33,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
         "nodes",
         nargs="+",
         metavar="NODE",
-        help="One or more Rabbit node names to disable.",
+        help="One or more Rabbit node names or hostlist patterns to disable (for example rabbit-[0-3]).",
     )
     parser.add_argument(
         "-r",

--- a/tools/nnf/src/nnf/commands/rabbit/drain.py
+++ b/tools/nnf/src/nnf/commands/rabbit/drain.py
@@ -40,7 +40,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
         "nodes",
         nargs="+",
         metavar="NODE",
-        help="One or more Rabbit node names to drain.",
+        help="One or more Rabbit node names or hostlist patterns to drain (for example rabbit-[0-3]).",
     )
     parser.add_argument(
         "-r",

--- a/tools/nnf/src/nnf/commands/rabbit/enable.py
+++ b/tools/nnf/src/nnf/commands/rabbit/enable.py
@@ -32,7 +32,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
         "nodes",
         nargs="+",
         metavar="NODE",
-        help="One or more Rabbit node names to enable.",
+        help="One or more Rabbit node names or hostlist patterns to enable (for example rabbit-[0-3]).",
     )
     parser.set_defaults(func=run)
 

--- a/tools/nnf/src/nnf/commands/rabbit/state.py
+++ b/tools/nnf/src/nnf/commands/rabbit/state.py
@@ -18,6 +18,7 @@ import kubernetes.client.exceptions  # type: ignore[import-untyped]
 from nnf import crd
 from nnf import k8s
 from nnf.commands import add_command_parser
+from nnf.hostlist import compress as _compress_hostlist
 from nnf.table import print_table as _print_table
 
 
@@ -53,55 +54,6 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
         help="Report the state of Rabbit storage resources.",
     )
     parser.set_defaults(func=run)
-
-
-def _compress_hostlist(names: List[str]) -> str:
-    """Compress a list of hostnames into bracketed range notation.
-
-    For example: ["rabbit-node-1", "rabbit-node-2", "rabbit-compute-2",
-    "rabbit-compute-3", "rabbit-compute-4", "rabbit-compute-5"]
-    becomes "rabbit-compute-[2-5],rabbit-node-[1-2]".
-
-    Names that don't end in digits are left as-is.
-    """
-    if not names:
-        return ""
-    if len(names) == 1:
-        return names[0]
-
-    # Split each name into (prefix, number).  Names without a numeric
-    # suffix are kept verbatim in the output.
-    groups: Dict[str, List[int]] = {}
-    plain: List[str] = []
-    for name in sorted(names):
-        i = len(name)
-        while i > 0 and name[i - 1].isdigit():
-            i -= 1
-        if i == len(name) or i == 0:
-            plain.append(name)
-        else:
-            prefix = name[:i]
-            groups.setdefault(prefix, []).append(int(name[i:]))
-
-    parts: List[str] = []
-    for prefix in sorted(groups):
-        nums = sorted(groups[prefix])
-        if len(nums) == 1:
-            parts.append(f"{prefix}{nums[0]}")
-            continue
-        ranges: List[str] = []
-        start = end = nums[0]
-        for n in nums[1:]:
-            if n == end + 1:
-                end = n
-            else:
-                ranges.append(str(start) if start == end else f"{start}-{end}")
-                start = end = n
-        ranges.append(str(start) if start == end else f"{start}-{end}")
-        parts.append(f"{prefix}[{','.join(ranges)}]")
-
-    parts.extend(sorted(plain))
-    return ",".join(parts)
 
 
 def _get_all_nnfnodes() -> List[Dict[str, Any]]:

--- a/tools/nnf/src/nnf/commands/rabbit/undrain.py
+++ b/tools/nnf/src/nnf/commands/rabbit/undrain.py
@@ -35,7 +35,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[ty
         "nodes",
         nargs="+",
         metavar="NODE",
-        help="One or more Rabbit node names to undrain.",
+        help="One or more Rabbit node names or hostlist patterns to undrain (for example rabbit-[0-3]).",
     )
     parser.set_defaults(func=run)
 

--- a/tools/nnf/src/nnf/hostlist.py
+++ b/tools/nnf/src/nnf/hostlist.py
@@ -47,10 +47,7 @@ def expand_args(values: Optional[List[str]]) -> List[str]:
         return []
     result: List[str] = []
     for v in values:
-        try:
-            result.extend(_hl.expand_hostlist(v))
-        except _hl.BadHostlist as exc:
-            raise BadHostlist(f"invalid hostlist '{v}': {exc}") from exc
+        result.extend(expand(v))
     return result
 
 

--- a/tools/nnf/src/nnf/hostlist.py
+++ b/tools/nnf/src/nnf/hostlist.py
@@ -1,0 +1,65 @@
+"""HPC-style hostlist expansion and compression.
+
+Wraps the python-hostlist library to provide a consistent interface used
+throughout the nnf CLI.
+"""
+
+from typing import List, Optional
+
+import hostlist as _hl
+
+
+class BadHostlist(ValueError):
+    """Raised when a hostlist pattern is malformed."""
+
+
+def expand(pattern: str) -> List[str]:
+    """Expand a single bracketed hostlist pattern into individual hostnames.
+
+    Examples:
+        expand("node[1-3]")       → ["node1", "node2", "node3"]
+        expand("node[1,3,5-7]")   → ["node1", "node3", "node5", "node6", "node7"]
+        expand("node[01-03]")     → ["node01", "node02", "node03"]
+        expand("node5")           → ["node5"]
+
+    Raises BadHostlist for malformed patterns.
+    """
+    try:
+        return _hl.expand_hostlist(pattern)
+    except _hl.BadHostlist as exc:
+        raise BadHostlist(f"invalid hostlist '{pattern}': {exc}") from exc
+
+
+def expand_args(values: Optional[List[str]]) -> List[str]:
+    """Normalize a list of argparse node arguments into expanded hostnames.
+
+    Handles:
+      - None → []
+      - Comma-splitting ("a,b,c" → ["a","b","c"])
+      - Hostlist expansion ("node[1-3]" → ["node1","node2","node3"])
+
+    This is the common normalization function for any argparse nargs="+"
+    node argument in the CLI.
+
+    Raises BadHostlist for malformed patterns.
+    """
+    if values is None:
+        return []
+    result: List[str] = []
+    for v in values:
+        try:
+            result.extend(_hl.expand_hostlist(v))
+        except _hl.BadHostlist as exc:
+            raise BadHostlist(f"invalid hostlist '{v}': {exc}") from exc
+    return result
+
+
+def compress(names: List[str]) -> str:
+    """Compress a list of hostnames into bracketed range notation.
+
+    Example: ["node1","node2","node3"] → "node[1-3]"
+    Returns empty string for an empty list.
+    """
+    if not names:
+        return ""
+    return _hl.collect_hostlist(names)

--- a/tools/nnf/tests/test_create_persistent.py
+++ b/tools/nnf/tests/test_create_persistent.py
@@ -130,6 +130,29 @@ def test_run_comma_separated_rabbits() -> None:
     assert call_kwargs["rabbits"] == ["rabbit-0", "rabbit-1", "rabbit-2"]
 
 
+def test_run_hostlist_expansion_rabbits() -> None:
+    """run() expands hostlist bracket patterns in --rabbits."""
+    from nnf.workflow import WorkflowRun
+
+    captured: Dict[str, object] = {}
+
+    def fake_create_and_run(wf: WorkflowRun, timeout: int) -> int:
+        captured["wf"] = wf
+        return 0
+
+    with patch("nnf.commands.persistent.create.workflow.create_and_run",
+               side_effect=fake_create_and_run), \
+            patch("nnf.commands.persistent.create.servers.fill_servers_default",
+                  return_value=(True, "")) as mock_fill:
+        assert run(_make_args(rabbits=["rabbit-[0-2]"])) == 0
+        hooks = captured["wf"].state_hooks["Proposal"]  # type: ignore[index]
+        hooks[0]("wf-name", "default")
+
+    mock_fill.assert_called_once()
+    _, call_kwargs = mock_fill.call_args
+    assert call_kwargs["rabbits"] == ["rabbit-0", "rabbit-1", "rabbit-2"]
+
+
 def test_run_post_proposal_hook_calls_fill_servers_default() -> None:
     """run() attaches a Proposal hook that delegates to fill_servers_default."""
     from nnf.workflow import WorkflowRun

--- a/tools/nnf/tests/test_hostlist.py
+++ b/tools/nnf/tests/test_hostlist.py
@@ -1,0 +1,137 @@
+"""Tests for nnf.hostlist module."""
+
+import pytest
+
+from nnf.hostlist import BadHostlist, compress, expand, expand_args
+
+
+# ---------------------------------------------------------------------------
+# expand()
+# ---------------------------------------------------------------------------
+
+
+def test_expand_single_host() -> None:
+    assert expand("rabbit-node-1") == ["rabbit-node-1"]
+
+
+def test_expand_simple_range() -> None:
+    assert expand("node[1-3]") == ["node1", "node2", "node3"]
+
+
+def test_expand_enumeration() -> None:
+    assert expand("node[1,3,5]") == ["node1", "node3", "node5"]
+
+
+def test_expand_mixed_range_and_enumeration() -> None:
+    result = expand("node[1-3,7,10-12]")
+    assert result == ["node1", "node2", "node3", "node7", "node10", "node11", "node12"]
+
+
+def test_expand_zero_padded() -> None:
+    assert expand("node[001-003]") == ["node001", "node002", "node003"]
+
+
+def test_expand_comma_separated_hosts() -> None:
+    assert expand("node1,node2,node3") == ["node1", "node2", "node3"]
+
+
+def test_expand_realistic_hostlist() -> None:
+    result = expand("rzadams[201-208]")
+    expected = [f"rzadams{i}" for i in range(201, 209)]
+    assert result == expected
+
+
+def test_expand_realistic_mixed() -> None:
+    result = expand("rzadams[201,207-208]")
+    assert result == ["rzadams201", "rzadams207", "rzadams208"]
+
+
+# ---------------------------------------------------------------------------
+# expand_args()
+# ---------------------------------------------------------------------------
+
+
+def test_expand_args_none() -> None:
+    assert expand_args(None) == []
+
+
+def test_expand_args_plain_names() -> None:
+    assert expand_args(["rabbit-1", "rabbit-2"]) == ["rabbit-1", "rabbit-2"]
+
+
+def test_expand_args_comma_separated() -> None:
+    assert expand_args(["a,b,c"]) == ["a", "b", "c"]
+
+
+def test_expand_args_hostlist_pattern() -> None:
+    result = expand_args(["node[1-3]"])
+    assert result == ["node1", "node2", "node3"]
+
+
+def test_expand_args_mixed_arguments() -> None:
+    result = expand_args(["node[1-3]", "gpu[1,2]"])
+    assert result == ["node1", "node2", "node3", "gpu1", "gpu2"]
+
+
+def test_expand_args_comma_with_brackets() -> None:
+    result = expand_args(["node[1-2],gpu[1-2]"])
+    assert result == ["node1", "node2", "gpu1", "gpu2"]
+
+
+# ---------------------------------------------------------------------------
+# compress()
+# ---------------------------------------------------------------------------
+
+
+def test_compress_empty() -> None:
+    assert compress([]) == ""
+
+
+def test_compress_single() -> None:
+    assert compress(["rabbit-0"]) == "rabbit-0"
+
+
+def test_compress_consecutive() -> None:
+    result = compress(["rabbit-0", "rabbit-1", "rabbit-2"])
+    # python-hostlist may format slightly differently — just check round-trip
+    expanded = expand(result)
+    assert sorted(expanded) == sorted(["rabbit-0", "rabbit-1", "rabbit-2"])
+
+
+def test_compress_gaps() -> None:
+    result = compress(["rabbit-0", "rabbit-1", "rabbit-3", "rabbit-5"])
+    expanded = expand(result)
+    assert sorted(expanded) == sorted(["rabbit-0", "rabbit-1", "rabbit-3", "rabbit-5"])
+
+
+def test_compress_different_prefixes() -> None:
+    result = compress(["rabbit-0", "compute-1"])
+    expanded = expand(result)
+    assert sorted(expanded) == sorted(["rabbit-0", "compute-1"])
+
+
+def test_compress_round_trip() -> None:
+    """Expanding a compressed hostlist yields the original names."""
+    names = [f"rzadams{i}" for i in range(201, 209)]
+    compressed = compress(names)
+    assert expand(compressed) == sorted(names)
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_expand_unmatched_bracket_raises() -> None:
+    with pytest.raises(BadHostlist, match="invalid hostlist"):
+        expand("rabbit-[")
+
+
+def test_expand_reversed_range_raises() -> None:
+    with pytest.raises(BadHostlist, match="invalid hostlist"):
+        expand("rabbit-[5-2]")
+
+
+def test_expand_args_bad_pattern_raises() -> None:
+    with pytest.raises(BadHostlist, match="invalid hostlist"):
+        expand_args(["good-node", "bad-["])

--- a/tools/nnf/tests/test_rabbit_disable.py
+++ b/tools/nnf/tests/test_rabbit_disable.py
@@ -4,6 +4,7 @@ import argparse
 from typing import Dict
 from unittest.mock import patch
 
+import pytest
 import kubernetes.client.exceptions  # type: ignore[import-untyped]
 
 from nnf.commands.rabbit.disable import _disable_storage, run
@@ -86,3 +87,44 @@ def test_run_all_fail_returns_1() -> None:
         rc = run(_make_args(nodes=["rabbit-0", "rabbit-1"]))
 
     assert rc == 1
+
+
+def test_run_expands_hostlist_pattern() -> None:
+    """run() expands bracket notation into individual node operations."""
+    with patch("nnf.commands.rabbit.disable._disable_storage") as mock_dis:
+        rc = run(_make_args(nodes=["rabbit-[0-2]"]))
+
+    assert rc == 0
+    assert mock_dis.call_count == 3
+    called_nodes = [call[0][0] for call in mock_dis.call_args_list]
+    assert called_nodes == ["rabbit-0", "rabbit-1", "rabbit-2"]
+
+
+def test_run_expands_mixed_hostlist() -> None:
+    """run() expands mixed enumeration and range patterns."""
+    with patch("nnf.commands.rabbit.disable._disable_storage") as mock_dis:
+        rc = run(_make_args(nodes=["rabbit-[0,3-4]"]))
+
+    assert rc == 0
+    assert mock_dis.call_count == 3
+    called_nodes = [call[0][0] for call in mock_dis.call_args_list]
+    assert called_nodes == ["rabbit-0", "rabbit-3", "rabbit-4"]
+
+
+def test_run_malformed_hostlist_returns_1(capsys: "pytest.CaptureFixture[str]") -> None:
+    """run() returns 1 and prints an error for malformed hostlist patterns."""
+    rc = run(_make_args(nodes=["rabbit-["]))
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "invalid hostlist" in err
+    assert "rabbit-[" in err
+
+
+def test_run_empty_expansion_returns_1(capsys: "pytest.CaptureFixture[str]") -> None:
+    """run() returns 1 when hostlist expansion yields zero nodes."""
+    rc = run(_make_args(nodes=[","]))
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "zero hosts" in err

--- a/tools/nnf/tests/test_system_state.py
+++ b/tools/nnf/tests/test_system_state.py
@@ -14,13 +14,13 @@ from nnf.commands.rabbit.state import (
     _build_annotation_rows,
     _build_node_status_rows,
     _build_storage_status_rows,
-    _compress_hostlist,
     _get_all_storages,
     _print_table,
     _run_cmd,
     _show_disabled_computes,
     run,
 )
+from nnf.hostlist import compress as _compress_hostlist
 
 
 def _make_args(**kwargs: object) -> argparse.Namespace:


### PR DESCRIPTION
Sub-commands that accept node names now support HPC-style hostlist bracket notation (e.g. rzadams[201-208], rabbit-[0,3-4]).

This fixes the following errors: nnf rabbit disable rzadams[201-208] error: failed to disable storage 'rzadams[201-208]': Not Found

Changes:
- Add src/nnf/hostlist.py wrapping python-hostlist for expand/compress
- Integrate expand_args() into for_each_node() (covers disable, drain, enable, undrain)
- Replace _split_nodes() in persistent/create.py with expand_args()
- Replace hand-rolled _compress_hostlist() in state.py with library call
- Add error handling for malformed patterns and empty expansions
- Add python-hostlist dependency to pyproject.toml and setup.py
- Update --help text and README with hostlist syntax and shell quoting